### PR TITLE
Fix broken Rust release: rebase before staging the version bump (#164)

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -84,7 +84,7 @@ jobs:
     needs: [changeset-check]
     if: always() && (github.event_name == 'push' || needs.changeset-check.result == 'success')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -129,7 +129,7 @@ jobs:
             runtime: node
             node-version: 24
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Bun
         if: matrix.runtime == 'bun'
@@ -164,7 +164,7 @@ jobs:
 
       - name: Setup Node.js
         if: matrix.runtime == 'node'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -198,12 +198,12 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
@@ -271,12 +271,12 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
@@ -328,7 +328,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -350,7 +350,7 @@ jobs:
         run: bunx prettier --write ".changeset/*.md"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: add changeset for manual JavaScript ${{ github.event.inputs.bump_type }} release'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,7 +55,7 @@ jobs:
     timeout-minutes: 10
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -77,7 +77,7 @@ jobs:
     needs: [changelog]
     if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changelog.result == 'success')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -85,7 +85,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -114,13 +114,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -138,6 +138,49 @@ jobs:
         working-directory: rust
         run: cargo test --doc --all-features --verbose
 
+  scripts:
+    name: Test Rust release scripts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [changelog]
+    if: always() && (github.event_name == 'push' || github.event_name == 'workflow_dispatch' || needs.changelog.result == 'success')
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/target
+          key: ${{ runner.os }}-cargo-scripts-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-scripts-
+
+      - name: Install rust-script
+        run: cargo install rust-script
+
+      - name: Run release script unit tests
+        # Run the inline `#[cfg(test)]` suites for every rust-script under
+        # rust/scripts/. `cargo test` only covers the library crate, so without
+        # this step the release-script regression tests (e.g. the rebase
+        # ordering guard) never execute in CI.
+        run: |
+          set -euo pipefail
+          status=0
+          for f in rust/scripts/*.rs; do
+            if grep -q 'cfg(test)' "$f"; then
+              echo "::group::rust-script --test $f"
+              rust-script --test "$f" || status=1
+              echo "::endgroup::"
+            fi
+          done
+          exit $status
+
   build:
     name: Build Rust package
     runs-on: ubuntu-latest
@@ -145,13 +188,13 @@ jobs:
     needs: [lint, test]
     if: always() && !cancelled() && needs.lint.result == 'success' && needs.test.result == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -171,7 +214,7 @@ jobs:
 
   release:
     name: Release Rust crate
-    needs: [lint, test, build]
+    needs: [lint, test, scripts, build]
     # Required because lint/test depend on the pull-request-only changelog job,
     # which is skipped on push events.
     if: |
@@ -180,13 +223,14 @@ jobs:
       github.event_name == 'push' &&
       needs.lint.result == 'success' &&
       needs.test.result == 'success' &&
+      needs.scripts.result == 'success' &&
       needs.build.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -241,7 +285,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -279,7 +323,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -293,7 +337,7 @@ jobs:
         run: rust-script rust/scripts/create-changelog-fragment.rs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: add changelog fragment for manual Rust ${{ github.event.inputs.bump_type }} release'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Logs
 logs
 *.log
+# Case-study CI evidence is committed intentionally (downloaded run logs).
+!docs/case-studies/**/ci-logs/
+!docs/case-studies/**/ci-logs/*.log
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-09T13:58:09.960Z for PR creation at branch issue-164-55c0bfaf481d for issue https://github.com/link-foundation/command-stream/issues/164

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-09T13:58:09.960Z for PR creation at branch issue-164-55c0bfaf481d for issue https://github.com/link-foundation/command-stream/issues/164

--- a/docs/case-studies/issue-164/README.md
+++ b/docs/case-studies/issue-164/README.md
@@ -1,0 +1,255 @@
+# Case study — Issue #164: "CI/CD is broken"
+
+- **Issue:** <https://github.com/link-foundation/command-stream/issues/164>
+- **Pull request:** <https://github.com/link-foundation/command-stream/pull/165>
+- **Reported:** 2026-06-08
+- **Affected runs:**
+  - JavaScript checks and release — [run 27164605452](https://github.com/link-foundation/command-stream/actions/runs/27164605452) — ✅ success
+  - Rust checks and release — [run 27164605403](https://github.com/link-foundation/command-stream/actions/runs/27164605403) — ❌ **failure**
+
+This folder contains the downloaded CI logs (`ci-logs/`) and this deep-dive
+analysis. It is self-contained: every claim below is backed by a line in the
+saved logs or by source already in the repository.
+
+---
+
+## 1. Executive summary
+
+The release pipeline broke because the **Rust** release script
+(`rust/scripts/version-and-commit.rs`) staged the version bump with `git add`
+**before** running `git rebase origin/main`. `git rebase` refuses to run with a
+dirty index, so the release aborted with:
+
+```
+Local branch is behind remote, rebasing...
+Error rebasing onto origin/main: Command failed: error: cannot rebase: Your index contains uncommitted changes.
+error: Please commit or stash them.
+##[error]Process completed with exit code 1.
+```
+
+The rebase was genuinely *needed*: the JavaScript release job, triggered by the
+same push, had already bumped the package to `0.9.6` and pushed it to `main`,
+so `origin/main` had advanced under the Rust job's feet. The Rust job correctly
+detected "local branch is behind remote" — but then could not rebase because it
+had already dirtied its index. The **JavaScript** script does the same two
+operations in the *opposite* (correct) order, which is exactly why the JS run
+succeeded while the Rust run failed on the very same commit.
+
+The fix moves the fetch + rebase to run **before any file modification**, while
+the working tree is clean — matching the JS script. The identical bug exists in
+`link-foundation/rust-ai-driven-development-pipeline-template` and has been
+reported upstream.
+
+---
+
+## 2. Timeline / sequence of events
+
+All timestamps UTC, from `ci-logs/rust-run-27164605403-full.log` and
+`ci-logs/js-release-job-27164605452.log`.
+
+| Time | Actor | Event |
+|------|-------|-------|
+| 20:22:00 | GitHub | Merge commit `89d47cf` ("Merge pull request #163") pushed to `main`. This triggers **both** `js.yml` (run …452) and `rust.yml` (run …403). Both check out `89d47cf`. |
+| 20:22:03–20:23:1x | both | `lint` / `test` / `build` jobs run and pass in both pipelines. |
+| 20:23:31 | JS release | JS `version-and-commit.mjs` bumps `js/package.json` to `0.9.6`, commits `971eab5`, and **pushes to `main`** → `origin/main` is now `971eab5`, ahead of `89d47cf`. (`✅ Version bump committed and pushed to main`) |
+| 20:25:16 | Rust release | Rust `version-and-commit.rs` starts; computes `0.9.6` as the next version. |
+| 20:25:21.44 | Rust release | Updates `rust/Cargo.toml` and `rust/Cargo.lock` to `0.9.6`, collects 2 changelog fragments, and **stages them with `git add`** (index now dirty). |
+| 20:25:21.71 | Rust release | Detects `origin/main` advanced → prints `Local branch is behind remote, rebasing...`. |
+| 20:25:21.72 | Rust release | `git rebase origin/main` **fails**: `cannot rebase: Your index contains uncommitted changes`. Script exits 1. ❌ |
+| 20:25:21.97 | runner | Post-job warning: `Node.js 20 actions are deprecated … actions/checkout@v4`. |
+
+The race is the trigger; the ordering bug is the root cause. Without the
+concurrent JS push there would have been nothing to rebase onto and the bug
+would have stayed dormant — which is why this had not surfaced before.
+
+---
+
+## 3. Requirements extracted from the issue
+
+| # | Requirement | Status |
+|---|-------------|--------|
+| R1 | Check for **all** false positives and errors in the two CI runs/jobs. | ✅ done — see §4 |
+| R2 | Compare **all** GitHub workflow / CI files against the 4 pipeline templates; reuse best practices. | ✅ done — see §5 |
+| R3 | If the same issue exists in a template, report an issue there too. | ✅ done — Rust template issue filed (§6) |
+| R4 | Download all logs/data to `./docs/case-studies/issue-164/` and do a deep case study (timeline, requirements, root causes, solution plans, existing-component survey, online facts). | ✅ this document + `logs/` |
+| R5 | If there is not enough data for root cause, add debug output / verbose mode. | ✅ enough data existed; additionally added a regression test + a CI job so the scripts are now exercised (§7) |
+| R6 | If the issue relates to another repo where issues can be filed, file them with reproducible example, workaround, and code-fix suggestion. | ✅ Rust template issue includes all three |
+| R7 | Fully apply the fix across the entire codebase (fix every place sharing the issue). | ✅ see §4.4 — only the Rust script shared it |
+| R8 | Plan and execute everything in the single PR #165. | ✅ all work on branch `issue-164-55c0bfaf481d` |
+
+---
+
+## 4. Root-cause analysis
+
+### 4.1 Primary failure — rebase with a dirty index (Rust release)
+
+**Symptom (verbatim, `ci-logs/release-rust-crate-step.log`):**
+
+```
+Updated rust/Cargo.toml to version 0.9.6
+Updated rust/Cargo.lock to version 0.9.6
+Collected 2 changelog fragment(s)
+Local branch is behind remote, rebasing...
+Error rebasing onto origin/main: Command failed: error: cannot rebase: Your index contains uncommitted changes.
+error: Please commit or stash them.
+##[error]Process completed with exit code 1.
+```
+
+**Buggy ordering (original `rust/scripts/version-and-commit.rs`):**
+
+1. Modify `Cargo.toml` / `Cargo.lock`.
+2. `git add` the manifest, lockfile, changelog, and changelog fragments → **index now dirty**.
+3. `git fetch origin <branch>`; if behind, `git rebase origin/<branch>` → **fails on the dirty index**.
+4. `git commit` (never reached).
+
+`git rebase` performs an implicit `require_clean_work_tree` and aborts if the
+index has staged-but-uncommitted changes — this is documented Git behaviour,
+not a flake (see §8).
+
+**Why the JS pipeline did not fail:** `js/scripts/version-and-commit.mjs` rebases
+*first*, then stages:
+
+```js
+await $`git rebase origin/main`;   // line 179 — clean tree
+...
+await $`git add -A`;               // line 215 — stage AFTER rebase
+await $`git commit -m "${escapedMessage}"`;
+```
+
+### 4.2 The race that exposed it
+
+Both workflows fire on every push to `main` that touches shared paths
+(`README.md`, `LICENSE`, the workflow files). The JS release finished first,
+bumped to `0.9.6`, and pushed — advancing `origin/main`. The Rust release,
+still based on the pre-push commit, then *had* to rebase, and the latent
+ordering bug turned a normal concurrent-release rebase into a hard failure.
+
+### 4.3 Secondary finding — Node 20 deprecation warnings (both pipelines)
+
+The runs emitted `Node.js 20 actions are deprecated … actions/checkout@v4`
+(6 occurrences in the Rust run). The workflows pinned `actions/checkout@v4`,
+`actions/cache@v4`, `actions/setup-node@v4`, and `peter-evans/create-pull-request@v7`.
+GitHub forces Node 20 actions to Node 24 starting 2026-06-16 and removes Node 20
+on 2026-09-16. These were warnings (not the failure) but are real future
+breakage and a documented "best practice" gap vs. the templates.
+
+### 4.4 Codebase-wide audit (R7)
+
+Every place that bumps a version and rebases/pushes was checked:
+
+| Script / file | Rebase before staging? | Verdict |
+|---------------|------------------------|---------|
+| `rust/scripts/version-and-commit.rs` | ❌ was after → **fixed** | was broken |
+| `js/scripts/version-and-commit.mjs` | ✅ rebases first (L179 < L215) | already correct |
+| `js/scripts/instant-version-bump.mjs` | only edits files; no git ops | not affected |
+| `rust/scripts/*.rs` (publish, release, wait, size, changelog) | no rebase-then-stage pattern | not affected |
+
+Only the Rust script shared the bug. No other occurrence exists in the repo.
+
+---
+
+## 5. Workflow comparison against the 4 templates (R2)
+
+Action versions in use **after** this PR vs. each template
+(`actions/checkout`, `actions/setup-node`, `actions/cache`,
+`peter-evans/create-pull-request`, `oven-sh/setup-bun`):
+
+| Action | command-stream (this PR) | js tmpl | rust tmpl | python tmpl | csharp tmpl |
+|--------|--------------------------|---------|-----------|-------------|-------------|
+| checkout | **v6** | v6 | v6 | v6 | v6 |
+| setup-node | **v6** | v6 | — | — | — |
+| cache | **v5** | — | v5 | — | — |
+| create-pull-request | **v8** | v8 | v8 | — | v8 |
+| setup-bun | v2 | v2 | — | — | v2 |
+
+All bumps now match the templates exactly.
+
+**`version-and-commit` rebase ordering across templates:**
+
+| Template | Pattern | Shares the bug? |
+|----------|---------|-----------------|
+| rust | `git add` (L710/719) → `fetch`+`rebase` (L736/744) → `commit` (L768) | ✅ **YES — reported (§6)** |
+| js | `git rebase` (L217) → `git add` (L260) → `commit` (L265) | ❌ no (correct order) |
+| csharp | `git add` (L374) → `commit` (L392); **no rebase at all** | ❌ no |
+| python | release-on-version-change in `release.yml`; no in-CI bump+rebase | ❌ no |
+
+---
+
+## 6. Upstream issue (R3, R6)
+
+The `rust-ai-driven-development-pipeline-template` `scripts/version-and-commit.rs`
+contains the identical staging-before-rebase ordering. An issue was filed
+upstream with: a reproducible example, a workaround, and a concrete code-fix
+suggestion (move the fetch+rebase block ahead of the first `git add`, mirroring
+the JS template).
+
+> Upstream issue: <https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/67>
+
+---
+
+## 7. Solution plans per requirement & what was implemented
+
+- **R1 / R4 / R7 — fix + audit:** moved the fetch+rebase sync in
+  `rust/scripts/version-and-commit.rs` to run **before** any file edit, while
+  the tree is clean. Verified no other script shares the pattern.
+- **R5 — observability & prevention:**
+  - Added a regression unit test
+    `rebase_must_run_before_staging_the_version_bump()` that builds a temp git
+    repo, reproduces the dirty-index failure for the buggy order, and proves the
+    fixed order succeeds.
+  - Added a **`scripts` CI job** to `rust.yml` that runs the inline
+    `rust-script --test` suites for every `rust/scripts/*.rs` and **gates the
+    `release` job** on it. Previously these tests never ran in CI (`cargo test`
+    only covers the library crate), so the release scripts were entirely
+    untested in CI.
+- **R2 — best practices:** bumped all actions to match the templates
+  (checkout v6, setup-node v6, cache v5, create-pull-request v8), clearing the
+  Node 20 deprecation warnings.
+- **R3 / R6 — upstream:** filed the template issue with repro + workaround + fix.
+
+A standalone local reproduction lives at
+`experiments/issue-164/reproduce-rebase-bug.sh`
+(`./reproduce-rebase-bug.sh buggy` fails with the exact error;
+`./reproduce-rebase-bug.sh fixed` succeeds).
+
+---
+
+## 8. Existing components / libraries & online facts surveyed
+
+- **Git's `require_clean_work_tree`** — `git rebase`, `git pull --rebase`, and
+  similar commands refuse to run with staged-but-uncommitted changes; this is
+  intentional, documented behaviour, not environment-specific. The robust
+  pattern is *sync first on a clean tree, then mutate*. The fix follows this.
+- **`git pull --rebase --autostash` / `git rebase --autostash`** — Git can
+  auto-stash and re-apply local changes around a rebase. We deliberately did
+  **not** rely on autostash: the correct fix is to never dirty the tree before
+  syncing (cheaper, no stash-conflict surface), and it keeps parity with the
+  already-correct JS script.
+- **Concurrency controls** — both workflows already set a `concurrency` group
+  (`${{ github.workflow }}-${{ github.ref }}`). That serializes runs *within a
+  single workflow* but not *across* the JS and Rust workflows, which is why the
+  cross-pipeline race is real and the rebase is genuinely required. Handling it
+  in-script (rebase onto the advanced `origin/main`) is the right layer.
+- **GitHub Actions Node 20 deprecation** — announced 2025-09-19; Node 20 actions
+  forced to Node 24 from 2026-06-16, Node 20 removed 2026-09-16. The template
+  repos had already upgraded to checkout v6 / setup-node v6 / cache v5; this PR
+  brings command-stream in line.
+- **`rust-script`** — single-file Rust scripts support inline `#[cfg(test)]`
+  modules executed via `rust-script --test <file>`; this is what the new
+  `scripts` CI job leverages so the release scripts gain real test coverage.
+
+---
+
+## 9. Files in this folder
+
+```
+docs/case-studies/issue-164/
+├── README.md                            # this analysis
+└── ci-logs/
+    ├── rust-run-27164605403-full.log    # full Rust run log, the failure (ANSI-stripped)
+    ├── release-rust-crate-step.log      # cleaned excerpt of the failing "Release Rust crate" step
+    └── js-release-job-27164605452.log   # the successful JS "Release" job (proves the correct ordering)
+```
+
+The logs live under `ci-logs/` rather than `logs/` because the repository's
+`.gitignore` ignores any directory literally named `logs`.

--- a/docs/case-studies/issue-164/ci-logs/js-release-job-27164605452.log
+++ b/docs/case-studies/issue-164/ci-logs/js-release-job-27164605452.log
@@ -1,0 +1,519 @@
+﻿2026-06-08T20:23:14.1609473Z Current runner version: '2.334.0'
+2026-06-08T20:23:14.1634667Z ##[group]Runner Image Provisioner
+2026-06-08T20:23:14.1635590Z Hosted Compute Agent
+2026-06-08T20:23:14.1636203Z Version: 20260520.533
+2026-06-08T20:23:14.1636914Z Commit: 189110e25284a9812c124fd27b339e2fb4f2f9db
+2026-06-08T20:23:14.1637671Z Build Date: 2026-05-20T17:44:04Z
+2026-06-08T20:23:14.1638367Z Worker ID: {a82d8230-c980-415f-a830-43a23294896b}
+2026-06-08T20:23:14.1639177Z Azure Region: centralus
+2026-06-08T20:23:14.1639833Z ##[endgroup]
+2026-06-08T20:23:14.1641160Z ##[group]Operating System
+2026-06-08T20:23:14.1642152Z Ubuntu
+2026-06-08T20:23:14.1642738Z 24.04.4
+2026-06-08T20:23:14.1643338Z LTS
+2026-06-08T20:23:14.1643924Z ##[endgroup]
+2026-06-08T20:23:14.1644489Z ##[group]Runner Image
+2026-06-08T20:23:14.1645238Z Image: ubuntu-24.04
+2026-06-08T20:23:14.1645837Z Version: 20260525.161.1
+2026-06-08T20:23:14.1647211Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260525.161/images/ubuntu/Ubuntu2404-Readme.md
+2026-06-08T20:23:14.1648697Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260525.161
+2026-06-08T20:23:14.1649826Z ##[endgroup]
+2026-06-08T20:23:14.1651023Z ##[group]GITHUB_TOKEN Permissions
+2026-06-08T20:23:14.1653349Z Contents: write
+2026-06-08T20:23:14.1653983Z Metadata: read
+2026-06-08T20:23:14.1654679Z PullRequests: write
+2026-06-08T20:23:14.1655286Z ##[endgroup]
+2026-06-08T20:23:14.1657319Z Secret source: Actions
+2026-06-08T20:23:14.1658203Z Prepare workflow directory
+2026-06-08T20:23:14.2001583Z Prepare all required actions
+2026-06-08T20:23:14.2038828Z Getting action download info
+2026-06-08T20:23:14.6676278Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2026-06-08T20:23:14.7981067Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
+2026-06-08T20:23:14.8874362Z Download action repository 'oven-sh/setup-bun@v2' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+2026-06-08T20:23:15.4456783Z Complete job name: Release JavaScript package
+2026-06-08T20:23:15.5375002Z ##[group]Run actions/checkout@v4
+2026-06-08T20:23:15.5376391Z with:
+2026-06-08T20:23:15.5377228Z   fetch-depth: 0
+2026-06-08T20:23:15.5378220Z   repository: link-foundation/command-stream
+2026-06-08T20:23:15.5389143Z   token: ***
+2026-06-08T20:23:15.5390106Z   ssh-strict: true
+2026-06-08T20:23:15.5391005Z   ssh-user: git
+2026-06-08T20:23:15.5392123Z   persist-credentials: true
+2026-06-08T20:23:15.5393170Z   clean: true
+2026-06-08T20:23:15.5394087Z   sparse-checkout-cone-mode: true
+2026-06-08T20:23:15.5395187Z   fetch-tags: false
+2026-06-08T20:23:15.5396113Z   show-progress: true
+2026-06-08T20:23:15.5397035Z   lfs: false
+2026-06-08T20:23:15.5397887Z   submodules: false
+2026-06-08T20:23:15.5398836Z   set-safe-directory: true
+2026-06-08T20:23:15.5400166Z ##[endgroup]
+2026-06-08T20:23:15.6531006Z Syncing repository: link-foundation/command-stream
+2026-06-08T20:23:15.6534343Z ##[group]Getting Git version info
+2026-06-08T20:23:15.6536035Z Working directory is '/home/runner/work/command-stream/command-stream'
+2026-06-08T20:23:15.6538360Z [command]/usr/bin/git version
+2026-06-08T20:23:15.6564617Z git version 2.54.0
+2026-06-08T20:23:15.6591369Z ##[endgroup]
+2026-06-08T20:23:15.6614362Z Temporarily overriding HOME='/home/runner/work/_temp/d7759c98-a9ea-4246-bfd4-032167b13f63' before making global git config changes
+2026-06-08T20:23:15.6619027Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-08T20:23:15.6623301Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+2026-06-08T20:23:15.6662590Z Deleting the contents of '/home/runner/work/command-stream/command-stream'
+2026-06-08T20:23:15.6665773Z ##[group]Initializing the repository
+2026-06-08T20:23:15.6669652Z [command]/usr/bin/git init /home/runner/work/command-stream/command-stream
+2026-06-08T20:23:15.6739980Z hint: Using 'master' as the name for the initial branch. This default branch name
+2026-06-08T20:23:15.6743573Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2026-06-08T20:23:15.6746590Z hint: to use in all of your new repositories, which will suppress this warning,
+2026-06-08T20:23:15.6748979Z hint: call:
+2026-06-08T20:23:15.6750477Z hint:
+2026-06-08T20:23:15.6752261Z hint: 	git config --global init.defaultBranch <name>
+2026-06-08T20:23:15.6754184Z hint:
+2026-06-08T20:23:15.6755989Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2026-06-08T20:23:15.6759012Z hint: 'development'. The just-created branch can be renamed via this command:
+2026-06-08T20:23:15.6761335Z hint:
+2026-06-08T20:23:15.6762961Z hint: 	git branch -m <name>
+2026-06-08T20:23:15.6764289Z hint:
+2026-06-08T20:23:15.6765557Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2026-06-08T20:23:15.6767750Z Initialized empty Git repository in /home/runner/work/command-stream/command-stream/.git/
+2026-06-08T20:23:15.6772929Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/command-stream
+2026-06-08T20:23:15.6806741Z ##[endgroup]
+2026-06-08T20:23:15.6808989Z ##[group]Disabling automatic garbage collection
+2026-06-08T20:23:15.6810740Z [command]/usr/bin/git config --local gc.auto 0
+2026-06-08T20:23:15.6843394Z ##[endgroup]
+2026-06-08T20:23:15.6845782Z ##[group]Setting up auth
+2026-06-08T20:23:15.6850986Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-08T20:23:15.6887349Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-08T20:23:15.7194978Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-06-08T20:23:15.7227847Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-06-08T20:23:15.7467072Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-06-08T20:23:15.7497964Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-06-08T20:23:15.7731585Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-06-08T20:23:15.7767681Z ##[endgroup]
+2026-06-08T20:23:15.7769298Z ##[group]Fetching the repository
+2026-06-08T20:23:15.7776718Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+2026-06-08T20:23:17.1072856Z From https://github.com/link-foundation/command-stream
+2026-06-08T20:23:17.1074640Z  * [new branch]      issue-1-03052bff       -> origin/issue-1-03052bff
+2026-06-08T20:23:17.1075494Z  * [new branch]      issue-1-7de9505b       -> origin/issue-1-7de9505b
+2026-06-08T20:23:17.1076287Z  * [new branch]      issue-135-5b3a55f7db0e -> origin/issue-135-5b3a55f7db0e
+2026-06-08T20:23:17.1077137Z  * [new branch]      issue-136-c2c75f0016c4 -> origin/issue-136-c2c75f0016c4
+2026-06-08T20:23:17.1077836Z  * [new branch]      issue-139-34f447966ab4 -> origin/issue-139-34f447966ab4
+2026-06-08T20:23:17.1078505Z  * [new branch]      issue-14-427a6e27      -> origin/issue-14-427a6e27
+2026-06-08T20:23:17.1079171Z  * [new branch]      issue-14-47a807dc      -> origin/issue-14-47a807dc
+2026-06-08T20:23:17.1079812Z  * [new branch]      issue-141-392e7fb32761 -> origin/issue-141-392e7fb32761
+2026-06-08T20:23:17.1080471Z  * [new branch]      issue-142-d79c313dc0de -> origin/issue-142-d79c313dc0de
+2026-06-08T20:23:17.1081118Z  * [new branch]      issue-144-4375266b4889 -> origin/issue-144-4375266b4889
+2026-06-08T20:23:17.1081967Z  * [new branch]      issue-146-f111406088b3 -> origin/issue-146-f111406088b3
+2026-06-08T20:23:17.1083061Z  * [new branch]      issue-149-feab21d6ff91 -> origin/issue-149-feab21d6ff91
+2026-06-08T20:23:17.1084376Z  * [new branch]      issue-15-9fc0cb72      -> origin/issue-15-9fc0cb72
+2026-06-08T20:23:17.1085093Z  * [new branch]      issue-15-b280a47e      -> origin/issue-15-b280a47e
+2026-06-08T20:23:17.1085695Z  * [new branch]      issue-151-3da6bb3ea5e3 -> origin/issue-151-3da6bb3ea5e3
+2026-06-08T20:23:17.1086211Z  * [new branch]      issue-153-58c6ab4753ab -> origin/issue-153-58c6ab4753ab
+2026-06-08T20:23:17.1086715Z  * [new branch]      issue-156-eb63a328307e -> origin/issue-156-eb63a328307e
+2026-06-08T20:23:17.1087209Z  * [new branch]      issue-158-7e95ada294ce -> origin/issue-158-7e95ada294ce
+2026-06-08T20:23:17.1087704Z  * [new branch]      issue-160-a2a2313cf693 -> origin/issue-160-a2a2313cf693
+2026-06-08T20:23:17.1088202Z  * [new branch]      issue-162-0c186d5158ec -> origin/issue-162-0c186d5158ec
+2026-06-08T20:23:17.1088692Z  * [new branch]      issue-18-16ce2f52      -> origin/issue-18-16ce2f52
+2026-06-08T20:23:17.1089169Z  * [new branch]      issue-18-51ece309      -> origin/issue-18-51ece309
+2026-06-08T20:23:17.1089679Z  * [new branch]      issue-19-99f29373      -> origin/issue-19-99f29373
+2026-06-08T20:23:17.1090149Z  * [new branch]      issue-19-ee86110f      -> origin/issue-19-ee86110f
+2026-06-08T20:23:17.1090614Z  * [new branch]      issue-20-12ad6602      -> origin/issue-20-12ad6602
+2026-06-08T20:23:17.1091073Z  * [new branch]      issue-20-171029a1      -> origin/issue-20-171029a1
+2026-06-08T20:23:17.1091530Z  * [new branch]      issue-21-4d44bbc7      -> origin/issue-21-4d44bbc7
+2026-06-08T20:23:17.1092366Z  * [new branch]      issue-21-621d3004      -> origin/issue-21-621d3004
+2026-06-08T20:23:17.1092893Z  * [new branch]      issue-22-51ab60ad      -> origin/issue-22-51ab60ad
+2026-06-08T20:23:17.1093477Z  * [new branch]      issue-22-57b75318      -> origin/issue-22-57b75318
+2026-06-08T20:23:17.1093945Z  * [new branch]      issue-23-acb80d89      -> origin/issue-23-acb80d89
+2026-06-08T20:23:17.1094405Z  * [new branch]      issue-23-cfe40154      -> origin/issue-23-cfe40154
+2026-06-08T20:23:17.1095079Z  * [new branch]      issue-24-0a217d8d      -> origin/issue-24-0a217d8d
+2026-06-08T20:23:17.1095558Z  * [new branch]      issue-24-2ec0e8fa      -> origin/issue-24-2ec0e8fa
+2026-06-08T20:23:17.1096067Z  * [new branch]      issue-25-8431dd64      -> origin/issue-25-8431dd64
+2026-06-08T20:23:17.1096566Z  * [new branch]      issue-25-8ff13a2c      -> origin/issue-25-8ff13a2c
+2026-06-08T20:23:17.1097062Z  * [new branch]      issue-26-2cc88ea0      -> origin/issue-26-2cc88ea0
+2026-06-08T20:23:17.1097550Z  * [new branch]      issue-26-9bec6ea5      -> origin/issue-26-9bec6ea5
+2026-06-08T20:23:17.1098020Z  * [new branch]      issue-27-01ac7c56      -> origin/issue-27-01ac7c56
+2026-06-08T20:23:17.1098484Z  * [new branch]      issue-27-1d58c6b2      -> origin/issue-27-1d58c6b2
+2026-06-08T20:23:17.1098982Z  * [new branch]      issue-28-1c9c13c6      -> origin/issue-28-1c9c13c6
+2026-06-08T20:23:17.1099452Z  * [new branch]      issue-28-e256afcb      -> origin/issue-28-e256afcb
+2026-06-08T20:23:17.1099932Z  * [new branch]      issue-29-55357638      -> origin/issue-29-55357638
+2026-06-08T20:23:17.1100394Z  * [new branch]      issue-29-987b8dd4      -> origin/issue-29-987b8dd4
+2026-06-08T20:23:17.1100850Z  * [new branch]      issue-30-a0052265      -> origin/issue-30-a0052265
+2026-06-08T20:23:17.1101310Z  * [new branch]      issue-30-f1b7d27d      -> origin/issue-30-f1b7d27d
+2026-06-08T20:23:17.1101980Z  * [new branch]      issue-31-bfcb9a80      -> origin/issue-31-bfcb9a80
+2026-06-08T20:23:17.1102461Z  * [new branch]      issue-31-dc3e9249      -> origin/issue-31-dc3e9249
+2026-06-08T20:23:17.1102923Z  * [new branch]      issue-32-3dccbfab      -> origin/issue-32-3dccbfab
+2026-06-08T20:23:17.1103381Z  * [new branch]      issue-32-7a506d69      -> origin/issue-32-7a506d69
+2026-06-08T20:23:17.1103844Z  * [new branch]      issue-34-389ba67e      -> origin/issue-34-389ba67e
+2026-06-08T20:23:17.1104303Z  * [new branch]      issue-34-7cfa0880      -> origin/issue-34-7cfa0880
+2026-06-08T20:23:17.1104923Z  * [new branch]      issue-36-042fe722      -> origin/issue-36-042fe722
+2026-06-08T20:23:17.1105397Z  * [new branch]      issue-36-52b7c0a5      -> origin/issue-36-52b7c0a5
+2026-06-08T20:23:17.1105855Z  * [new branch]      issue-37-20720488      -> origin/issue-37-20720488
+2026-06-08T20:23:17.1106311Z  * [new branch]      issue-37-e875842b      -> origin/issue-37-e875842b
+2026-06-08T20:23:17.1106773Z  * [new branch]      issue-38-8ff5f784      -> origin/issue-38-8ff5f784
+2026-06-08T20:23:17.1107256Z  * [new branch]      issue-38-d399116a      -> origin/issue-38-d399116a
+2026-06-08T20:23:17.1107735Z  * [new branch]      issue-39-607bfb8e      -> origin/issue-39-607bfb8e
+2026-06-08T20:23:17.1108211Z  * [new branch]      issue-39-b4116e88      -> origin/issue-39-b4116e88
+2026-06-08T20:23:17.1108698Z  * [new branch]      issue-4-9c65943d       -> origin/issue-4-9c65943d
+2026-06-08T20:23:17.1109190Z  * [new branch]      issue-4-e24f5412       -> origin/issue-4-e24f5412
+2026-06-08T20:23:17.1109679Z  * [new branch]      issue-40-b1e760e6      -> origin/issue-40-b1e760e6
+2026-06-08T20:23:17.1110179Z  * [new branch]      issue-40-ef18d92c      -> origin/issue-40-ef18d92c
+2026-06-08T20:23:17.1110687Z  * [new branch]      issue-41-49cfed34      -> origin/issue-41-49cfed34
+2026-06-08T20:23:17.1111180Z  * [new branch]      issue-41-fed22157      -> origin/issue-41-fed22157
+2026-06-08T20:23:17.1111666Z  * [new branch]      issue-42-77ee242c      -> origin/issue-42-77ee242c
+2026-06-08T20:23:17.1112342Z  * [new branch]      issue-42-908eb7f7      -> origin/issue-42-908eb7f7
+2026-06-08T20:23:17.1183739Z  * [new branch]      issue-43-7298cd5c      -> origin/issue-43-7298cd5c
+2026-06-08T20:23:17.1184811Z  * [new branch]      issue-43-85b3ddfd      -> origin/issue-43-85b3ddfd
+2026-06-08T20:23:17.1185706Z  * [new branch]      issue-43-af132027      -> origin/issue-43-af132027
+2026-06-08T20:23:17.1186414Z  * [new branch]      issue-44-75df50dd      -> origin/issue-44-75df50dd
+2026-06-08T20:23:17.1187208Z  * [new branch]      issue-44-796ff0a8      -> origin/issue-44-796ff0a8
+2026-06-08T20:23:17.1188390Z  * [new branch]      issue-45-0325c0f5      -> origin/issue-45-0325c0f5
+2026-06-08T20:23:17.1189222Z  * [new branch]      issue-45-1ed9a563      -> origin/issue-45-1ed9a563
+2026-06-08T20:23:17.1190027Z  * [new branch]      issue-45-ce5f1e15      -> origin/issue-45-ce5f1e15
+2026-06-08T20:23:17.1190864Z  * [new branch]      issue-46-52edd2db      -> origin/issue-46-52edd2db
+2026-06-08T20:23:17.1191685Z  * [new branch]      issue-46-d4eec70e      -> origin/issue-46-d4eec70e
+2026-06-08T20:23:17.1192756Z  * [new branch]      issue-46-f237aa54      -> origin/issue-46-f237aa54
+2026-06-08T20:23:17.1193577Z  * [new branch]      issue-47-7a71c96e      -> origin/issue-47-7a71c96e
+2026-06-08T20:23:17.1194436Z  * [new branch]      issue-47-b31e0547      -> origin/issue-47-b31e0547
+2026-06-08T20:23:17.1195276Z  * [new branch]      issue-47-e7830e99      -> origin/issue-47-e7830e99
+2026-06-08T20:23:17.1196099Z  * [new branch]      issue-48-aaa5df6f      -> origin/issue-48-aaa5df6f
+2026-06-08T20:23:17.1196948Z  * [new branch]      issue-48-ad9abe01      -> origin/issue-48-ad9abe01
+2026-06-08T20:23:17.1197771Z  * [new branch]      issue-48-ead273fb      -> origin/issue-48-ead273fb
+2026-06-08T20:23:17.1198625Z  * [new branch]      issue-49-08e57741      -> origin/issue-49-08e57741
+2026-06-08T20:23:17.1199504Z  * [new branch]      issue-49-54f19e82      -> origin/issue-49-54f19e82
+2026-06-08T20:23:17.1200295Z  * [new branch]      issue-49-e74051ab      -> origin/issue-49-e74051ab
+2026-06-08T20:23:17.1200917Z  * [new branch]      issue-50-02f42ae4      -> origin/issue-50-02f42ae4
+2026-06-08T20:23:17.1201420Z  * [new branch]      issue-50-0b915412      -> origin/issue-50-0b915412
+2026-06-08T20:23:17.1202188Z  * [new branch]      issue-50-5de8b754      -> origin/issue-50-5de8b754
+2026-06-08T20:23:17.1202721Z  * [new branch]      issue-6-156225d2       -> origin/issue-6-156225d2
+2026-06-08T20:23:17.1203238Z  * [new branch]      issue-6-52fa1fa4       -> origin/issue-6-52fa1fa4
+2026-06-08T20:23:17.1203963Z  * [new branch]      issue-9-55d6d25e       -> origin/issue-9-55d6d25e
+2026-06-08T20:23:17.1204461Z  * [new branch]      issue-9-c5ab4ea2       -> origin/issue-9-c5ab4ea2
+2026-06-08T20:23:17.1204957Z  * [new branch]      issue-96-a24e1d66      -> origin/issue-96-a24e1d66
+2026-06-08T20:23:17.1205458Z  * [new branch]      issue-96-eb9bb8d1      -> origin/issue-96-eb9bb8d1
+2026-06-08T20:23:17.1205928Z  * [new branch]      main                   -> origin/main
+2026-06-08T20:23:17.1206348Z  * [new tag]         v0.0.1                 -> v0.0.1
+2026-06-08T20:23:17.1206746Z  * [new tag]         v0.0.2                 -> v0.0.2
+2026-06-08T20:23:17.1207133Z  * [new tag]         v0.0.3                 -> v0.0.3
+2026-06-08T20:23:17.1207512Z  * [new tag]         v0.0.4                 -> v0.0.4
+2026-06-08T20:23:17.1207894Z  * [new tag]         v0.0.5                 -> v0.0.5
+2026-06-08T20:23:17.1208264Z  * [new tag]         v0.1.0                 -> v0.1.0
+2026-06-08T20:23:17.1208647Z  * [new tag]         v0.2.0                 -> v0.2.0
+2026-06-08T20:23:17.1209016Z  * [new tag]         v0.3.0                 -> v0.3.0
+2026-06-08T20:23:17.1209389Z  * [new tag]         v0.3.1                 -> v0.3.1
+2026-06-08T20:23:17.1209756Z  * [new tag]         v0.3.2                 -> v0.3.2
+2026-06-08T20:23:17.1210125Z  * [new tag]         v0.4.0                 -> v0.4.0
+2026-06-08T20:23:17.1210492Z  * [new tag]         v0.5.0                 -> v0.5.0
+2026-06-08T20:23:17.1210859Z  * [new tag]         v0.6.0                 -> v0.6.0
+2026-06-08T20:23:17.1211233Z  * [new tag]         v0.7.0                 -> v0.7.0
+2026-06-08T20:23:17.1211617Z  * [new tag]         v0.7.1                 -> v0.7.1
+2026-06-08T20:23:17.1212216Z  * [new tag]         v0.8.0                 -> v0.8.0
+2026-06-08T20:23:17.1212601Z  * [new tag]         v0.8.1                 -> v0.8.1
+2026-06-08T20:23:17.1212975Z  * [new tag]         v0.8.2                 -> v0.8.2
+2026-06-08T20:23:17.1213352Z  * [new tag]         v0.8.3                 -> v0.8.3
+2026-06-08T20:23:17.1213881Z  * [new tag]         v0.9.0                 -> v0.9.0
+2026-06-08T20:23:17.1214265Z  * [new tag]         v0.9.1                 -> v0.9.1
+2026-06-08T20:23:17.1214646Z  * [new tag]         v0.9.2                 -> v0.9.2
+2026-06-08T20:23:17.1215018Z  * [new tag]         v0.9.4                 -> v0.9.4
+2026-06-08T20:23:17.1215402Z  * [new tag]         v0.9.5                 -> v0.9.5
+2026-06-08T20:23:17.1261012Z [command]/usr/bin/git branch --list --remote origin/main
+2026-06-08T20:23:17.1365286Z   origin/main
+2026-06-08T20:23:17.1375127Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+2026-06-08T20:23:17.1396646Z 89d47cf62671f8e1c4813af51128b0b9e47b6fa6
+2026-06-08T20:23:17.1400860Z ##[endgroup]
+2026-06-08T20:23:17.1401365Z ##[group]Determining the checkout info
+2026-06-08T20:23:17.1402263Z ##[endgroup]
+2026-06-08T20:23:17.1406584Z [command]/usr/bin/git sparse-checkout disable
+2026-06-08T20:23:17.1447174Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2026-06-08T20:23:17.1473243Z ##[group]Checking out the ref
+2026-06-08T20:23:17.1477982Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2026-06-08T20:23:17.2253393Z Switched to a new branch 'main'
+2026-06-08T20:23:17.2254727Z branch 'main' set up to track 'origin/main'.
+2026-06-08T20:23:17.2267377Z ##[endgroup]
+2026-06-08T20:23:17.2314260Z [command]/usr/bin/git log -1 --format=%H
+2026-06-08T20:23:17.2338894Z 89d47cf62671f8e1c4813af51128b0b9e47b6fa6
+2026-06-08T20:23:17.2573896Z ##[group]Run actions/setup-node@v4
+2026-06-08T20:23:17.2574250Z with:
+2026-06-08T20:23:17.2574515Z   node-version: 20.x
+2026-06-08T20:23:17.2574838Z   registry-url: https://registry.npmjs.org
+2026-06-08T20:23:17.2575191Z   always-auth: false
+2026-06-08T20:23:17.2575517Z   check-latest: false
+2026-06-08T20:23:17.2578665Z   token: ***
+2026-06-08T20:23:17.2578930Z ##[endgroup]
+2026-06-08T20:23:17.4333389Z Attempting to download 20.x...
+2026-06-08T20:23:18.0836947Z Acquiring 20.20.2 - x64 from https://github.com/actions/node-versions/releases/download/20.20.2-23521894959/node-20.20.2-linux-x64.tar.gz
+2026-06-08T20:23:18.6483395Z Extracting ...
+2026-06-08T20:23:18.6589305Z [command]/usr/bin/tar xz --strip 1 --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/5125e9b6-bde6-466b-aeec-a954a58b3d40 -f /home/runner/work/_temp/4adaee56-01ee-4b13-b712-71f5ad7f0ebb
+2026-06-08T20:23:19.7340999Z Adding to the cache ...
+2026-06-08T20:23:21.2300847Z ##[group]Environment details
+2026-06-08T20:23:21.4513214Z node: v20.20.2
+2026-06-08T20:23:21.4513625Z npm: 10.8.2
+2026-06-08T20:23:21.4514039Z yarn: 1.22.22
+2026-06-08T20:23:21.4514804Z ##[endgroup]
+2026-06-08T20:23:21.4729969Z ##[group]Run oven-sh/setup-bun@v2
+2026-06-08T20:23:21.4730281Z with:
+2026-06-08T20:23:21.4730510Z   bun-version: latest
+2026-06-08T20:23:21.4730754Z   no-cache: false
+2026-06-08T20:23:21.4734254Z   token: ***
+2026-06-08T20:23:21.4734490Z env:
+2026-06-08T20:23:21.4734786Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+2026-06-08T20:23:21.4735175Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+2026-06-08T20:23:21.4735468Z ##[endgroup]
+2026-06-08T20:23:21.9978231Z Downloading a new version of Bun: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-linux-x64.zip
+2026-06-08T20:23:22.4568769Z [command]/usr/bin/unzip -o -q /home/runner/work/_temp/97279be7-5d8e-4139-83f6-46c824ca1357.zip
+2026-06-08T20:23:23.2339111Z [command]/home/runner/.bun/bin/bun --revision
+2026-06-08T20:23:23.2380810Z 1.3.14+0d9b296af
+2026-06-08T20:23:23.2525004Z ##[group]Run bun install
+2026-06-08T20:23:23.2525363Z ^[[36;1mbun install^[[0m
+2026-06-08T20:23:23.2557687Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:23:23.2557980Z env:
+2026-06-08T20:23:23.2558258Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+2026-06-08T20:23:23.2558642Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+2026-06-08T20:23:23.2558937Z ##[endgroup]
+2026-06-08T20:23:23.2656025Z bun install v1.3.14 (0d9b296a)
+2026-06-08T20:23:23.6266917Z 
+2026-06-08T20:23:23.6272317Z $ cd .. && js/node_modules/.bin/husky || true
+2026-06-08T20:23:23.6682566Z 
+2026-06-08T20:23:23.6683476Z + @changesets/cli@2.29.8
+2026-06-08T20:23:23.6684419Z + eslint@9.39.2
+2026-06-08T20:23:23.6685216Z + eslint-config-prettier@10.1.8
+2026-06-08T20:23:23.6686079Z + eslint-plugin-prettier@5.5.4
+2026-06-08T20:23:23.6686532Z + husky@9.1.7
+2026-06-08T20:23:23.6686854Z + jscpd@4.0.5
+2026-06-08T20:23:23.6687184Z + lint-staged@16.2.7
+2026-06-08T20:23:23.6687520Z + prettier@3.7.4
+2026-06-08T20:23:23.6687704Z 
+2026-06-08T20:23:23.6688016Z 301 packages installed [403.00ms]
+2026-06-08T20:23:23.6758426Z ##[group]Run bun scripts/setup-npm.mjs
+2026-06-08T20:23:23.6758796Z ^[[36;1mbun scripts/setup-npm.mjs^[[0m
+2026-06-08T20:23:23.6786964Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:23:23.6787237Z env:
+2026-06-08T20:23:23.6787514Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+2026-06-08T20:23:23.6787891Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+2026-06-08T20:23:23.6788182Z ##[endgroup]
+2026-06-08T20:23:24.5130913Z 10.8.2
+2026-06-08T20:23:24.5164393Z Current npm version: 10.8.2
+2026-06-08T20:23:27.8663672Z 
+2026-06-08T20:23:27.8664621Z removed 65 packages, and changed 112 packages in 3s
+2026-06-08T20:23:27.8679935Z 
+2026-06-08T20:23:27.8682246Z 15 packages are looking for funding
+2026-06-08T20:23:27.8682991Z   run `npm fund` for details
+2026-06-08T20:23:27.9803064Z 11.16.0
+2026-06-08T20:23:27.9836215Z Updated npm version: 11.16.0
+2026-06-08T20:23:27.9894189Z ##[group]Run CHANGESET_COUNT=$(find .changeset -name "*.md" ! -name "README.md" | wc -l)
+2026-06-08T20:23:27.9894845Z ^[[36;1mCHANGESET_COUNT=$(find .changeset -name "*.md" ! -name "README.md" | wc -l)^[[0m
+2026-06-08T20:23:27.9895450Z ^[[36;1mecho "Found $CHANGESET_COUNT JavaScript changeset file(s)"^[[0m
+2026-06-08T20:23:27.9917524Z ^[[36;1mecho "has_changesets=$([[ $CHANGESET_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT^[[0m
+2026-06-08T20:23:27.9918140Z ^[[36;1mecho "changeset_count=$CHANGESET_COUNT" >> $GITHUB_OUTPUT^[[0m
+2026-06-08T20:23:27.9946268Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:23:27.9946541Z env:
+2026-06-08T20:23:27.9946823Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+2026-06-08T20:23:27.9947189Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+2026-06-08T20:23:27.9947473Z ##[endgroup]
+2026-06-08T20:23:28.0067968Z Found 2 JavaScript changeset file(s)
+2026-06-08T20:23:28.0143850Z ##[group]Run bun scripts/merge-changesets.mjs
+2026-06-08T20:23:28.0144219Z ^[[36;1mbun scripts/merge-changesets.mjs^[[0m
+2026-06-08T20:23:28.0168578Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:23:28.0168846Z env:
+2026-06-08T20:23:28.0169116Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+2026-06-08T20:23:28.0169471Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+2026-06-08T20:23:28.0169769Z ##[endgroup]
+2026-06-08T20:23:28.0434413Z Checking for multiple changesets to merge...
+2026-06-08T20:23:28.0435094Z Found 2 changeset file(s)
+2026-06-08T20:23:28.0435584Z Multiple changesets found, merging...
+2026-06-08T20:23:28.0436135Z   - release-job-skipped-by-gate.md
+2026-06-08T20:23:28.0436514Z   - separate-language-releases.md
+2026-06-08T20:23:28.0441050Z 
+2026-06-08T20:23:28.0441240Z Merge summary:
+2026-06-08T20:23:28.0441601Z   Bump types found: patch
+2026-06-08T20:23:28.0442189Z   Using highest: patch
+2026-06-08T20:23:28.0442533Z   Descriptions to merge: 2
+2026-06-08T20:23:28.0443452Z 
+2026-06-08T20:23:28.0443762Z Created merged changeset: merged-neat-flower.md
+2026-06-08T20:23:28.0444119Z 
+2026-06-08T20:23:28.0444362Z Removing original changeset files:
+2026-06-08T20:23:28.0444870Z   Removed: release-job-skipped-by-gate.md
+2026-06-08T20:23:28.0445405Z   Removed: separate-language-releases.md
+2026-06-08T20:23:28.0445712Z 
+2026-06-08T20:23:28.0445872Z Changeset merge completed successfully
+2026-06-08T20:23:28.0446070Z 
+2026-06-08T20:23:28.0446190Z Merged changeset content:
+2026-06-08T20:23:28.0446444Z ---
+2026-06-08T20:23:28.0446685Z 'command-stream': patch
+2026-06-08T20:23:28.0446935Z ---
+2026-06-08T20:23:28.0447046Z 
+2026-06-08T20:23:28.0447372Z Ensure the JavaScript release job still evaluates on main pushes after the
+2026-06-08T20:23:28.0447873Z pull-request-only changeset gate is skipped.
+2026-06-08T20:23:28.0448090Z 
+2026-06-08T20:23:28.0448399Z Separate JavaScript package metadata, scripts, documentation, and release tags
+2026-06-08T20:23:28.0448881Z from the Rust crate release path.
+2026-06-08T20:23:28.0449072Z 
+2026-06-08T20:23:28.0488028Z ##[group]Run bun scripts/version-and-commit.mjs --mode changeset
+2026-06-08T20:23:28.0488512Z ^[[36;1mbun scripts/version-and-commit.mjs --mode changeset^[[0m
+2026-06-08T20:23:28.0516782Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:23:28.0517063Z env:
+2026-06-08T20:23:28.0517350Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+2026-06-08T20:23:28.0517721Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+2026-06-08T20:23:28.0518012Z ##[endgroup]
+2026-06-08T20:23:28.7909206Z Parsed configuration: {
+2026-06-08T20:23:28.7909579Z   mode: "changeset",
+2026-06-08T20:23:28.7909846Z   bumpType: "",
+2026-06-08T20:23:28.7910136Z   description: "(none)",
+2026-06-08T20:23:28.7910394Z }
+2026-06-08T20:23:28.9476818Z Checking for remote changes...
+2026-06-08T20:23:29.2056549Z From https://github.com/link-foundation/command-stream
+2026-06-08T20:23:29.2057045Z  * branch            main       -> FETCH_HEAD
+2026-06-08T20:23:29.2166829Z 89d47cf62671f8e1c4813af51128b0b9e47b6fa6
+2026-06-08T20:23:29.2227895Z 89d47cf62671f8e1c4813af51128b0b9e47b6fa6
+2026-06-08T20:23:29.2234792Z Current version: 0.9.5
+2026-06-08T20:23:29.2235241Z Running changeset version...
+2026-06-08T20:23:29.2301042Z $ bun scripts/changeset-version.mjs
+2026-06-08T20:23:29.3866588Z Running changeset version...
+2026-06-08T20:23:29.8319340Z 🦋  All files have been updated. Review them and commit at your leisure
+2026-06-08T20:23:29.8444241Z 
+2026-06-08T20:23:29.8444720Z Synchronizing package-lock.json...
+2026-06-08T20:23:30.1377697Z npm warn Unknown user config "always-auth". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
+2026-06-08T20:23:31.0072439Z 
+2026-06-08T20:23:31.0073110Z > command-stream@0.9.6 prepare
+2026-06-08T20:23:31.0073774Z > cd .. && js/node_modules/.bin/husky || true
+2026-06-08T20:23:31.0074135Z 
+2026-06-08T20:23:31.0764962Z 
+2026-06-08T20:23:31.0766323Z up to date, audited 320 packages in 1s
+2026-06-08T20:23:31.0766700Z 
+2026-06-08T20:23:31.0767001Z 74 packages are looking for funding
+2026-06-08T20:23:31.0767465Z   run `npm fund` for details
+2026-06-08T20:23:31.0848065Z 
+2026-06-08T20:23:31.0848757Z 6 vulnerabilities (3 moderate, 3 high)
+2026-06-08T20:23:31.0849428Z 
+2026-06-08T20:23:31.0849900Z To address all issues, run:
+2026-06-08T20:23:31.0850473Z   npm audit fix
+2026-06-08T20:23:31.0850758Z 
+2026-06-08T20:23:31.0851038Z Run `npm audit` for details.
+2026-06-08T20:23:31.0942022Z 
+2026-06-08T20:23:31.0943317Z ✅ Version bump complete with synchronized package-lock.json
+2026-06-08T20:23:31.0974567Z New version: 0.9.6
+2026-06-08T20:23:31.1475939Z  D js/.changeset/release-job-skipped-by-gate.md
+2026-06-08T20:23:31.1477010Z  D js/.changeset/separate-language-releases.md
+2026-06-08T20:23:31.1477553Z  M js/CHANGELOG.md
+2026-06-08T20:23:31.1502725Z  M js/package-lock.json
+2026-06-08T20:23:31.1513042Z  M js/package.json
+2026-06-08T20:23:31.1513519Z Changes detected, committing...
+2026-06-08T20:23:31.4652308Z npm warn Unknown user config "always-auth". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
+2026-06-08T20:23:31.5957419Z ^[[33m[STARTED]^[[39m Backing up original state...
+2026-06-08T20:23:31.6262088Z ^[[32m[COMPLETED]^[[39m Backed up original state in git stash (e54180c)
+2026-06-08T20:23:31.6263509Z ^[[33m[STARTED]^[[39m Running tasks for staged files...
+2026-06-08T20:23:31.6272910Z ^[[33m[STARTED]^[[39m package.json^[[0;90m — 3 files^[[0m
+2026-06-08T20:23:31.6273708Z ^[[33m[STARTED]^[[39m *.{js,mjs,cjs}^[[0;90m — 0 files^[[0m
+2026-06-08T20:23:31.6274388Z ^[[33m[STARTED]^[[39m *.md^[[0;90m — 1 file^[[0m
+2026-06-08T20:23:31.6275096Z ^[[33m[SKIPPED]^[[39m *.{js,mjs,cjs}^[[0;90m — no files^[[0m
+2026-06-08T20:23:31.6275815Z ^[[33m[STARTED]^[[39m prettier --write
+2026-06-08T20:23:31.8222756Z ^[[32m[COMPLETED]^[[39m prettier --write
+2026-06-08T20:23:31.8223860Z ^[[33m[STARTED]^[[39m prettier --check
+2026-06-08T20:23:32.0130022Z ^[[32m[COMPLETED]^[[39m prettier --check
+2026-06-08T20:23:32.0131133Z ^[[32m[COMPLETED]^[[39m *.md^[[0;90m — 1 file^[[0m
+2026-06-08T20:23:32.0132696Z ^[[32m[COMPLETED]^[[39m package.json^[[0;90m — 3 files^[[0m
+2026-06-08T20:23:32.0133508Z ^[[32m[COMPLETED]^[[39m Running tasks for staged files...
+2026-06-08T20:23:32.0134297Z ^[[33m[STARTED]^[[39m Applying modifications from tasks...
+2026-06-08T20:23:32.0206872Z ^[[32m[COMPLETED]^[[39m Applying modifications from tasks...
+2026-06-08T20:23:32.0208231Z ^[[33m[STARTED]^[[39m Cleaning up temporary files...
+2026-06-08T20:23:32.0297713Z ^[[32m[COMPLETED]^[[39m Cleaning up temporary files...
+2026-06-08T20:23:32.0632282Z [main 971eab5] 0.9.6
+2026-06-08T20:23:32.0632883Z  5 files changed, 13 insertions(+), 15 deletions(-)
+2026-06-08T20:23:32.0633657Z  delete mode 100644 js/.changeset/release-job-skipped-by-gate.md
+2026-06-08T20:23:32.0634224Z  delete mode 100644 js/.changeset/separate-language-releases.md
+2026-06-08T20:23:33.0985738Z To https://github.com/link-foundation/command-stream
+2026-06-08T20:23:33.0986198Z    89d47cf..971eab5  main -> main
+2026-06-08T20:23:33.1033689Z ✅ Version bump committed and pushed to main
+2026-06-08T20:23:33.1112003Z ##[group]Run bun scripts/publish-to-npm.mjs --should-pull
+2026-06-08T20:23:33.1112532Z ^[[36;1mbun scripts/publish-to-npm.mjs --should-pull^[[0m
+2026-06-08T20:23:33.1140325Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:23:33.1140588Z env:
+2026-06-08T20:23:33.1140862Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+2026-06-08T20:23:33.1141224Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+2026-06-08T20:23:33.1141511Z ##[endgroup]
+2026-06-08T20:23:33.5956087Z From https://github.com/link-foundation/command-stream
+2026-06-08T20:23:33.5956558Z  * branch            main       -> FETCH_HEAD
+2026-06-08T20:23:33.6021552Z Already up to date.
+2026-06-08T20:23:33.6035719Z Current version to publish: 0.9.6
+2026-06-08T20:23:33.6036314Z Checking if version 0.9.6 is already published...
+2026-06-08T20:23:33.8340945Z npm warn Unknown user config "always-auth". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
+2026-06-08T20:23:34.1273674Z npm error code E404
+2026-06-08T20:23:34.1275716Z npm error 404 No match found for version 0.9.6
+2026-06-08T20:23:34.1276272Z npm error 404
+2026-06-08T20:23:34.1278484Z npm error 404  The requested resource 'command-stream@0.9.6' could not be found or you do not have permission to access it.
+2026-06-08T20:23:34.1279413Z npm error 404
+2026-06-08T20:23:34.1280271Z npm error 404 Note that you can also install from a
+2026-06-08T20:23:34.1283619Z npm error 404 tarball, folder, http url, or git url.
+2026-06-08T20:23:34.1297311Z npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-06-08T20_23_33_667Z-debug-0.log
+2026-06-08T20:23:34.1343010Z Version 0.9.6 not found on npm, proceeding with publish...
+2026-06-08T20:23:34.1343593Z Publish attempt 1 of 3...
+2026-06-08T20:23:34.1412613Z $ changeset publish
+2026-06-08T20:23:34.4264741Z 🦋  ^[[36minfo^[[39m npm info command-stream
+2026-06-08T20:23:34.8987808Z 🦋  ^[[36minfo^[[39m command-stream is being published because our local version (0.9.6) has not been published on npm
+2026-06-08T20:23:34.8990085Z 🦋  ^[[36minfo^[[39m Publishing ^[[36m"command-stream"^[[39m at ^[[32m"0.9.6"^[[39m
+2026-06-08T20:23:36.8282336Z 🦋  ^[[31merror^[[39m an error occurred while publishing command-stream: E404 Not Found - PUT https://registry.npmjs.org/command-stream - Not found 
+2026-06-08T20:23:36.8284507Z 🦋  ^[[31merror^[[39m The requested resource 'command-stream@0.9.6' could not be found or you do not have permission to access it.
+2026-06-08T20:23:36.8286052Z 🦋  ^[[31merror^[[39m 
+2026-06-08T20:23:36.8286803Z 🦋  ^[[31merror^[[39m Note that you can also install from a
+2026-06-08T20:23:36.8287751Z 🦋  ^[[31merror^[[39m tarball, folder, http url, or git url.
+2026-06-08T20:23:36.8289593Z 🦋  ^[[31merror^[[39m npm warn Unknown user config "always-auth". This will stop working in the next major version of npm. See `npm help npmrc` for supported config options.
+2026-06-08T20:23:36.8290871Z 🦋  command-stream@0.9.6
+2026-06-08T20:23:36.8291510Z 🦋  ^[[31merror^[[39m 
+2026-06-08T20:23:36.8292626Z 🦋  ^[[31merror^[[39m > command-stream@0.9.6 prepare
+2026-06-08T20:23:36.8293251Z 🦋  ^[[31merror^[[39m > cd .. && js/node_modules/.bin/husky || true
+2026-06-08T20:23:36.8293679Z 🦋  ^[[31merror^[[39m 
+2026-06-08T20:23:36.8294562Z 🦋  ^[[31merror^[[39m npm notice Publishing to https://registry.npmjs.org with tag latest and public access
+2026-06-08T20:23:36.8295542Z 🦋  ^[[31merror^[[39m npm error code E404
+2026-06-08T20:23:36.8296615Z 🦋  ^[[31merror^[[39m npm error 404 Not Found - PUT https://registry.npmjs.org/command-stream - Not found
+2026-06-08T20:23:36.8297483Z 🦋  ^[[31merror^[[39m npm error 404
+2026-06-08T20:23:36.8298747Z 🦋  ^[[31merror^[[39m npm error 404  The requested resource 'command-stream@0.9.6' could not be found or you do not have permission to access it.
+2026-06-08T20:23:36.8299833Z 🦋  ^[[31merror^[[39m npm error 404
+2026-06-08T20:23:36.8300552Z 🦋  ^[[31merror^[[39m npm error 404 Note that you can also install from a
+2026-06-08T20:23:36.8301951Z 🦋  ^[[31merror^[[39m npm error 404 tarball, folder, http url, or git url.
+2026-06-08T20:23:36.8303337Z 🦋  ^[[31merror^[[39m npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2026-06-08T20_23_34_962Z-debug-0.log
+2026-06-08T20:23:36.8304256Z 🦋  ^[[31merror^[[39m 
+2026-06-08T20:23:36.8304788Z 🦋  ^[[31merror^[[39m packages failed to publish:
+2026-06-08T20:23:36.8335352Z error: script "changeset:publish" exited with code 1
+2026-06-08T20:23:36.8341059Z ✅ Published command-stream@0.9.6 to npm
+2026-06-08T20:23:36.8430783Z ##[group]Run bun scripts/create-github-release.mjs --release-version "0.9.6" --repository "link-foundation/command-stream" --tag-prefix js-v
+2026-06-08T20:23:36.8432263Z ^[[36;1mbun scripts/create-github-release.mjs --release-version "0.9.6" --repository "link-foundation/command-stream" --tag-prefix js-v^[[0m
+2026-06-08T20:23:36.8460065Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:23:36.8460350Z env:
+2026-06-08T20:23:36.8460623Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+2026-06-08T20:23:36.8460992Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+2026-06-08T20:23:36.8464675Z   GH_TOKEN: ***
+2026-06-08T20:23:36.8464927Z ##[endgroup]
+2026-06-08T20:23:37.0550219Z Creating JavaScript GitHub release for js-v0.9.6...
+2026-06-08T20:23:39.5370042Z {"url":"https://api.github.com/repos/link-foundation/command-stream/releases/336219532","assets_url":"https://api.github.com/repos/link-foundation/command-stream/releases/336219532/assets","upload_url":"https://uploads.github.com/repos/link-foundation/command-stream/releases/336219532/assets{?name,label}","html_url":"https://github.com/link-foundation/command-stream/releases/tag/js-v0.9.6","id":336219532,"author":{"login":"github-actions[bot]","id":41898282,"node_id":"MDM6Qm90NDE4OTgyODI=","avatar_url":"https://avatars.githubusercontent.com/in/15368?v=4","gravatar_id":"","url":"https://api.github.com/users/github-actions%5Bbot%5D","html_url":"https://github.com/apps/github-actions","followers_url":"https://api.github.com/users/github-actions%5Bbot%5D/followers","following_url":"https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}","gists_url":"https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}","starred_url":"https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github-actions%5Bbot%5D/subscriptions","organizations_url":"https://api.github.com/users/github-actions%5Bbot%5D/orgs","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","events_url":"https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}","received_events_url":"https://api.github.com/users/github-actions%5Bbot%5D/received_events","type":"Bot","user_view_type":"public","site_admin":false},"node_id":"RE_kwDOPc80Bs4UCk2M","tag_name":"js-v0.9.6","target_commitish":"main","name":"JavaScript 0.9.6","draft":false,"immutable":false,"prerelease":false,"created_at":"2026-06-08T20:23:31Z","updated_at":"2026-06-08T20:23:39Z","published_at":"2026-06-08T20:23:39Z","assets":[],"tarball_url":"https://api.github.com/repos/link-foundation/command-stream/tarball/js-v0.9.6","zipball_url":"https://api.github.com/repos/link-foundation/command-stream/zipball/js-v0.9.6","body":"### Patch Changes\n\n- Ensure the JavaScript release job still evaluates on main pushes after the\n  pull-request-only changeset gate is skipped.\n\n  Separate JavaScript package metadata, scripts, documentation, and release tags\n  from the Rust crate release path."}Created JavaScript GitHub release: js-v0.9.6
+2026-06-08T20:23:39.5450961Z ##[group]Run bun scripts/format-github-release.mjs --release-version "0.9.6" --repository "link-foundation/command-stream" --commit-sha "89d47cf62671f8e1c4813af51128b0b9e47b6fa6" --tag-prefix js-v
+2026-06-08T20:23:39.5452656Z ^[[36;1mbun scripts/format-github-release.mjs --release-version "0.9.6" --repository "link-foundation/command-stream" --commit-sha "89d47cf62671f8e1c4813af51128b0b9e47b6fa6" --tag-prefix js-v^[[0m
+2026-06-08T20:23:39.5480960Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:23:39.5481237Z env:
+2026-06-08T20:23:39.5481516Z   NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
+2026-06-08T20:23:39.5482088Z   NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+2026-06-08T20:23:39.5485451Z   GH_TOKEN: ***
+2026-06-08T20:23:39.5485724Z ##[endgroup]
+2026-06-08T20:23:40.1272460Z 336219532
+2026-06-08T20:23:40.1301009Z Formatting JavaScript release notes for js-v0.9.6...
+2026-06-08T20:23:40.6026961Z {"url":"https://api.github.com/repos/link-foundation/command-stream/releases/336219532","assets_url":"https://api.github.com/repos/link-foundation/command-stream/releases/336219532/assets","upload_url":"https://uploads.github.com/repos/link-foundation/command-stream/releases/336219532/assets{?name,label}","html_url":"https://github.com/link-foundation/command-stream/releases/tag/js-v0.9.6","id":336219532,"author":{"login":"github-actions[bot]","id":41898282,"node_id":"MDM6Qm90NDE4OTgyODI=","avatar_url":"https://avatars.githubusercontent.com/in/15368?v=4","gravatar_id":"","url":"https://api.github.com/users/github-actions%5Bbot%5D","html_url":"https://github.com/apps/github-actions","followers_url":"https://api.github.com/users/github-actions%5Bbot%5D/followers","following_url":"https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}","gists_url":"https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}","starred_url":"https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github-actions%5Bbot%5D/subscriptions","organizations_url":"https://api.github.com/users/github-actions%5Bbot%5D/orgs","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","events_url":"https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}","received_events_url":"https://api.github.com/users/github-actions%5Bbot%5D/received_events","type":"Bot","user_view_type":"public","site_admin":false},"node_id":"RE_kwDOPc80Bs4UCk2M","tag_name":"js-v0.9.6","target_commitish":"main","name":"JavaScript 0.9.6","draft":false,"immutable":false,"prerelease":false,"created_at":"2026-06-08T20:23:31Z","updated_at":"2026-06-08T20:23:39Z","published_at":"2026-06-08T20:23:39Z","assets":[],"tarball_url":"https://api.github.com/repos/link-foundation/command-stream/tarball/js-v0.9.6","zipball_url":"https://api.github.com/repos/link-foundation/command-stream/zipball/js-v0.9.6","body":"### Patch Changes\n\n- Ensure the JavaScript release job still evaluates on main pushes after the\n  pull-request-only changeset gate is skipped.\n\n  Separate JavaScript package metadata, scripts, documentation, and release tags\n  from the Rust crate release path."}ℹ️ Found Patch Changes section
+2026-06-08T20:23:40.6040992Z ℹ️ Looking up PR for commit 89d47cf62671f8e1c4813af51128b0b9e47b6fa6 (from workflow)
+2026-06-08T20:23:41.1477531Z [{"url":"https://api.github.com/repos/link-foundation/command-stream/pulls/163","id":3826240845,"node_id":"PR_kwDOPc80Bs7kD81N","html_url":"https://github.com/link-foundation/command-stream/pull/163","diff_url":"https://github.com/link-foundation/command-stream/pull/163.diff","patch_url":"https://github.com/link-foundation/command-stream/pull/163.patch","issue_url":"https://api.github.com/repos/link-foundation/command-stream/issues/163","number":163,"state":"closed","locked":false,"title":"Fix split language release jobs after skipped gates","user":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"body":"Fixes #162\n\n## Summary\n\nThis PR fixes the split JavaScript/Rust release workflows introduced by PR #161. The post-merge runs after PR #161 succeeded overall, but the actual language release jobs were skipped because their `needs` graph included PR-only gate jobs that are skipped on `push`.\n\nThe release jobs now use explicit status-check guards so GitHub Actions evaluates them after skipped PR-only dependencies:\n\n- JavaScript release: `always() && !cancelled()` plus successful `lint` and `test` results.\n- Rust release: `always() && !cancelled()` plus successful `lint`, `test`, and `build` results.\n\n## Case Study\n\nFull investigation and evidence:\n\nhttps://github.com/link-foundation/command-stream/blob/issue-162-0c186d5158ec/docs/case-studies/issue-162/README.md\n\nThe case study includes the PR #161 timeline, downloaded CI logs, package registry snapshots, template snapshots, and before/after test logs.\n\n## Template Reports\n\nThe JavaScript and Rust upstream templates already protect their automatic release paths from this skipped-needs behavior. I found related workflow-dispatch risks in two other templates and opened upstream reports:\n\n- Python template: https://github.com/link-foundation/python-ai-driven-development-pipeline-template/issues/18\n- C# template: https://github.com/link-foundation/csharp-ai-driven-development-pipeline-template/issues/23\n\n## Verification\n\nLocal checks run:\n\n```sh\nbun test js/tests/repository-layout.test.mjs --timeout 10000\nruby -e \"require 'yaml'; YAML.load_file('.github/workflows/js.yml'); YAML.load_file('.github/workflows/rust.yml'); puts 'ok'\"\ncd js && bun run format:check\ncd js && bun run lint\ncd js && bun run check:duplication\ncd js && PATH=/tmp/issue-162-bin:$PATH bun run test\n```\n\nThe full JS suite passed with 686 passing tests, 5 skipped, 0 failed. The container did not provide `jq` and passwordless sudo was unavailable, so the full local JS test run used a temporary uncommitted `jq-1.7.1` binary under `/tmp/issue-162-bin`; CI installs `jq` in the workflow.\n\n## Release Notes\n\nPatch release markers were added for both packages so the next merge to `main` has release input to consume.\n","created_at":"2026-06-08T19:24:51Z","updated_at":"2026-06-08T20:21:57Z","closed_at":"2026-06-08T20:21:56Z","merged_at":"2026-06-08T20:21:56Z","merge_commit_sha":"89d47cf62671f8e1c4813af51128b0b9e47b6fa6","assignees":[{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false}],"requested_reviewers":[],"requested_teams":[],"labels":[],"milestone":null,"draft":false,"commits_url":"https://api.github.com/repos/link-foundation/command-stream/pulls/163/commits","review_comments_url":"https://api.github.com/repos/link-foundation/command-stream/pulls/163/comments","review_comment_url":"https://api.github.com/repos/link-foundation/command-stream/pulls/comments{/number}","comments_url":"https://api.github.com/repos/link-foundation/command-stream/issues/163/comments","statuses_url":"https://api.github.com/repos/link-foundation/command-stream/statuses/9d18ab35d9e2a5f279695e606d61ecb763e1950e","head":{"label":"link-foundation:issue-162-0c186d5158ec","ref":"issue-162-0c186d5158ec","sha":"9d18ab35d9e2a5f279695e606d61ecb763e1950e","user":{"login":"link-foundation","id":176174013,"node_id":"O_kgDOCoAzvQ","avatar_url":"https://avatars.githubusercontent.com/u/176174013?v=4","gravatar_id":"","url":"https://api.github.com/users/link-foundation","html_url":"https://github.com/link-foundation","followers_url":"https://api.github.com/users/link-foundation/followers","following_url":"https://api.github.com/users/link-foundation/following{/other_user}","gists_url":"https://api.github.com/users/link-foundation/gists{/gist_id}","starred_url":"https://api.github.com/users/link-foundation/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/link-foundation/subscriptions","organizations_url":"https://api.github.com/users/link-foundation/orgs","repos_url":"https://api.github.com/users/link-foundation/repos","events_url":"https://api.github.com/users/link-foundation/events{/privacy}","received_events_url":"https://api.github.com/users/link-foundation/received_events","type":"Organization","user_view_type":"public","site_admin":false},"repo":{"id":1036989446,"node_id":"R_kgDOPc80Bg","name":"command-stream","full_name":"link-foundation/command-stream","private":false,"owner":{"login":"link-foundation","id":176174013,"node_id":"O_kgDOCoAzvQ","avatar_url":"https://avatars.githubusercontent.com/u/176174013?v=4","gravatar_id":"","url":"https://api.github.com/users/link-foundation","html_url":"https://github.com/link-foundation","followers_url":"https://api.github.com/users/link-foundation/followers","following_url":"https://api.github.com/users/link-foundation/following{/other_user}","gists_url":"https://api.github.com/users/link-foundation/gists{/gist_id}","starred_url":"https://api.github.com/users/link-foundation/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/link-foundation/subscriptions","organizations_url":"https://api.github.com/users/link-foundation/orgs","repos_url":"https://api.github.com/users/link-foundation/repos","events_url":"https://api.github.com/users/link-foundation/events{/privacy}","received_events_url":"https://api.github.com/users/link-foundation/received_events","type":"Organization","user_view_type":"public","site_admin":false},"html_url":"https://github.com/link-foundation/command-stream","description":"$treamable commands executor","fork":false,"url":"https://api.github.com/repos/link-foundation/command-stream","forks_url":"https://api.github.com/repos/link-foundation/command-stream/forks","keys_url":"https://api.github.com/repos/link-foundation/command-stream/keys{/key_id}","collaborators_url":"https://api.github.com/repos/link-foundation/command-stream/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/link-foundation/command-stream/teams","hooks_url":"https://api.github.com/repos/link-foundation/command-stream/hooks","issue_events_url":"https://api.github.com/repos/link-foundation/command-stream/issues/events{/number}","events_url":"https://api.github.com/repos/link-foundation/command-stream/events","assignees_url":"https://api.github.com/repos/link-foundation/command-stream/assignees{/user}","branches_url":"https://api.github.com/repos/link-foundation/command-stream/branches{/branch}","tags_url":"https://api.github.com/repos/link-foundation/command-stream/tags","blobs_url":"https://api.github.com/repos/link-foundation/command-stream/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/link-foundation/command-stream/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/link-foundation/command-stream/git/refs{/sha}","trees_url":"https://api.github.com/repos/link-foundation/command-stream/git/trees{/sha}","statuses_url":"https://api.github.com/repos/link-foundation/command-stream/statuses/{sha}","languages_url":"https://api.github.com/repos/link-foundation/command-stream/languages","stargazers_url":"https://api.github.com/repos/link-foundation/command-stream/stargazers","contributors_url":"https://api.github.com/repos/link-foundation/command-stream/contributors","subscribers_url":"https://api.github.com/repos/link-foundation/command-stream/subscribers","subscription_url":"https://api.github.com/repos/link-foundation/command-stream/subscription","commits_url":"https://api.github.com/repos/link-foundation/command-stream/commits{/sha}","git_commits_url":"https://api.github.com/repos/link-foundation/command-stream/git/commits{/sha}","comments_url":"https://api.github.com/repos/link-foundation/command-stream/comments{/number}","issue_comment_url":"https://api.github.com/repos/link-foundation/command-stream/issues/comments{/number}","contents_url":"https://api.github.com/repos/link-foundation/command-stream/contents/{+path}","compare_url":"https://api.github.com/repos/link-foundation/command-stream/compare/{base}...{head}","merges_url":"https://api.github.com/repos/link-foundation/command-stream/merges","archive_url":"https://api.github.com/repos/link-foundation/command-stream/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/link-foundation/command-stream/downloads","issues_url":"https://api.github.com/repos/link-foundation/command-stream/issues{/number}","pulls_url":"https://api.github.com/repos/link-foundation/command-stream/pulls{/number}","milestones_url":"https://api.github.com/repos/link-foundation/command-stream/milestones{/number}","notifications_url":"https://api.github.com/repos/link-foundation/command-stream/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/link-foundation/command-stream/labels{/name}","releases_url":"https://api.github.com/repos/link-foundation/command-stream/releases{/id}","deployments_url":"https://api.github.com/repos/link-foundation/command-stream/deployments","created_at":"2025-08-12T22:30:25Z","updated_at":"2026-06-08T20:23:36Z","pushed_at":"2026-06-08T20:23:39Z","git_url":"git://github.com/link-foundation/command-stream.git","ssh_url":"git@github.com:link-foundation/command-stream.git","clone_url":"https://github.com/link-foundation/command-stream.git","svn_url":"https://github.com/link-foundation/command-stream","homepage":null,"size":10069,"stargazers_count":4,"watchers_count":4,"language":"JavaScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"has_discussions":false,"forks_count":1,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":75,"license":{"key":"unlicense","name":"The Unlicense","spdx_id":"Unlicense","url":"https://api.github.com/licenses/unlicense","node_id":"MDc6TGljZW5zZTE1"},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"has_pull_requests":true,"pull_request_creation_policy":"all","topics":[],"visibility":"public","forks":1,"open_issues":75,"watchers":4,"default_branch":"main"}},"base":{"label":"link-foundation:main","ref":"main","sha":"c84031dec59ab29d7199c0685c980d7e10532bc7","user":{"login":"link-foundation","id":176174013,"node_id":"O_kgDOCoAzvQ","avatar_url":"https://avatars.githubusercontent.com/u/176174013?v=4","gravatar_id":"","url":"https://api.github.com/users/link-foundation","html_url":"https://github.com/link-foundation","followers_url":"https://api.github.com/users/link-foundation/followers","following_url":"https://api.github.com/users/link-foundation/following{/other_user}","gists_url":"https://api.github.com/users/link-foundation/gists{/gist_id}","starred_url":"https://api.github.com/users/link-foundation/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/link-foundation/subscriptions","organizations_url":"https://api.github.com/users/link-foundation/orgs","repos_url":"https://api.github.com/users/link-foundation/repos","events_url":"https://api.github.com/users/link-foundation/events{/privacy}","received_events_url":"https://api.github.com/users/link-foundation/received_events","type":"Organization","user_view_type":"public","site_admin":false},"repo":{"id":1036989446,"node_id":"R_kgDOPc80Bg","name":"command-stream","full_name":"link-foundation/command-stream","private":false,"owner":{"login":"link-foundation","id":176174013,"node_id":"O_kgDOCoAzvQ","avatar_url":"https://avatars.githubusercontent.com/u/176174013?v=4","gravatar_id":"","url":"https://api.github.com/users/link-foundation","html_url":"https://github.com/link-foundation","followers_url":"https://api.github.com/users/link-foundation/followers","following_url":"https://api.github.com/users/link-foundation/following{/other_user}","gists_url":"https://api.github.com/users/link-foundation/gists{/gist_id}","starred_url":"https://api.github.com/users/link-foundation/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/link-foundation/subscriptions","organizations_url":"https://api.github.com/users/link-foundation/orgs","repos_url":"https://api.github.com/users/link-foundation/repos","events_url":"https://api.github.com/users/link-foundation/events{/privacy}","received_events_url":"https://api.github.com/users/link-foundation/received_events","type":"Organization","user_view_type":"public","site_admin":false},"html_url":"https://github.com/link-foundation/command-stream","description":"$treamable commands executor","fork":false,"url":"https://api.github.com/repos/link-foundation/command-stream","forks_url":"https://api.github.com/repos/link-foundation/command-stream/forks","keys_url":"https://api.github.com/repos/link-foundation/command-stream/keys{/key_id}","collaborators_url":"https://api.github.com/repos/link-foundation/command-stream/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/link-foundation/command-stream/teams","hooks_url":"https://api.github.com/repos/link-foundation/command-stream/hooks","issue_events_url":"https://api.github.com/repos/link-foundation/command-stream/issues/events{/number}","events_url":"https://api.github.com/repos/link-foundation/command-stream/events","assignees_url":"https://api.github.com/repos/link-foundation/command-stream/assignees{/user}","branches_url":"https://api.github.com/repos/link-foundation/command-stream/branches{/branch}","tags_url":"https://api.github.com/repos/link-foundation/command-stream/tags","blobs_url":"https://api.github.com/repos/link-foundation/command-stream/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/link-foundation/command-stream/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/link-foundation/command-stream/git/refs{/sha}","trees_url":"https://api.github.com/repos/link-foundation/command-stream/git/trees{/sha}","statuses_url":"https://api.github.com/repos/link-foundation/command-stream/statuses/{sha}","languages_url":"https://api.github.com/repos/link-foundation/command-stream/languages","stargazers_url":"https://api.github.com/repos/link-foundation/command-stream/stargazers","contributors_url":"https://api.github.com/repos/link-foundation/command-stream/contributors","subscribers_url":"https://api.github.com/repos/link-foundation/command-stream/subscribers","subscription_url":"https://api.github.com/repos/link-foundation/command-stream/subscription","commits_url":"https://api.github.com/repos/link-foundation/command-stream/commits{/sha}","git_commits_url":"https://api.github.com/repos/link-foundation/command-stream/git/commits{/sha}","comments_url":"https://api.github.com/repos/link-foundation/command-stream/comments{/number}","issue_comment_url":"https://api.github.com/repos/link-foundation/command-stream/issues/comments{/number}","contents_url":"https://api.github.com/repos/link-foundation/command-stream/contents/{+path}","compare_url":"https://api.github.com/repos/link-foundation/command-stream/compare/{base}...{head}","merges_url":"https://api.github.com/repos/link-foundation/command-stream/merges","archive_url":"https://api.github.com/repos/link-foundation/command-stream/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/link-foundation/command-stream/downloads","issues_url":"https://api.github.com/repos/link-foundation/command-stream/issues{/number}","pulls_url":"https://api.github.com/repos/link-foundation/command-stream/pulls{/number}","milestones_url":"https://api.github.com/repos/link-foundation/command-stream/milestones{/number}","notifications_url":"https://api.github.com/repos/link-foundation/command-stream/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/link-foundation/command-stream/labels{/name}","releases_url":"https://api.github.com/repos/link-foundation/command-stream/releases{/id}","deployments_url":"https://api.github.com/repos/link-foundation/command-stream/deployments","created_at":"2025-08-12T22:30:25Z","updated_at":"2026-06-08T20:23:36Z","pushed_at":"2026-06-08T20:23:39Z","git_url":"git://github.com/link-foundation/command-stream.git","ssh_url":"git@github.com:link-foundation/command-stream.git","clone_url":"https://github.com/link-foundation/command-stream.git","svn_url":"https://github.com/link-foundation/command-stream","homepage":null,"size":10069,"stargazers_count":4,"watchers_count":4,"language":"JavaScript","has_issues":true,"has_projects":true,"has_downloads":true,"has_wiki":true,"has_pages":false,"has_discussions":false,"forks_count":1,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":75,"license":{"key":"unlicense","name":"The Unlicense","spdx_id":"Unlicense","url":"https://api.github.com/licenses/unlicense","node_id":"MDc6TGljZW5zZTE1"},"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"has_pull_requests":true,"pull_request_creation_policy":"all","topics":[],"visibility":"public","forks":1,"open_issues":75,"watchers":4,"default_branch":"main"}},"_links":{"self":{"href":"https://api.github.com/repos/link-foundation/command-stream/pulls/163"},"html":{"href":"https://github.com/link-foundation/command-stream/pull/163"},"issue":{"href":"https://api.github.com/repos/link-foundation/command-stream/issues/163"},"comments":{"href":"https://api.github.com/repos/link-foundation/command-stream/issues/163/comments"},"review_comments":{"href":"https://api.github.com/repos/link-foundation/command-stream/pulls/163/comments"},"review_comment":{"href":"https://api.github.com/repos/link-foundation/command-stream/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/link-foundation/command-stream/pulls/163/commits"},"statuses":{"href":"https://api.github.com/repos/link-foundation/command-stream/statuses/9d18ab35d9e2a5f279695e606d61ecb763e1950e"}},"author_association":"MEMBER","auto_merge":null,"assignee":{"login":"konard","id":1431904,"node_id":"MDQ6VXNlcjE0MzE5MDQ=","avatar_url":"https://avatars.githubusercontent.com/u/1431904?v=4","gravatar_id":"","url":"https://api.github.com/users/konard","html_url":"https://github.com/konard","followers_url":"https://api.github.com/users/konard/followers","following_url":"https://api.github.com/users/konard/following{/other_user}","gists_url":"https://api.github.com/users/konard/gists{/gist_id}","starred_url":"https://api.github.com/users/konard/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/konard/subscriptions","organizations_url":"https://api.github.com/users/konard/orgs","repos_url":"https://api.github.com/users/konard/repos","events_url":"https://api.github.com/users/konard/events{/privacy}","received_events_url":"https://api.github.com/users/konard/received_events","type":"User","user_view_type":"public","site_admin":false},"active_lock_reason":null}]✅ Found PR #163 containing commit
+2026-06-08T20:23:41.6530095Z {"url":"https://api.github.com/repos/link-foundation/command-stream/releases/336219532","assets_url":"https://api.github.com/repos/link-foundation/command-stream/releases/336219532/assets","upload_url":"https://uploads.github.com/repos/link-foundation/command-stream/releases/336219532/assets{?name,label}","html_url":"https://github.com/link-foundation/command-stream/releases/tag/js-v0.9.6","id":336219532,"author":{"login":"github-actions[bot]","id":41898282,"node_id":"MDM6Qm90NDE4OTgyODI=","avatar_url":"https://avatars.githubusercontent.com/in/15368?v=4","gravatar_id":"","url":"https://api.github.com/users/github-actions%5Bbot%5D","html_url":"https://github.com/apps/github-actions","followers_url":"https://api.github.com/users/github-actions%5Bbot%5D/followers","following_url":"https://api.github.com/users/github-actions%5Bbot%5D/following{/other_user}","gists_url":"https://api.github.com/users/github-actions%5Bbot%5D/gists{/gist_id}","starred_url":"https://api.github.com/users/github-actions%5Bbot%5D/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/github-actions%5Bbot%5D/subscriptions","organizations_url":"https://api.github.com/users/github-actions%5Bbot%5D/orgs","repos_url":"https://api.github.com/users/github-actions%5Bbot%5D/repos","events_url":"https://api.github.com/users/github-actions%5Bbot%5D/events{/privacy}","received_events_url":"https://api.github.com/users/github-actions%5Bbot%5D/received_events","type":"Bot","user_view_type":"public","site_admin":false},"node_id":"RE_kwDOPc80Bs4UCk2M","tag_name":"js-v0.9.6","target_commitish":"main","name":"JavaScript 0.9.6","draft":false,"immutable":false,"prerelease":false,"created_at":"2026-06-08T20:23:31Z","updated_at":"2026-06-08T20:23:41Z","published_at":"2026-06-08T20:23:39Z","assets":[],"tarball_url":"https://api.github.com/repos/link-foundation/command-stream/tarball/js-v0.9.6","zipball_url":"https://api.github.com/repos/link-foundation/command-stream/zipball/js-v0.9.6","body":"Ensure the JavaScript release job still evaluates on main pushes after the\npull-request-only changeset gate is skipped.\n\nSeparate JavaScript package metadata, scripts, documentation, and release tags\nfrom the Rust crate release path.\n\n**Related Pull Request:** #163\n\n---\n\n[![npm version](https://img.shields.io/badge/npm-0.9.6-blue.svg)](https://www.npmjs.com/package/command-stream/v/0.9.6)"}✅ Formatted release notes for v0.9.6
+2026-06-08T20:23:41.6545383Z    - Added link to PR #163
+2026-06-08T20:23:41.6545866Z    - Added shields.io npm badge
+2026-06-08T20:23:41.6546318Z    - Cleaned up formatting
+2026-06-08T20:23:41.6580697Z Formatted JavaScript release notes for js-v0.9.6
+2026-06-08T20:23:41.6668268Z Post job cleanup.
+2026-06-08T20:23:41.8352807Z Post job cleanup.
+2026-06-08T20:23:42.0116184Z Post job cleanup.
+2026-06-08T20:23:42.1109502Z [command]/usr/bin/git version
+2026-06-08T20:23:42.1145043Z git version 2.54.0
+2026-06-08T20:23:42.1187427Z Temporarily overriding HOME='/home/runner/work/_temp/6f599d01-55aa-4994-b560-e767eca39335' before making global git config changes
+2026-06-08T20:23:42.1188593Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-08T20:23:42.1200736Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+2026-06-08T20:23:42.1235819Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-08T20:23:42.1268851Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-08T20:23:42.1509269Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-06-08T20:23:42.1533894Z http.https://github.com/.extraheader
+2026-06-08T20:23:42.1547248Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2026-06-08T20:23:42.1578085Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-06-08T20:23:42.1811288Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-06-08T20:23:42.1842702Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-06-08T20:23:42.2219802Z Cleaning up orphan processes
+2026-06-08T20:23:42.2509150Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/docs/case-studies/issue-164/ci-logs/release-rust-crate-step.log
+++ b/docs/case-studies/issue-164/ci-logs/release-rust-crate-step.log
@@ -1,0 +1,640 @@
+﻿2026-06-08T20:23:54.4405378Z Current runner version: '2.334.0'
+2026-06-08T20:23:54.4444536Z ##[group]Runner Image Provisioner
+2026-06-08T20:23:54.4446014Z Hosted Compute Agent
+2026-06-08T20:23:54.4447025Z Version: 20260520.533
+2026-06-08T20:23:54.4448290Z Commit: 189110e25284a9812c124fd27b339e2fb4f2f9db
+2026-06-08T20:23:54.4449706Z Build Date: 2026-05-20T17:44:04Z
+2026-06-08T20:23:54.4451083Z Worker ID: {7283fe08-cc80-4ca7-bc7b-382d71ea581e}
+2026-06-08T20:23:54.4452514Z Azure Region: northcentralus
+2026-06-08T20:23:54.4453566Z ##[endgroup]
+2026-06-08T20:23:54.4456373Z ##[group]Operating System
+2026-06-08T20:23:54.4457584Z Ubuntu
+2026-06-08T20:23:54.4458674Z 24.04.4
+2026-06-08T20:23:54.4459673Z LTS
+2026-06-08T20:23:54.4460608Z ##[endgroup]
+2026-06-08T20:23:54.4461701Z ##[group]Runner Image
+2026-06-08T20:23:54.4462866Z Image: ubuntu-24.04
+2026-06-08T20:23:54.4463970Z Version: 20260525.161.1
+2026-06-08T20:23:54.4466570Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260525.161/images/ubuntu/Ubuntu2404-Readme.md
+2026-06-08T20:23:54.4469586Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260525.161
+2026-06-08T20:23:54.4471423Z ##[endgroup]
+2026-06-08T20:23:54.4473489Z ##[group]GITHUB_TOKEN Permissions
+2026-06-08T20:23:54.4476852Z Contents: write
+2026-06-08T20:23:54.4478083Z Metadata: read
+2026-06-08T20:23:54.4479214Z ##[endgroup]
+2026-06-08T20:23:54.4482068Z Secret source: Actions
+2026-06-08T20:23:54.4483924Z Prepare workflow directory
+2026-06-08T20:23:54.5277375Z Prepare all required actions
+2026-06-08T20:23:54.5335035Z Getting action download info
+2026-06-08T20:23:54.9078990Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+2026-06-08T20:23:55.0301247Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+2026-06-08T20:23:55.3529121Z Complete job name: Release Rust crate
+2026-06-08T20:23:55.4306194Z ##[group]Run actions/checkout@v4
+2026-06-08T20:23:55.4307216Z with:
+2026-06-08T20:23:55.4307728Z   fetch-depth: 0
+2026-06-08T20:23:55.4308290Z   repository: link-foundation/command-stream
+2026-06-08T20:23:55.4313321Z   token: ***
+2026-06-08T20:23:55.4313815Z   ssh-strict: true
+2026-06-08T20:23:55.4314510Z   ssh-user: git
+2026-06-08T20:23:55.4315049Z   persist-credentials: true
+2026-06-08T20:23:55.4315608Z   clean: true
+2026-06-08T20:23:55.4316110Z   sparse-checkout-cone-mode: true
+2026-06-08T20:23:55.4316714Z   fetch-tags: false
+2026-06-08T20:23:55.4317226Z   show-progress: true
+2026-06-08T20:23:55.4317754Z   lfs: false
+2026-06-08T20:23:55.4318220Z   submodules: false
+2026-06-08T20:23:55.4318727Z   set-safe-directory: true
+2026-06-08T20:23:55.4319531Z env:
+2026-06-08T20:23:55.4320019Z   CARGO_TERM_COLOR: always
+2026-06-08T20:23:55.4320772Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:23:55.4321419Z   CARGO_TOKEN: ***
+2026-06-08T20:23:55.4321906Z ##[endgroup]
+2026-06-08T20:23:55.5503685Z Syncing repository: link-foundation/command-stream
+2026-06-08T20:23:55.5506465Z ##[group]Getting Git version info
+2026-06-08T20:23:55.5507443Z Working directory is '/home/runner/work/command-stream/command-stream'
+2026-06-08T20:23:55.5508671Z [command]/usr/bin/git version
+2026-06-08T20:23:55.5581680Z git version 2.54.0
+2026-06-08T20:23:55.5609902Z ##[endgroup]
+2026-06-08T20:23:55.5633825Z Temporarily overriding HOME='/home/runner/work/_temp/cc60aa35-9b34-4c61-92a7-d312abf037c9' before making global git config changes
+2026-06-08T20:23:55.5635796Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-08T20:23:55.5640524Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+2026-06-08T20:23:55.5689419Z Deleting the contents of '/home/runner/work/command-stream/command-stream'
+2026-06-08T20:23:55.5693252Z ##[group]Initializing the repository
+2026-06-08T20:23:55.5698191Z [command]/usr/bin/git init /home/runner/work/command-stream/command-stream
+2026-06-08T20:23:55.5796539Z hint: Using 'master' as the name for the initial branch. This default branch name
+2026-06-08T20:23:55.5798659Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+2026-06-08T20:23:55.5800589Z hint: to use in all of your new repositories, which will suppress this warning,
+2026-06-08T20:23:55.5802085Z hint: call:
+2026-06-08T20:23:55.5802797Z hint:
+2026-06-08T20:23:55.5803414Z hint: 	git config --global init.defaultBranch <name>
+2026-06-08T20:23:55.5804097Z hint:
+2026-06-08T20:23:55.5805283Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+2026-06-08T20:23:55.5806367Z hint: 'development'. The just-created branch can be renamed via this command:
+2026-06-08T20:23:55.5807183Z hint:
+2026-06-08T20:23:55.5807836Z hint: 	git branch -m <name>
+2026-06-08T20:23:55.5808715Z hint:
+2026-06-08T20:23:55.5809465Z hint: Disable this message with "git config set advice.defaultBranchName false"
+2026-06-08T20:23:55.5810755Z Initialized empty Git repository in /home/runner/work/command-stream/command-stream/.git/
+2026-06-08T20:23:55.5815378Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/command-stream
+2026-06-08T20:23:55.5860360Z ##[endgroup]
+2026-06-08T20:23:55.5861283Z ##[group]Disabling automatic garbage collection
+2026-06-08T20:23:55.5864957Z [command]/usr/bin/git config --local gc.auto 0
+2026-06-08T20:23:55.5896210Z ##[endgroup]
+2026-06-08T20:23:55.5897052Z ##[group]Setting up auth
+2026-06-08T20:23:55.5903349Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-08T20:23:55.5939833Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-08T20:23:55.6309412Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-06-08T20:23:55.6343427Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-06-08T20:23:55.6575125Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-06-08T20:23:55.6612821Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-06-08T20:23:55.6850400Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+2026-06-08T20:23:55.6887528Z ##[endgroup]
+2026-06-08T20:23:55.6889207Z ##[group]Fetching the repository
+2026-06-08T20:23:55.6898716Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+2026-06-08T20:23:57.5920811Z From https://github.com/link-foundation/command-stream
+2026-06-08T20:23:57.5922986Z  * [new branch]      issue-1-03052bff       -> origin/issue-1-03052bff
+2026-06-08T20:23:57.5923593Z  * [new branch]      issue-1-7de9505b       -> origin/issue-1-7de9505b
+2026-06-08T20:23:57.5924198Z  * [new branch]      issue-135-5b3a55f7db0e -> origin/issue-135-5b3a55f7db0e
+2026-06-08T20:23:57.5925562Z  * [new branch]      issue-136-c2c75f0016c4 -> origin/issue-136-c2c75f0016c4
+2026-06-08T20:23:57.5926592Z  * [new branch]      issue-139-34f447966ab4 -> origin/issue-139-34f447966ab4
+2026-06-08T20:23:57.5927419Z  * [new branch]      issue-14-427a6e27      -> origin/issue-14-427a6e27
+2026-06-08T20:23:57.5928010Z  * [new branch]      issue-14-47a807dc      -> origin/issue-14-47a807dc
+2026-06-08T20:23:57.5928569Z  * [new branch]      issue-141-392e7fb32761 -> origin/issue-141-392e7fb32761
+2026-06-08T20:23:57.5929150Z  * [new branch]      issue-142-d79c313dc0de -> origin/issue-142-d79c313dc0de
+2026-06-08T20:23:57.5929743Z  * [new branch]      issue-144-4375266b4889 -> origin/issue-144-4375266b4889
+2026-06-08T20:23:57.5930351Z  * [new branch]      issue-146-f111406088b3 -> origin/issue-146-f111406088b3
+2026-06-08T20:23:57.5930908Z  * [new branch]      issue-149-feab21d6ff91 -> origin/issue-149-feab21d6ff91
+2026-06-08T20:23:57.5931828Z  * [new branch]      issue-15-9fc0cb72      -> origin/issue-15-9fc0cb72
+2026-06-08T20:23:57.5932418Z  * [new branch]      issue-15-b280a47e      -> origin/issue-15-b280a47e
+2026-06-08T20:23:57.5933078Z  * [new branch]      issue-151-3da6bb3ea5e3 -> origin/issue-151-3da6bb3ea5e3
+2026-06-08T20:23:57.5933642Z  * [new branch]      issue-153-58c6ab4753ab -> origin/issue-153-58c6ab4753ab
+2026-06-08T20:23:57.5934195Z  * [new branch]      issue-156-eb63a328307e -> origin/issue-156-eb63a328307e
+2026-06-08T20:23:57.5935374Z  * [new branch]      issue-158-7e95ada294ce -> origin/issue-158-7e95ada294ce
+2026-06-08T20:23:57.5935972Z  * [new branch]      issue-160-a2a2313cf693 -> origin/issue-160-a2a2313cf693
+2026-06-08T20:23:57.5936527Z  * [new branch]      issue-162-0c186d5158ec -> origin/issue-162-0c186d5158ec
+2026-06-08T20:23:57.5937133Z  * [new branch]      issue-18-16ce2f52      -> origin/issue-18-16ce2f52
+2026-06-08T20:23:57.5937694Z  * [new branch]      issue-18-51ece309      -> origin/issue-18-51ece309
+2026-06-08T20:23:57.5938260Z  * [new branch]      issue-19-99f29373      -> origin/issue-19-99f29373
+2026-06-08T20:23:57.5938814Z  * [new branch]      issue-19-ee86110f      -> origin/issue-19-ee86110f
+2026-06-08T20:23:57.5939361Z  * [new branch]      issue-20-12ad6602      -> origin/issue-20-12ad6602
+2026-06-08T20:23:57.5939920Z  * [new branch]      issue-20-171029a1      -> origin/issue-20-171029a1
+2026-06-08T20:23:57.5940518Z  * [new branch]      issue-21-4d44bbc7      -> origin/issue-21-4d44bbc7
+2026-06-08T20:23:57.5941094Z  * [new branch]      issue-21-621d3004      -> origin/issue-21-621d3004
+2026-06-08T20:23:57.5941745Z  * [new branch]      issue-22-51ab60ad      -> origin/issue-22-51ab60ad
+2026-06-08T20:23:57.5942649Z  * [new branch]      issue-22-57b75318      -> origin/issue-22-57b75318
+2026-06-08T20:23:57.5943419Z  * [new branch]      issue-23-acb80d89      -> origin/issue-23-acb80d89
+2026-06-08T20:23:57.5944051Z  * [new branch]      issue-23-cfe40154      -> origin/issue-23-cfe40154
+2026-06-08T20:23:57.5945059Z  * [new branch]      issue-24-0a217d8d      -> origin/issue-24-0a217d8d
+2026-06-08T20:23:57.5945636Z  * [new branch]      issue-24-2ec0e8fa      -> origin/issue-24-2ec0e8fa
+2026-06-08T20:23:57.5946189Z  * [new branch]      issue-25-8431dd64      -> origin/issue-25-8431dd64
+2026-06-08T20:23:57.5946730Z  * [new branch]      issue-25-8ff13a2c      -> origin/issue-25-8ff13a2c
+2026-06-08T20:23:57.5947284Z  * [new branch]      issue-26-2cc88ea0      -> origin/issue-26-2cc88ea0
+2026-06-08T20:23:57.5947832Z  * [new branch]      issue-26-9bec6ea5      -> origin/issue-26-9bec6ea5
+2026-06-08T20:23:57.5948386Z  * [new branch]      issue-27-01ac7c56      -> origin/issue-27-01ac7c56
+2026-06-08T20:23:57.5948930Z  * [new branch]      issue-27-1d58c6b2      -> origin/issue-27-1d58c6b2
+2026-06-08T20:23:57.5949490Z  * [new branch]      issue-28-1c9c13c6      -> origin/issue-28-1c9c13c6
+2026-06-08T20:23:57.5950039Z  * [new branch]      issue-28-e256afcb      -> origin/issue-28-e256afcb
+2026-06-08T20:23:57.5950591Z  * [new branch]      issue-29-55357638      -> origin/issue-29-55357638
+2026-06-08T20:23:57.5951116Z  * [new branch]      issue-29-987b8dd4      -> origin/issue-29-987b8dd4
+2026-06-08T20:23:57.5951640Z  * [new branch]      issue-30-a0052265      -> origin/issue-30-a0052265
+2026-06-08T20:23:57.5952170Z  * [new branch]      issue-30-f1b7d27d      -> origin/issue-30-f1b7d27d
+2026-06-08T20:23:57.5952701Z  * [new branch]      issue-31-bfcb9a80      -> origin/issue-31-bfcb9a80
+2026-06-08T20:23:57.5953231Z  * [new branch]      issue-31-dc3e9249      -> origin/issue-31-dc3e9249
+2026-06-08T20:23:57.5953771Z  * [new branch]      issue-32-3dccbfab      -> origin/issue-32-3dccbfab
+2026-06-08T20:23:57.5954543Z  * [new branch]      issue-32-7a506d69      -> origin/issue-32-7a506d69
+2026-06-08T20:23:57.5955286Z  * [new branch]      issue-34-389ba67e      -> origin/issue-34-389ba67e
+2026-06-08T20:23:57.5955832Z  * [new branch]      issue-34-7cfa0880      -> origin/issue-34-7cfa0880
+2026-06-08T20:23:57.5956577Z  * [new branch]      issue-36-042fe722      -> origin/issue-36-042fe722
+2026-06-08T20:23:57.5957109Z  * [new branch]      issue-36-52b7c0a5      -> origin/issue-36-52b7c0a5
+2026-06-08T20:23:57.5957632Z  * [new branch]      issue-37-20720488      -> origin/issue-37-20720488
+2026-06-08T20:23:57.5958164Z  * [new branch]      issue-37-e875842b      -> origin/issue-37-e875842b
+2026-06-08T20:23:57.5958696Z  * [new branch]      issue-38-8ff5f784      -> origin/issue-38-8ff5f784
+2026-06-08T20:23:57.5959251Z  * [new branch]      issue-38-d399116a      -> origin/issue-38-d399116a
+2026-06-08T20:23:57.5959821Z  * [new branch]      issue-39-607bfb8e      -> origin/issue-39-607bfb8e
+2026-06-08T20:23:57.5960380Z  * [new branch]      issue-39-b4116e88      -> origin/issue-39-b4116e88
+2026-06-08T20:23:57.5960952Z  * [new branch]      issue-4-9c65943d       -> origin/issue-4-9c65943d
+2026-06-08T20:23:57.5961518Z  * [new branch]      issue-4-e24f5412       -> origin/issue-4-e24f5412
+2026-06-08T20:23:57.5962097Z  * [new branch]      issue-40-b1e760e6      -> origin/issue-40-b1e760e6
+2026-06-08T20:23:57.5962671Z  * [new branch]      issue-40-ef18d92c      -> origin/issue-40-ef18d92c
+2026-06-08T20:23:57.5963300Z  * [new branch]      issue-41-49cfed34      -> origin/issue-41-49cfed34
+2026-06-08T20:23:57.5963937Z  * [new branch]      issue-41-fed22157      -> origin/issue-41-fed22157
+2026-06-08T20:23:57.5964900Z  * [new branch]      issue-42-77ee242c      -> origin/issue-42-77ee242c
+2026-06-08T20:23:57.5965511Z  * [new branch]      issue-42-908eb7f7      -> origin/issue-42-908eb7f7
+2026-06-08T20:23:57.5966086Z  * [new branch]      issue-43-7298cd5c      -> origin/issue-43-7298cd5c
+2026-06-08T20:23:57.5966649Z  * [new branch]      issue-43-85b3ddfd      -> origin/issue-43-85b3ddfd
+2026-06-08T20:23:57.5967221Z  * [new branch]      issue-43-af132027      -> origin/issue-43-af132027
+2026-06-08T20:23:57.5968013Z  * [new branch]      issue-44-75df50dd      -> origin/issue-44-75df50dd
+2026-06-08T20:23:57.5968626Z  * [new branch]      issue-44-796ff0a8      -> origin/issue-44-796ff0a8
+2026-06-08T20:23:57.5969203Z  * [new branch]      issue-45-0325c0f5      -> origin/issue-45-0325c0f5
+2026-06-08T20:23:57.5969915Z  * [new branch]      issue-45-1ed9a563      -> origin/issue-45-1ed9a563
+2026-06-08T20:23:57.5970510Z  * [new branch]      issue-45-ce5f1e15      -> origin/issue-45-ce5f1e15
+2026-06-08T20:23:57.5971087Z  * [new branch]      issue-46-52edd2db      -> origin/issue-46-52edd2db
+2026-06-08T20:23:57.5971663Z  * [new branch]      issue-46-d4eec70e      -> origin/issue-46-d4eec70e
+2026-06-08T20:23:57.5972230Z  * [new branch]      issue-46-f237aa54      -> origin/issue-46-f237aa54
+2026-06-08T20:23:57.5972823Z  * [new branch]      issue-47-7a71c96e      -> origin/issue-47-7a71c96e
+2026-06-08T20:23:57.5973394Z  * [new branch]      issue-47-b31e0547      -> origin/issue-47-b31e0547
+2026-06-08T20:23:57.5973989Z  * [new branch]      issue-47-e7830e99      -> origin/issue-47-e7830e99
+2026-06-08T20:23:57.5975007Z  * [new branch]      issue-48-aaa5df6f      -> origin/issue-48-aaa5df6f
+2026-06-08T20:23:57.5975649Z  * [new branch]      issue-48-ad9abe01      -> origin/issue-48-ad9abe01
+2026-06-08T20:23:57.5976242Z  * [new branch]      issue-48-ead273fb      -> origin/issue-48-ead273fb
+2026-06-08T20:23:57.5976826Z  * [new branch]      issue-49-08e57741      -> origin/issue-49-08e57741
+2026-06-08T20:23:57.5977392Z  * [new branch]      issue-49-54f19e82      -> origin/issue-49-54f19e82
+2026-06-08T20:23:57.5977948Z  * [new branch]      issue-49-e74051ab      -> origin/issue-49-e74051ab
+2026-06-08T20:23:57.5978504Z  * [new branch]      issue-50-02f42ae4      -> origin/issue-50-02f42ae4
+2026-06-08T20:23:57.5979068Z  * [new branch]      issue-50-0b915412      -> origin/issue-50-0b915412
+2026-06-08T20:23:57.5979627Z  * [new branch]      issue-50-5de8b754      -> origin/issue-50-5de8b754
+2026-06-08T20:23:57.5980211Z  * [new branch]      issue-6-156225d2       -> origin/issue-6-156225d2
+2026-06-08T20:23:57.5980792Z  * [new branch]      issue-6-52fa1fa4       -> origin/issue-6-52fa1fa4
+2026-06-08T20:23:57.5981563Z  * [new branch]      issue-9-55d6d25e       -> origin/issue-9-55d6d25e
+2026-06-08T20:23:57.5982135Z  * [new branch]      issue-9-c5ab4ea2       -> origin/issue-9-c5ab4ea2
+2026-06-08T20:23:57.5982705Z  * [new branch]      issue-96-a24e1d66      -> origin/issue-96-a24e1d66
+2026-06-08T20:23:57.5983291Z  * [new branch]      issue-96-eb9bb8d1      -> origin/issue-96-eb9bb8d1
+2026-06-08T20:23:57.5983822Z  * [new branch]      main                   -> origin/main
+2026-06-08T20:23:57.5984782Z  * [new tag]         js-v0.9.6              -> js-v0.9.6
+2026-06-08T20:23:57.5985353Z  * [new tag]         v0.0.1                 -> v0.0.1
+2026-06-08T20:23:57.5985808Z  * [new tag]         v0.0.2                 -> v0.0.2
+2026-06-08T20:23:57.5986274Z  * [new tag]         v0.0.3                 -> v0.0.3
+2026-06-08T20:23:57.5986781Z  * [new tag]         v0.0.4                 -> v0.0.4
+2026-06-08T20:23:57.6057484Z  * [new tag]         v0.0.5                 -> v0.0.5
+2026-06-08T20:23:57.6058190Z  * [new tag]         v0.1.0                 -> v0.1.0
+2026-06-08T20:23:57.6058698Z  * [new tag]         v0.2.0                 -> v0.2.0
+2026-06-08T20:23:57.6059182Z  * [new tag]         v0.3.0                 -> v0.3.0
+2026-06-08T20:23:57.6059637Z  * [new tag]         v0.3.1                 -> v0.3.1
+2026-06-08T20:23:57.6060082Z  * [new tag]         v0.3.2                 -> v0.3.2
+2026-06-08T20:23:57.6060545Z  * [new tag]         v0.4.0                 -> v0.4.0
+2026-06-08T20:23:57.6060998Z  * [new tag]         v0.5.0                 -> v0.5.0
+2026-06-08T20:23:57.6061439Z  * [new tag]         v0.6.0                 -> v0.6.0
+2026-06-08T20:23:57.6061870Z  * [new tag]         v0.7.0                 -> v0.7.0
+2026-06-08T20:23:57.6062297Z  * [new tag]         v0.7.1                 -> v0.7.1
+2026-06-08T20:23:57.6063013Z  * [new tag]         v0.8.0                 -> v0.8.0
+2026-06-08T20:23:57.6063487Z  * [new tag]         v0.8.1                 -> v0.8.1
+2026-06-08T20:23:57.6063929Z  * [new tag]         v0.8.2                 -> v0.8.2
+2026-06-08T20:23:57.6064683Z  * [new tag]         v0.8.3                 -> v0.8.3
+2026-06-08T20:23:57.6065139Z  * [new tag]         v0.9.0                 -> v0.9.0
+2026-06-08T20:23:57.6065566Z  * [new tag]         v0.9.1                 -> v0.9.1
+2026-06-08T20:23:57.6065992Z  * [new tag]         v0.9.2                 -> v0.9.2
+2026-06-08T20:23:57.6066436Z  * [new tag]         v0.9.4                 -> v0.9.4
+2026-06-08T20:23:57.6066875Z  * [new tag]         v0.9.5                 -> v0.9.5
+2026-06-08T20:23:57.6131227Z [command]/usr/bin/git branch --list --remote origin/main
+2026-06-08T20:23:57.6161130Z   origin/main
+2026-06-08T20:23:57.6170334Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+2026-06-08T20:23:57.6193288Z 971eab54771ce20ecc02038a1c9ec6cd378eee0a
+2026-06-08T20:23:57.6203867Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules origin +89d47cf62671f8e1c4813af51128b0b9e47b6fa6:refs/remotes/origin/main
+2026-06-08T20:23:57.6260440Z From https://github.com/link-foundation/command-stream
+2026-06-08T20:23:57.6261736Z  + 971eab5...89d47cf 89d47cf62671f8e1c4813af51128b0b9e47b6fa6 -> origin/main  (forced update)
+2026-06-08T20:23:57.6286416Z ##[endgroup]
+2026-06-08T20:23:57.6287325Z ##[group]Determining the checkout info
+2026-06-08T20:23:57.6288038Z ##[endgroup]
+2026-06-08T20:23:57.6293231Z [command]/usr/bin/git sparse-checkout disable
+2026-06-08T20:23:57.6336449Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+2026-06-08T20:23:57.6362591Z ##[group]Checking out the ref
+2026-06-08T20:23:57.6366532Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+2026-06-08T20:23:57.7133102Z Switched to a new branch 'main'
+2026-06-08T20:23:57.7136346Z branch 'main' set up to track 'origin/main'.
+2026-06-08T20:23:57.7147763Z ##[endgroup]
+2026-06-08T20:23:57.7195467Z [command]/usr/bin/git log -1 --format=%H
+2026-06-08T20:23:57.7220494Z 89d47cf62671f8e1c4813af51128b0b9e47b6fa6
+2026-06-08T20:23:57.7560833Z ##[group]Run dtolnay/rust-toolchain@stable
+2026-06-08T20:23:57.7561316Z with:
+2026-06-08T20:23:57.7561630Z   toolchain: stable
+2026-06-08T20:23:57.7561956Z env:
+2026-06-08T20:23:57.7562268Z   CARGO_TERM_COLOR: always
+2026-06-08T20:23:57.7563014Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:23:57.7563461Z   CARGO_TOKEN: ***
+2026-06-08T20:23:57.7563786Z ##[endgroup]
+2026-06-08T20:23:57.7696177Z ##[group]Run : parse toolchain version
+2026-06-08T20:23:57.7696717Z ^[[36;1m: parse toolchain version^[[0m
+2026-06-08T20:23:57.7697144Z ^[[36;1mif [[ -z $toolchain ]]; then^[[0m
+2026-06-08T20:23:57.7697851Z ^[[36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070^[[0m
+2026-06-08T20:23:57.7698587Z ^[[36;1m  echo "'toolchain' is a required input" >&2^[[0m
+2026-06-08T20:23:57.7699025Z ^[[36;1m  exit 1^[[0m
+2026-06-08T20:23:57.7699505Z ^[[36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then^[[0m
+2026-06-08T20:23:57.7700144Z ^[[36;1m  if [[ Linux == macOS ]]; then^[[0m
+2026-06-08T20:23:57.7700827Z ^[[36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+2026-06-08T20:23:57.7701486Z ^[[36;1m  else^[[0m
+2026-06-08T20:23:57.7702033Z ^[[36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+2026-06-08T20:23:57.7702657Z ^[[36;1m  fi^[[0m
+2026-06-08T20:23:57.7703119Z ^[[36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then^[[0m
+2026-06-08T20:23:57.7703827Z ^[[36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT^[[0m
+2026-06-08T20:23:57.7704638Z ^[[36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then^[[0m
+2026-06-08T20:23:57.7705335Z ^[[36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT^[[0m
+2026-06-08T20:23:57.7705981Z ^[[36;1melse^[[0m
+2026-06-08T20:23:57.7706374Z ^[[36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT^[[0m
+2026-06-08T20:23:57.7706805Z ^[[36;1mfi^[[0m
+2026-06-08T20:23:57.7739409Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:23:57.7739912Z env:
+2026-06-08T20:23:57.7740232Z   CARGO_TERM_COLOR: always
+2026-06-08T20:23:57.7740856Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:23:57.7741330Z   CARGO_TOKEN: ***
+2026-06-08T20:23:57.7741673Z   toolchain: stable
+2026-06-08T20:23:57.7741998Z ##[endgroup]
+2026-06-08T20:23:57.7896031Z ##[group]Run : construct rustup command line
+2026-06-08T20:23:57.7896551Z ^[[36;1m: construct rustup command line^[[0m
+2026-06-08T20:23:57.7897182Z ^[[36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT^[[0m
+2026-06-08T20:23:57.7898011Z ^[[36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT^[[0m
+2026-06-08T20:23:57.7898681Z ^[[36;1mecho "downgrade=" >> $GITHUB_OUTPUT^[[0m
+2026-06-08T20:23:57.7927583Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:23:57.7928085Z env:
+2026-06-08T20:23:57.7928408Z   CARGO_TERM_COLOR: always
+2026-06-08T20:23:57.7929022Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:23:57.7929516Z   CARGO_TOKEN: ***
+2026-06-08T20:23:57.7929849Z   targets: 
+2026-06-08T20:23:57.7930147Z   components: 
+2026-06-08T20:23:57.7930458Z ##[endgroup]
+2026-06-08T20:23:57.8026329Z ##[group]Run : set $CARGO_HOME
+2026-06-08T20:23:57.8026749Z ^[[36;1m: set $CARGO_HOME^[[0m
+2026-06-08T20:23:57.8027213Z ^[[36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV^[[0m
+2026-06-08T20:23:57.8055250Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:23:57.8055726Z env:
+2026-06-08T20:23:57.8056033Z   CARGO_TERM_COLOR: always
+2026-06-08T20:23:57.8056593Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:23:57.8057024Z   CARGO_TOKEN: ***
+2026-06-08T20:23:57.8057340Z ##[endgroup]
+2026-06-08T20:23:57.8148148Z ##[group]Run : install rustup if needed
+2026-06-08T20:23:57.8148945Z ^[[36;1m: install rustup if needed^[[0m
+2026-06-08T20:23:57.8149400Z ^[[36;1mif ! command -v rustup &>/dev/null; then^[[0m
+2026-06-08T20:23:57.8150346Z ^[[36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y^[[0m
+2026-06-08T20:23:57.8151273Z ^[[36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH^[[0m
+2026-06-08T20:23:57.8151676Z ^[[36;1mfi^[[0m
+2026-06-08T20:23:57.8178002Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:23:57.8178470Z env:
+2026-06-08T20:23:57.8178786Z   CARGO_TERM_COLOR: always
+2026-06-08T20:23:57.8179343Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:23:57.8179786Z   CARGO_TOKEN: ***
+2026-06-08T20:23:57.8180127Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:23:57.8180494Z ##[endgroup]
+2026-06-08T20:23:57.8272036Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+2026-06-08T20:23:57.8272805Z ^[[36;1mrustup toolchain install stable --profile minimal --no-self-update^[[0m
+2026-06-08T20:23:57.8301187Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:23:57.8301663Z env:
+2026-06-08T20:23:57.8301978Z   CARGO_TERM_COLOR: always
+2026-06-08T20:23:57.8302548Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:23:57.8302977Z   CARGO_TOKEN: ***
+2026-06-08T20:23:57.8303318Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:23:57.8303710Z   RUSTUP_PERMIT_COPY_RENAME: 1
+2026-06-08T20:23:57.8304073Z ##[endgroup]
+2026-06-08T20:23:57.9947657Z info: syncing channel updates for stable-x86_64-unknown-linux-gnu
+2026-06-08T20:23:58.1505991Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+2026-06-08T20:23:58.1650327Z info: removing previous version of component clippy
+2026-06-08T20:23:58.1667794Z info: removing previous version of component rustfmt
+2026-06-08T20:23:58.1679150Z info: removing previous version of component cargo
+2026-06-08T20:23:58.1726692Z info: removing previous version of component rust-std
+2026-06-08T20:23:58.1775184Z info: removing previous version of component rustc
+2026-06-08T20:23:58.1827801Z info: downloading 5 components
+2026-06-08T20:24:06.5670205Z 
+2026-06-08T20:24:06.5743878Z   stable-x86_64-unknown-linux-gnu updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.95.0 (59807616e 2026-04-14))
+2026-06-08T20:24:06.5744889Z 
+2026-06-08T20:24:06.5831403Z ##[group]Run rustup default stable
+2026-06-08T20:24:06.5831718Z ^[[36;1mrustup default stable^[[0m
+2026-06-08T20:24:06.5858575Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:24:06.5858935Z env:
+2026-06-08T20:24:06.5859192Z   CARGO_TERM_COLOR: always
+2026-06-08T20:24:06.5859806Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:24:06.5860133Z   CARGO_TOKEN: ***
+2026-06-08T20:24:06.5860358Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:24:06.5860615Z ##[endgroup]
+2026-06-08T20:24:06.5962165Z info: using existing install for stable-x86_64-unknown-linux-gnu
+2026-06-08T20:24:06.5969908Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+2026-06-08T20:24:06.5970254Z 
+2026-06-08T20:24:06.6038960Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-08T20:24:06.6039343Z 
+2026-06-08T20:24:06.6096849Z ##[group]Run : create cachekey
+2026-06-08T20:24:06.6097147Z ^[[36;1m: create cachekey^[[0m
+2026-06-08T20:24:06.6097662Z ^[[36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')^[[0m
+2026-06-08T20:24:06.6098324Z ^[[36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')^[[0m
+2026-06-08T20:24:06.6098839Z ^[[36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT^[[0m
+2026-06-08T20:24:06.6124204Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:24:06.6124860Z env:
+2026-06-08T20:24:06.6125066Z   CARGO_TERM_COLOR: always
+2026-06-08T20:24:06.6125497Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:24:06.6125810Z   CARGO_TOKEN: ***
+2026-06-08T20:24:06.6126031Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:24:06.6126613Z ##[endgroup]
+2026-06-08T20:24:06.6483625Z ##[group]Run : disable incremental compilation
+2026-06-08T20:24:06.6484007Z ^[[36;1m: disable incremental compilation^[[0m
+2026-06-08T20:24:06.6484688Z ^[[36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then^[[0m
+2026-06-08T20:24:06.6485058Z ^[[36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV^[[0m
+2026-06-08T20:24:06.6485351Z ^[[36;1mfi^[[0m
+2026-06-08T20:24:06.6511192Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:24:06.6511536Z env:
+2026-06-08T20:24:06.6511734Z   CARGO_TERM_COLOR: always
+2026-06-08T20:24:06.6512143Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:24:06.6512461Z   CARGO_TOKEN: ***
+2026-06-08T20:24:06.6512688Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:24:06.6512940Z ##[endgroup]
+2026-06-08T20:24:06.6581171Z ##[group]Run : enable colors in Cargo output
+2026-06-08T20:24:06.6581520Z ^[[36;1m: enable colors in Cargo output^[[0m
+2026-06-08T20:24:06.6581851Z ^[[36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then^[[0m
+2026-06-08T20:24:06.6582225Z ^[[36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV^[[0m
+2026-06-08T20:24:06.6582526Z ^[[36;1mfi^[[0m
+2026-06-08T20:24:06.6606990Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:24:06.6607342Z env:
+2026-06-08T20:24:06.6607546Z   CARGO_TERM_COLOR: always
+2026-06-08T20:24:06.6607935Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:24:06.6608231Z   CARGO_TOKEN: ***
+2026-06-08T20:24:06.6608446Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:24:06.6608699Z   CARGO_INCREMENTAL: 0
+2026-06-08T20:24:06.6608915Z ##[endgroup]
+2026-06-08T20:24:06.6677936Z ##[group]Run : enable Cargo sparse registry
+2026-06-08T20:24:06.6678295Z ^[[36;1m: enable Cargo sparse registry^[[0m
+2026-06-08T20:24:06.6678670Z ^[[36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70^[[0m
+2026-06-08T20:24:06.6679389Z ^[[36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then^[[0m
+2026-06-08T20:24:06.6680190Z ^[[36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then^[[0m
+2026-06-08T20:24:06.6680773Z ^[[36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+2026-06-08T20:24:06.6681316Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV^[[0m
+2026-06-08T20:24:06.6681826Z ^[[36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then^[[0m
+2026-06-08T20:24:06.6682400Z ^[[36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+2026-06-08T20:24:06.6682920Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV^[[0m
+2026-06-08T20:24:06.6683277Z ^[[36;1m  fi^[[0m
+2026-06-08T20:24:06.6683477Z ^[[36;1mfi^[[0m
+2026-06-08T20:24:06.6708201Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:24:06.6708538Z env:
+2026-06-08T20:24:06.6708739Z   CARGO_TERM_COLOR: always
+2026-06-08T20:24:06.6709142Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:24:06.6709467Z   CARGO_TOKEN: ***
+2026-06-08T20:24:06.6709684Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:24:06.6709939Z   CARGO_INCREMENTAL: 0
+2026-06-08T20:24:06.6710157Z ##[endgroup]
+2026-06-08T20:24:06.7040756Z ##[group]Run : work around spurious network errors in curl 8.0
+2026-06-08T20:24:06.7041219Z ^[[36;1m: work around spurious network errors in curl 8.0^[[0m
+2026-06-08T20:24:06.7041827Z ^[[36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation^[[0m
+2026-06-08T20:24:06.7042446Z ^[[36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then^[[0m
+2026-06-08T20:24:06.7042919Z ^[[36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV^[[0m
+2026-06-08T20:24:06.7043236Z ^[[36;1mfi^[[0m
+2026-06-08T20:24:06.7068899Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:24:06.7069244Z env:
+2026-06-08T20:24:06.7069448Z   CARGO_TERM_COLOR: always
+2026-06-08T20:24:06.7069860Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:24:06.7070506Z   CARGO_TOKEN: ***
+2026-06-08T20:24:06.7070737Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:24:06.7071057Z   CARGO_INCREMENTAL: 0
+2026-06-08T20:24:06.7071277Z ##[endgroup]
+2026-06-08T20:24:06.7271145Z ##[group]Run rustc +stable --version --verbose
+2026-06-08T20:24:06.7271543Z ^[[36;1mrustc +stable --version --verbose^[[0m
+2026-06-08T20:24:06.7297404Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+2026-06-08T20:24:06.7297764Z env:
+2026-06-08T20:24:06.7297973Z   CARGO_TERM_COLOR: always
+2026-06-08T20:24:06.7298393Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:24:06.7298695Z   CARGO_TOKEN: ***
+2026-06-08T20:24:06.7298923Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:24:06.7299182Z   CARGO_INCREMENTAL: 0
+2026-06-08T20:24:06.7299399Z ##[endgroup]
+2026-06-08T20:24:06.7467155Z rustc 1.96.0 (ac68faa20 2026-05-25)
+2026-06-08T20:24:06.7467871Z binary: rustc
+2026-06-08T20:24:06.7468238Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+2026-06-08T20:24:06.7468676Z commit-date: 2026-05-25
+2026-06-08T20:24:06.7469284Z host: x86_64-unknown-linux-gnu
+2026-06-08T20:24:06.7469884Z release: 1.96.0
+2026-06-08T20:24:06.7470329Z LLVM version: 22.1.2
+2026-06-08T20:24:06.7538702Z ##[group]Run cargo install rust-script
+2026-06-08T20:24:06.7539071Z ^[[36;1mcargo install rust-script^[[0m
+2026-06-08T20:24:06.7565399Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:24:06.7565662Z env:
+2026-06-08T20:24:06.7565865Z   CARGO_TERM_COLOR: always
+2026-06-08T20:24:06.7566283Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:24:06.7566590Z   CARGO_TOKEN: ***
+2026-06-08T20:24:06.7566821Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:24:06.7567078Z   CARGO_INCREMENTAL: 0
+2026-06-08T20:24:06.7567297Z ##[endgroup]
+2026-06-08T20:24:06.7863996Z ^[[1m^[[92m    Updating^[[0m crates.io index
+2026-06-08T20:24:07.0103308Z ^[[1m^[[92m Downloading^[[0m crates ...
+2026-06-08T20:24:07.0422652Z ^[[1m^[[92m  Downloaded^[[0m rust-script v0.36.0
+2026-06-08T20:24:07.0610264Z ^[[1m^[[92m  Installing^[[0m rust-script v0.36.0
+2026-06-08T20:24:07.0766341Z ^[[1m^[[92m    Updating^[[0m crates.io index
+2026-06-08T20:24:07.2845353Z ^[[1m^[[92m     Locking^[[0m 113 packages to latest compatible versions
+2026-06-08T20:24:07.2901177Z ^[[1m^[[92m      Adding^[[0m generic-array v0.14.7 ^[[1m^[[33m(available: v0.14.9)^[[0m
+2026-06-08T20:24:07.3033097Z ^[[1m^[[92m      Adding^[[0m sha1 v0.10.6 ^[[1m^[[33m(available: v0.11.0)^[[0m
+2026-06-08T20:24:07.3052950Z ^[[1m^[[92m      Adding^[[0m toml v0.9.12+spec-1.1.0 ^[[1m^[[33m(available: v1.1.2+spec-1.1.0)^[[0m
+2026-06-08T20:24:07.3083436Z ^[[1m^[[92m      Adding^[[0m winreg v0.55.0 ^[[1m^[[33m(available: v0.56.0)^[[0m
+2026-06-08T20:24:07.3106368Z ^[[1m^[[92m Downloading^[[0m crates ...
+2026-06-08T20:24:07.3377306Z ^[[1m^[[92m  Downloaded^[[0m anstyle-query v1.1.5
+2026-06-08T20:24:07.3393439Z ^[[1m^[[92m  Downloaded^[[0m env_filter v1.0.1
+2026-06-08T20:24:07.3409297Z ^[[1m^[[92m  Downloaded^[[0m anstyle v1.0.14
+2026-06-08T20:24:07.3427742Z ^[[1m^[[92m  Downloaded^[[0m digest v0.10.7
+2026-06-08T20:24:07.3449776Z ^[[1m^[[92m  Downloaded^[[0m anstyle-parse v1.0.0
+2026-06-08T20:24:07.3471035Z ^[[1m^[[92m  Downloaded^[[0m generic-array v0.14.7
+2026-06-08T20:24:07.3488214Z ^[[1m^[[92m  Downloaded^[[0m block-buffer v0.10.4
+2026-06-08T20:24:07.3502913Z ^[[1m^[[92m  Downloaded^[[0m fastrand v2.4.1
+2026-06-08T20:24:07.3519703Z ^[[1m^[[92m  Downloaded^[[0m errno v0.3.14
+2026-06-08T20:24:07.3538865Z ^[[1m^[[92m  Downloaded^[[0m dirs-sys v0.5.0
+2026-06-08T20:24:07.3552189Z ^[[1m^[[92m  Downloaded^[[0m clap_lex v1.1.0
+2026-06-08T20:24:07.3564852Z ^[[1m^[[92m  Downloaded^[[0m clap_builder v4.6.0
+2026-06-08T20:24:07.3636670Z ^[[1m^[[92m  Downloaded^[[0m shell-words v1.1.1
+2026-06-08T20:24:07.3653375Z ^[[1m^[[92m  Downloaded^[[0m utf8parse v0.2.2
+2026-06-08T20:24:07.3665796Z ^[[1m^[[92m  Downloaded^[[0m cpufeatures v0.2.17
+2026-06-08T20:24:07.3682784Z ^[[1m^[[92m  Downloaded^[[0m sha1 v0.10.6
+2026-06-08T20:24:07.3703685Z ^[[1m^[[92m  Downloaded^[[0m version_check v0.9.5
+2026-06-08T20:24:07.3720401Z ^[[1m^[[92m  Downloaded^[[0m getopts v0.2.24
+2026-06-08T20:24:07.3742206Z ^[[1m^[[92m  Downloaded^[[0m unicase v2.9.0
+2026-06-08T20:24:07.3763275Z ^[[1m^[[92m  Downloaded^[[0m toml_parser v1.1.2+spec-1.1.0
+2026-06-08T20:24:07.3793732Z ^[[1m^[[92m  Downloaded^[[0m log v0.4.32
+2026-06-08T20:24:07.3824492Z ^[[1m^[[92m  Downloaded^[[0m typenum v1.20.1
+2026-06-08T20:24:07.3867433Z ^[[1m^[[92m  Downloaded^[[0m memchr v2.8.1
+2026-06-08T20:24:07.3928412Z ^[[1m^[[92m  Downloaded^[[0m indexmap v2.14.0
+2026-06-08T20:24:07.3975391Z ^[[1m^[[92m  Downloaded^[[0m bitflags v2.13.0
+2026-06-08T20:24:07.4025369Z ^[[1m^[[92m  Downloaded^[[0m regex v1.12.3
+2026-06-08T20:24:07.4085651Z ^[[1m^[[92m  Downloaded^[[0m winnow v1.0.3
+2026-06-08T20:24:07.4186759Z ^[[1m^[[92m  Downloaded^[[0m winnow v0.7.15
+2026-06-08T20:24:07.4286913Z ^[[1m^[[92m  Downloaded^[[0m pulldown-cmark v0.13.4
+2026-06-08T20:24:07.4341837Z ^[[1m^[[92m  Downloaded^[[0m toml v0.9.12+spec-1.1.0
+2026-06-08T20:24:07.4387584Z ^[[1m^[[92m  Downloaded^[[0m unicode-width v0.2.2
+2026-06-08T20:24:07.4447707Z ^[[1m^[[92m  Downloaded^[[0m tempfile v3.27.0
+2026-06-08T20:24:07.4476161Z ^[[1m^[[92m  Downloaded^[[0m serde_core v1.0.228
+2026-06-08T20:24:07.4506934Z ^[[1m^[[92m  Downloaded^[[0m hashbrown v0.17.1
+2026-06-08T20:24:07.4567209Z ^[[1m^[[92m  Downloaded^[[0m clap v4.6.1
+2026-06-08T20:24:07.4667401Z ^[[1m^[[92m  Downloaded^[[0m regex-syntax v0.8.10
+2026-06-08T20:24:07.4737937Z ^[[1m^[[92m  Downloaded^[[0m once_cell v1.21.4
+2026-06-08T20:24:07.4765952Z ^[[1m^[[92m  Downloaded^[[0m dirs v6.0.0
+2026-06-08T20:24:07.4780286Z ^[[1m^[[92m  Downloaded^[[0m toml_writer v1.1.1+spec-1.1.0
+2026-06-08T20:24:07.4796666Z ^[[1m^[[92m  Downloaded^[[0m rustix v1.1.4
+2026-06-08T20:24:07.5072777Z ^[[1m^[[92m  Downloaded^[[0m toml_datetime v0.7.5+spec-1.1.0
+2026-06-08T20:24:07.5086629Z ^[[1m^[[92m  Downloaded^[[0m strsim v0.11.1
+2026-06-08T20:24:07.5101535Z ^[[1m^[[92m  Downloaded^[[0m equivalent v1.0.2
+2026-06-08T20:24:07.5113283Z ^[[1m^[[92m  Downloaded^[[0m env_logger v0.11.10
+2026-06-08T20:24:07.5137647Z ^[[1m^[[92m  Downloaded^[[0m cfg-if v1.0.4
+2026-06-08T20:24:07.5155115Z ^[[1m^[[92m  Downloaded^[[0m serde_spanned v1.1.1
+2026-06-08T20:24:07.5167943Z ^[[1m^[[92m  Downloaded^[[0m pulldown-cmark-escape v0.11.0
+2026-06-08T20:24:07.5177595Z ^[[1m^[[92m  Downloaded^[[0m crypto-common v0.1.7
+2026-06-08T20:24:07.5189074Z ^[[1m^[[92m  Downloaded^[[0m colorchoice v1.0.5
+2026-06-08T20:24:07.5200812Z ^[[1m^[[92m  Downloaded^[[0m option-ext v0.2.0
+2026-06-08T20:24:07.5211212Z ^[[1m^[[92m  Downloaded^[[0m is_terminal_polyfill v1.70.2
+2026-06-08T20:24:07.5223005Z ^[[1m^[[92m  Downloaded^[[0m regex-automata v0.4.14
+2026-06-08T20:24:07.5365617Z ^[[1m^[[92m  Downloaded^[[0m getrandom v0.4.2
+2026-06-08T20:24:07.5404865Z ^[[1m^[[92m  Downloaded^[[0m aho-corasick v1.1.4
+2026-06-08T20:24:07.5459818Z ^[[1m^[[92m  Downloaded^[[0m anstream v1.0.0
+2026-06-08T20:24:07.5482961Z ^[[1m^[[92m  Downloaded^[[0m libc v0.2.186
+2026-06-08T20:24:07.5877308Z ^[[1m^[[92m  Downloaded^[[0m jiff v0.2.28
+2026-06-08T20:24:07.6123932Z ^[[1m^[[92m  Downloaded^[[0m linux-raw-sys v0.12.1
+2026-06-08T20:24:07.6895711Z ^[[1m^[[92m   Compiling^[[0m version_check v0.9.5
+2026-06-08T20:24:07.6896626Z ^[[1m^[[92m   Compiling^[[0m memchr v2.8.1
+2026-06-08T20:24:07.6897346Z ^[[1m^[[92m   Compiling^[[0m libc v0.2.186
+2026-06-08T20:24:07.6897901Z ^[[1m^[[92m   Compiling^[[0m utf8parse v0.2.2
+2026-06-08T20:24:07.7371401Z ^[[1m^[[92m   Compiling^[[0m typenum v1.20.1
+2026-06-08T20:24:07.8995963Z ^[[1m^[[92m   Compiling^[[0m generic-array v0.14.7
+2026-06-08T20:24:07.9426315Z ^[[1m^[[92m   Compiling^[[0m serde_core v1.0.228
+2026-06-08T20:24:08.1193799Z ^[[1m^[[92m   Compiling^[[0m anstyle-parse v1.0.0
+2026-06-08T20:24:08.2512852Z ^[[1m^[[92m   Compiling^[[0m aho-corasick v1.1.4
+2026-06-08T20:24:08.5809389Z ^[[1m^[[92m   Compiling^[[0m anstyle v1.0.14
+2026-06-08T20:24:08.7716892Z ^[[1m^[[92m   Compiling^[[0m is_terminal_polyfill v1.70.2
+2026-06-08T20:24:08.8085754Z ^[[1m^[[92m   Compiling^[[0m regex-syntax v0.8.10
+2026-06-08T20:24:09.0127472Z ^[[1m^[[92m   Compiling^[[0m colorchoice v1.0.5
+2026-06-08T20:24:09.0575883Z ^[[1m^[[92m   Compiling^[[0m anstyle-query v1.1.5
+2026-06-08T20:24:09.0941399Z ^[[1m^[[92m   Compiling^[[0m anstream v1.0.0
+2026-06-08T20:24:09.4225757Z ^[[1m^[[92m   Compiling^[[0m getrandom v0.4.2
+2026-06-08T20:24:09.5205776Z ^[[1m^[[92m   Compiling^[[0m bitflags v2.13.0
+2026-06-08T20:24:09.7575838Z ^[[1m^[[92m   Compiling^[[0m cfg-if v1.0.4
+2026-06-08T20:24:09.7855709Z ^[[1m^[[92m   Compiling^[[0m rustix v1.1.4
+2026-06-08T20:24:10.0625861Z ^[[1m^[[92m   Compiling^[[0m block-buffer v0.10.4
+2026-06-08T20:24:10.1425991Z ^[[1m^[[92m   Compiling^[[0m crypto-common v0.1.7
+2026-06-08T20:24:10.1983135Z ^[[1m^[[92m   Compiling^[[0m option-ext v0.2.0
+2026-06-08T20:24:10.2376284Z ^[[1m^[[92m   Compiling^[[0m pulldown-cmark v0.13.4
+2026-06-08T20:24:10.3146699Z ^[[1m^[[92m   Compiling^[[0m clap_lex v1.1.0
+2026-06-08T20:24:10.5315761Z ^[[1m^[[92m   Compiling^[[0m linux-raw-sys v0.12.1
+2026-06-08T20:24:10.8773462Z ^[[1m^[[92m   Compiling^[[0m regex-automata v0.4.14
+2026-06-08T20:24:11.6277823Z ^[[1m^[[92m   Compiling^[[0m log v0.4.32
+2026-06-08T20:24:11.8146348Z ^[[1m^[[92m   Compiling^[[0m strsim v0.11.1
+2026-06-08T20:24:11.9166177Z ^[[1m^[[92m   Compiling^[[0m winnow v1.0.3
+2026-06-08T20:24:12.3185960Z ^[[1m^[[92m   Compiling^[[0m unicode-width v0.2.2
+2026-06-08T20:24:12.3482166Z ^[[1m^[[92m   Compiling^[[0m toml_parser v1.1.2+spec-1.1.0
+2026-06-08T20:24:12.5195946Z ^[[1m^[[92m   Compiling^[[0m getopts v0.2.24
+2026-06-08T20:24:13.1666698Z ^[[1m^[[92m   Compiling^[[0m clap_builder v4.6.0
+2026-06-08T20:24:13.2928998Z ^[[1m^[[92m   Compiling^[[0m toml_datetime v0.7.5+spec-1.1.0
+2026-06-08T20:24:13.3309125Z ^[[1m^[[92m   Compiling^[[0m serde_spanned v1.1.1
+2026-06-08T20:24:13.6256201Z ^[[1m^[[92m   Compiling^[[0m dirs-sys v0.5.0
+2026-06-08T20:24:13.9496153Z ^[[1m^[[92m   Compiling^[[0m regex v1.12.3
+2026-06-08T20:24:14.8436250Z ^[[1m^[[92m   Compiling^[[0m env_filter v1.0.1
+2026-06-08T20:24:15.3726261Z ^[[1m^[[92m   Compiling^[[0m digest v0.10.7
+2026-06-08T20:24:15.6446117Z ^[[1m^[[92m   Compiling^[[0m toml_writer v1.1.1+spec-1.1.0
+2026-06-08T20:24:15.8071611Z ^[[1m^[[92m   Compiling^[[0m once_cell v1.21.4
+2026-06-08T20:24:15.8220401Z ^[[1m^[[92m   Compiling^[[0m cpufeatures v0.2.17
+2026-06-08T20:24:15.8535890Z ^[[1m^[[92m   Compiling^[[0m fastrand v2.4.1
+2026-06-08T20:24:15.9755956Z ^[[1m^[[92m   Compiling^[[0m unicase v2.9.0
+2026-06-08T20:24:16.0515788Z ^[[1m^[[92m   Compiling^[[0m jiff v0.2.28
+2026-06-08T20:24:16.1305792Z ^[[1m^[[92m   Compiling^[[0m winnow v0.7.15
+2026-06-08T20:24:17.9316230Z ^[[1m^[[92m   Compiling^[[0m pulldown-cmark-escape v0.11.0
+2026-06-08T20:24:18.0686432Z ^[[1m^[[92m   Compiling^[[0m toml v0.9.12+spec-1.1.0
+2026-06-08T20:24:19.6283498Z ^[[1m^[[92m   Compiling^[[0m tempfile v3.27.0
+2026-06-08T20:24:20.1846320Z ^[[1m^[[92m   Compiling^[[0m env_logger v0.11.10
+2026-06-08T20:24:20.4691990Z ^[[1m^[[92m   Compiling^[[0m sha1 v0.10.6
+2026-06-08T20:24:20.6606422Z ^[[1m^[[92m   Compiling^[[0m clap v4.6.1
+2026-06-08T20:24:20.6906023Z ^[[1m^[[92m   Compiling^[[0m dirs v6.0.0
+2026-06-08T20:24:20.7686285Z ^[[1m^[[92m   Compiling^[[0m shell-words v1.1.1
+2026-06-08T20:24:21.3622967Z ^[[1m^[[92m   Compiling^[[0m rust-script v0.36.0
+2026-06-08T20:24:42.1369206Z ^[[1m^[[92m    Finished^[[0m `release` profile [optimized] target(s) in 35.36s
+2026-06-08T20:24:42.1632120Z ^[[1m^[[92m  Installing^[[0m /home/runner/.cargo/bin/rust-script
+2026-06-08T20:24:42.1688051Z ^[[1m^[[92m   Installed^[[0m package `rust-script v0.36.0` (executable `rust-script`)
+2026-06-08T20:24:42.1982491Z ##[group]Run rust-script rust/scripts/get-bump-type.rs
+2026-06-08T20:24:42.1982930Z ^[[36;1mrust-script rust/scripts/get-bump-type.rs^[[0m
+2026-06-08T20:24:42.2008424Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:24:42.2008690Z env:
+2026-06-08T20:24:42.2008893Z   CARGO_TERM_COLOR: always
+2026-06-08T20:24:42.2009284Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:24:42.2009615Z   CARGO_TOKEN: ***
+2026-06-08T20:24:42.2009843Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:24:42.2010101Z   CARGO_INCREMENTAL: 0
+2026-06-08T20:24:42.2010328Z ##[endgroup]
+2026-06-08T20:24:50.9760794Z Detected multi-language repository (Cargo.toml in rust/)
+2026-06-08T20:24:50.9766350Z Fragment 20260608_issue_160_separate_language_releases.md: bump=patch
+2026-06-08T20:24:50.9769169Z Fragment 20260608_issue_162_release_job_skip.md: bump=patch
+2026-06-08T20:24:50.9769582Z 
+2026-06-08T20:24:50.9769809Z Determined bump type: patch (from 2 fragment(s))
+2026-06-08T20:24:50.9771049Z Output: bump_type=patch
+2026-06-08T20:24:50.9771880Z Output: fragment_count=2
+2026-06-08T20:24:50.9772192Z Output: has_fragments=true
+2026-06-08T20:24:50.9805464Z ##[group]Run rust-script rust/scripts/check-release-needed.rs --tag-prefix rust-v
+2026-06-08T20:24:50.9806154Z ^[[36;1mrust-script rust/scripts/check-release-needed.rs --tag-prefix rust-v^[[0m
+2026-06-08T20:24:50.9831752Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:24:50.9832012Z env:
+2026-06-08T20:24:50.9832215Z   CARGO_TERM_COLOR: always
+2026-06-08T20:24:50.9832611Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:24:50.9832931Z   CARGO_TOKEN: ***
+2026-06-08T20:24:50.9833168Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:24:50.9833442Z   CARGO_INCREMENTAL: 0
+2026-06-08T20:24:50.9833670Z   HAS_FRAGMENTS: true
+2026-06-08T20:24:50.9837299Z   GITHUB_TOKEN: ***
+2026-06-08T20:24:50.9837595Z   GITHUB_REPOSITORY: link-foundation/command-stream
+2026-06-08T20:24:50.9837922Z ##[endgroup]
+2026-06-08T20:25:16.8145343Z Detected multi-language repository (Cargo.toml in rust/)
+2026-06-08T20:25:16.9128922Z Max published version on crates.io: 0.9.5
+2026-06-08T20:25:16.9130336Z Output: max_published_version=0.9.5
+2026-06-08T20:25:16.9131244Z Found changelog fragments, proceeding with release
+2026-06-08T20:25:16.9131748Z Output: should_release=true
+2026-06-08T20:25:16.9132108Z Output: skip_bump=false
+2026-06-08T20:25:16.9168983Z ##[group]Run rust-script rust/scripts/version-and-commit.rs --bump-type "patch" --tag-prefix rust-v --release-label Rust
+2026-06-08T20:25:16.9169881Z ^[[36;1mrust-script rust/scripts/version-and-commit.rs --bump-type "patch" --tag-prefix rust-v --release-label Rust^[[0m
+2026-06-08T20:25:16.9195758Z shell: /usr/bin/bash -e {0}
+2026-06-08T20:25:16.9196014Z env:
+2026-06-08T20:25:16.9196211Z   CARGO_TERM_COLOR: always
+2026-06-08T20:25:16.9196590Z   CARGO_REGISTRY_TOKEN: ***
+2026-06-08T20:25:16.9196900Z   CARGO_TOKEN: ***
+2026-06-08T20:25:16.9197124Z   CARGO_HOME: /home/runner/.cargo
+2026-06-08T20:25:16.9197385Z   CARGO_INCREMENTAL: 0
+2026-06-08T20:25:16.9197612Z ##[endgroup]
+2026-06-08T20:25:21.2906155Z Detected multi-language repository (Cargo.toml in rust/)
+2026-06-08T20:25:21.3522664Z Max published version on crates.io: 0.9.5
+2026-06-08T20:25:21.3523408Z Initial bump (patch) from 0.9.5: 0.9.6
+2026-06-08T20:25:21.4398758Z Final release version: 0.9.6
+2026-06-08T20:25:21.4401445Z Updated rust/Cargo.toml to version 0.9.6
+2026-06-08T20:25:21.4404470Z Updated rust/Cargo.lock to version 0.9.6
+2026-06-08T20:25:21.4408593Z Collected 2 changelog fragment(s)
+2026-06-08T20:25:21.7163126Z Local branch is behind remote, rebasing...
+2026-06-08T20:25:21.7217274Z Error rebasing onto origin/main: Command failed: error: cannot rebase: Your index contains uncommitted changes.
+2026-06-08T20:25:21.7218289Z error: Please commit or stash them.
+2026-06-08T20:25:21.7218639Z 
+2026-06-08T20:25:21.7245572Z ##[error]Process completed with exit code 1.
+2026-06-08T20:25:21.7363861Z Post job cleanup.
+2026-06-08T20:25:21.8350775Z [command]/usr/bin/git version
+2026-06-08T20:25:21.8387532Z git version 2.54.0
+2026-06-08T20:25:21.8431001Z Temporarily overriding HOME='/home/runner/work/_temp/93b579b8-f405-438b-afcd-13dc4a65e395' before making global git config changes
+2026-06-08T20:25:21.8431809Z Adding repository directory to the temporary git global config as a safe directory
+2026-06-08T20:25:21.8436841Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+2026-06-08T20:25:21.8473817Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+2026-06-08T20:25:21.8506694Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+2026-06-08T20:25:21.8740333Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+2026-06-08T20:25:21.8766238Z http.https://github.com/.extraheader
+2026-06-08T20:25:21.8778431Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+2026-06-08T20:25:21.8808910Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+2026-06-08T20:25:21.9033460Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+2026-06-08T20:25:21.9064169Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+2026-06-08T20:25:21.9407294Z Cleaning up orphan processes
+2026-06-08T20:25:21.9710847Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/docs/case-studies/issue-164/ci-logs/rust-run-27164605403-full.log
+++ b/docs/case-studies/issue-164/ci-logs/rust-run-27164605403-full.log
@@ -1,0 +1,5033 @@
+Lint and format Rust	UNKNOWN STEP	﻿2026-06-08T20:22:03.6881897Z Current runner version: '2.334.0'
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6908812Z ##[group]Runner Image Provisioner
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6909749Z Hosted Compute Agent
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6910351Z Version: 20260520.533
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6911157Z Commit: 189110e25284a9812c124fd27b339e2fb4f2f9db
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6911899Z Build Date: 2026-05-20T17:44:04Z
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6912996Z Worker ID: {d0e0524d-391e-46a4-b00c-8604d30e0a84}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6913839Z Azure Region: eastus
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6914408Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6916107Z ##[group]Operating System
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6916775Z Ubuntu
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6917411Z 24.04.4
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6918007Z LTS
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6918707Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6919414Z ##[group]Runner Image
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6920122Z Image: ubuntu-24.04
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6920787Z Version: 20260525.161.1
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6922108Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260525.161/images/ubuntu/Ubuntu2404-Readme.md
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6923730Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260525.161
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6924729Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6927700Z ##[group]GITHUB_TOKEN Permissions
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6930433Z Actions: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6931238Z ArtifactMetadata: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6931897Z Attestations: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6932529Z Checks: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6933180Z CodeQuality: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6933780Z Contents: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6934394Z Deployments: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6934987Z Discussions: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6935723Z Issues: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6936307Z Metadata: read
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6936876Z Models: read
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6937621Z Packages: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6938325Z Pages: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6939204Z PullRequests: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6939899Z RepositoryProjects: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6940587Z SecurityEvents: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6941259Z Statuses: write
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6941862Z VulnerabilityAlerts: read
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6942512Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6944843Z Secret source: Actions
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.6945653Z Prepare workflow directory
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.7459732Z Prepare all required actions
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:03.7496630Z Getting action download info
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.1157619Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.2293363Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.3490039Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.6789954Z Complete job name: Lint and format Rust
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7501616Z ##[group]Run actions/checkout@v4
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7502592Z with:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7503183Z   repository: link-foundation/command-stream
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7512797Z   token: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7513321Z   ssh-strict: true
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7513894Z   ssh-user: git
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7514444Z   persist-credentials: true
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7515077Z   clean: true
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7515628Z   sparse-checkout-cone-mode: true
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7516316Z   fetch-depth: 1
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7516853Z   fetch-tags: false
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7517413Z   show-progress: true
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7517961Z   lfs: false
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7518459Z   submodules: false
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7519161Z   set-safe-directory: true
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7519989Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7520477Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7521342Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7522119Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.7522647Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8667181Z Syncing repository: link-foundation/command-stream
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8669834Z ##[group]Getting Git version info
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8671033Z Working directory is '/home/runner/work/command-stream/command-stream'
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8672558Z [command]/usr/bin/git version
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8710083Z git version 2.54.0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8735627Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8757357Z Temporarily overriding HOME='/home/runner/work/_temp/e79b7b34-098c-4c4b-992d-a536d85c1a27' before making global git config changes
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8759773Z Adding repository directory to the temporary git global config as a safe directory
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8762587Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8804404Z Deleting the contents of '/home/runner/work/command-stream/command-stream'
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8807698Z ##[group]Initializing the repository
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8812101Z [command]/usr/bin/git init /home/runner/work/command-stream/command-stream
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8902461Z hint: Using 'master' as the name for the initial branch. This default branch name
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8904514Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8906363Z hint: to use in all of your new repositories, which will suppress this warning,
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8907622Z hint: call:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8908116Z hint:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8908995Z hint: 	git config --global init.defaultBranch <name>
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8909865Z hint:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8910643Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8912234Z hint: 'development'. The just-created branch can be renamed via this command:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8913322Z hint:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8913826Z hint: 	git branch -m <name>
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8914437Z hint:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8915484Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8917497Z Initialized empty Git repository in /home/runner/work/command-stream/command-stream/.git/
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8920307Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/command-stream
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8957552Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8958672Z ##[group]Disabling automatic garbage collection
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8962066Z [command]/usr/bin/git config --local gc.auto 0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8990643Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8991540Z ##[group]Setting up auth
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.8996905Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.9031396Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.9344816Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.9377681Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.9606420Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.9646854Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.9881503Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.9916557Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.9917947Z ##[group]Fetching the repository
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:04.9925296Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +89d47cf62671f8e1c4813af51128b0b9e47b6fa6:refs/remotes/origin/main
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4017393Z From https://github.com/link-foundation/command-stream
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4020325Z  * [new ref]         89d47cf62671f8e1c4813af51128b0b9e47b6fa6 -> origin/main
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4054713Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4056476Z ##[group]Determining the checkout info
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4059122Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4060979Z [command]/usr/bin/git sparse-checkout disable
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4105327Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4133710Z ##[group]Checking out the ref
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4138013Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4881876Z Switched to a new branch 'main'
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4890188Z branch 'main' set up to track 'origin/main'.
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4897128Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4938835Z [command]/usr/bin/git log -1 --format=%H
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.4961926Z 89d47cf62671f8e1c4813af51128b0b9e47b6fa6
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5568239Z ##[group]Run dtolnay/rust-toolchain@stable
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5569705Z with:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5570623Z   components: rustfmt, clippy
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5571703Z   toolchain: stable
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5572647Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5573542Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5575113Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5576434Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5577383Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5732645Z ##[group]Run : parse toolchain version
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5733928Z ^[[36;1m: parse toolchain version^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5735052Z ^[[36;1mif [[ -z $toolchain ]]; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5736952Z ^[[36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5739191Z ^[[36;1m  echo "'toolchain' is a required input" >&2^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5740391Z ^[[36;1m  exit 1^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5741759Z ^[[36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5743342Z ^[[36;1m  if [[ Linux == macOS ]]; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5745281Z ^[[36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5747200Z ^[[36;1m  else^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5748827Z ^[[36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5750613Z ^[[36;1m  fi^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5751814Z ^[[36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5753793Z ^[[36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5755543Z ^[[36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5757515Z ^[[36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5759508Z ^[[36;1melse^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5760528Z ^[[36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5761733Z ^[[36;1mfi^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5796421Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5797731Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5798739Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5800069Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5801250Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5802131Z   toolchain: stable
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5803006Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5973846Z ##[group]Run : construct rustup command line
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5975079Z ^[[36;1m: construct rustup command line^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5976760Z ^[[36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5979270Z ^[[36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.5981125Z ^[[36;1mecho "downgrade=" >> $GITHUB_OUTPUT^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6009311Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6010598Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6011428Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6012736Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6013929Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6014810Z   targets: 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6015664Z   components: rustfmt, clippy
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6016853Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6134578Z ##[group]Run : set $CARGO_HOME
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6135624Z ^[[36;1m: set $CARGO_HOME^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6136886Z ^[[36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6165283Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6166557Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6167396Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6168928Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6170092Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6170973Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6288943Z ##[group]Run : install rustup if needed
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6290148Z ^[[36;1m: install rustup if needed^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6291329Z ^[[36;1mif ! command -v rustup &>/dev/null; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6294028Z ^[[36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6296604Z ^[[36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6297765Z ^[[36;1mfi^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6325921Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6327176Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6328015Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6329581Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6330738Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6331648Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6332656Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6456315Z ##[group]Run rustup toolchain install stable --component rustfmt --component clippy --profile minimal --no-self-update
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6459299Z ^[[36;1mrustup toolchain install stable --component rustfmt --component clippy --profile minimal --no-self-update^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6490647Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6491896Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6492700Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6493954Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6495084Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6495970Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6497001Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.6497963Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:05.8633557Z info: syncing channel updates for stable-x86_64-unknown-linux-gnu
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:06.1560085Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:06.1847391Z info: removing previous version of component clippy
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:06.1911261Z info: removing previous version of component rustfmt
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:06.1920531Z info: removing previous version of component cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:06.1957546Z info: removing previous version of component rust-std
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:06.2049074Z info: removing previous version of component rustc
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:06.2093975Z info: downloading 5 components
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8025946Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8109036Z   stable-x86_64-unknown-linux-gnu updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.95.0 (59807616e 2026-04-14))
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8109777Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8200294Z ##[group]Run rustup default stable
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8200641Z ^[[36;1mrustup default stable^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8227647Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8228017Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8228242Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8229070Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8229395Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8229644Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8229920Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8335123Z info: using existing install for stable-x86_64-unknown-linux-gnu
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8342941Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8343399Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8412252Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8412850Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8449603Z ##[group]Run : create cachekey
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8449935Z ^[[36;1m: create cachekey^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8450629Z ^[[36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8451278Z ^[[36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8451797Z ^[[36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8476959Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8477325Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8477554Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8478151Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8478486Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8478959Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8479236Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8839121Z ##[group]Run : disable incremental compilation
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8839577Z ^[[36;1m: disable incremental compilation^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8839950Z ^[[36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8840357Z ^[[36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8840673Z ^[[36;1mfi^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8867739Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8868115Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8868348Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8868962Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8869286Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8869552Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8869835Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8966996Z ##[group]Run : enable colors in Cargo output
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8967383Z ^[[36;1m: enable colors in Cargo output^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8967750Z ^[[36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8968134Z ^[[36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8968461Z ^[[36;1mfi^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8993178Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8993911Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8994157Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8994557Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8994896Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8995146Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8995440Z   CARGO_INCREMENTAL: 0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.8995689Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9065840Z ##[group]Run : enable Cargo sparse registry
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9066215Z ^[[36;1m: enable Cargo sparse registry^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9066613Z ^[[36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9067378Z ^[[36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9068132Z ^[[36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9069041Z ^[[36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9069647Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9070205Z ^[[36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9070807Z ^[[36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9071352Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9071735Z ^[[36;1m  fi^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9071955Z ^[[36;1mfi^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9096337Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9096711Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9096937Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9097338Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9097653Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9097896Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9098190Z   CARGO_INCREMENTAL: 0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9098430Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9435260Z ##[group]Run : work around spurious network errors in curl 8.0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9435922Z ^[[36;1m: work around spurious network errors in curl 8.0^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9436754Z ^[[36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9437416Z ^[[36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9437926Z ^[[36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9438272Z ^[[36;1mfi^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9465812Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9466182Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9466576Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9467022Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9467338Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9467580Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9467862Z   CARGO_INCREMENTAL: 0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9468104Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9669049Z ##[group]Run rustc +stable --version --verbose
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9669455Z ^[[36;1mrustc +stable --version --verbose^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9695130Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9695503Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9695734Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9696148Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9696471Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9696725Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9697017Z   CARGO_INCREMENTAL: 0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9697270Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9859898Z rustc 1.96.0 (ac68faa20 2026-05-25)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9860553Z binary: rustc
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9861021Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9861520Z commit-date: 2026-05-25
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9861855Z host: x86_64-unknown-linux-gnu
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9862388Z release: 1.96.0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:14.9862814Z LLVM version: 22.1.2
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0573045Z ##[group]Run actions/cache@v4
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0573362Z with:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0573636Z   path: ~/.cargo/registry
+Lint and format Rust	UNKNOWN STEP	~/.cargo/git
+Lint and format Rust	UNKNOWN STEP	rust/target
+Lint and format Rust	UNKNOWN STEP	
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0574169Z   key: Linux-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0574681Z   restore-keys: Linux-cargo-
+Lint and format Rust	UNKNOWN STEP	
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0574973Z   enableCrossOsArchive: false
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0575250Z   fail-on-cache-miss: false
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0575513Z   lookup-only: false
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0575759Z   save-always: false
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0575989Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0576210Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0576656Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0576992Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0577237Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0577523Z   CARGO_INCREMENTAL: 0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.0577768Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:15.2903937Z Cache hit for: Linux-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:16.3656277Z Received 205520896 of 249180146 (82.5%), 195.8 MBs/sec
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:16.5917140Z Received 249180146 of 249180146 (100.0%), 193.7 MBs/sec
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:16.5919877Z Cache Size: ~238 MB (249180146 B)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:16.6021443Z [command]/usr/bin/tar -xf /home/runner/work/_temp/29280800-b43a-4574-915a-36ec4a6a3da0/cache.tzst -P -C /home/runner/work/command-stream/command-stream --use-compress-program unzstd
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.1358262Z Cache restored successfully
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.2849216Z Cache restored from key: Linux-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.2956392Z ##[group]Run cargo fmt --all -- --check
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.2956765Z ^[[36;1mcargo fmt --all -- --check^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.2986661Z shell: /usr/bin/bash -e {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.2986984Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.2987212Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.2987633Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.2987953Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.2988192Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.2988475Z   CARGO_INCREMENTAL: 0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.2989168Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.4030564Z ##[group]Run cargo clippy --all-targets --all-features
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.4030988Z ^[[36;1mcargo clippy --all-targets --all-features^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.4057669Z shell: /usr/bin/bash -e {0}
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.4057935Z env:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.4058152Z   CARGO_TERM_COLOR: always
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.4058761Z   CARGO_REGISTRY_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.4059172Z   CARGO_TOKEN: ***
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.4059415Z   CARGO_HOME: /home/runner/.cargo
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.4059691Z   CARGO_INCREMENTAL: 0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.4059931Z ##[endgroup]
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.5316995Z ^[[1m^[[92m    Checking^[[0m command-stream v0.9.5 (/home/runner/work/command-stream/command-stream/rust)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.5874934Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `std::path::Path`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.5875993Z   ^[[1m^[[94m--> ^[[0msrc/commands/mod.rs:53:5
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.5876713Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.5877466Z ^[[1m^[[94m53^[[0m ^[[1m^[[94m|^[[0m use std::path::Path;
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.5878496Z    ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.5879436Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.5880321Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.5881055Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8497897Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `e`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8498813Z   ^[[1m^[[94m--> ^[[0msrc/commands/touch.rs:33:24
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8499342Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8499845Z ^[[1m^[[94m33^[[0m ^[[1m^[[94m|^[[0m             if let Err(e) =
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8500940Z    ^[[1m^[[94m|^[[0m                        ^[[1m^[[33m^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_e`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8501771Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8502487Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8503045Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8871117Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `file_type`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8871908Z    ^[[1m^[[94m--> ^[[0msrc/commands/ls.rs:124:9
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8872422Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8873107Z ^[[1m^[[94m124^[[0m ^[[1m^[[94m|^[[0m     let file_type = if metadata.is_dir() { "d" } else { "-" };
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8874291Z     ^[[1m^[[94m|^[[0m         ^[[1m^[[33m^^^^^^^^^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_file_type`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.8875000Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9102177Z ^[[1m^[[33mwarning^[[0m^[[1m: field `output_rx` is never read^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9102927Z    ^[[1m^[[94m--> ^[[0msrc/lib.rs:184:5
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9103409Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9103941Z ^[[1m^[[94m175^[[0m ^[[1m^[[94m|^[[0m pub struct ProcessRunner {
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9104736Z     ^[[1m^[[94m|^[[0m            ^[[1m^[[94m-------------^[[0m ^[[1m^[[94mfield in this struct^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9105351Z ^[[1m^[[94m...^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9106216Z ^[[1m^[[94m184^[[0m ^[[1m^[[94m|^[[0m     output_rx: Option<mpsc::Receiver<StreamChunk>>,
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9106972Z     ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9107461Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9108141Z     ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9108896Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9247523Z ^[[1m^[[33mwarning^[[0m^[[1m: method `add` can be confused for the standard trait method `std::ops::Add::add`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9248909Z   ^[[1m^[[94m--> ^[[0msrc/pipeline.rs:75:5
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9249580Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9250571Z ^[[1m^[[94m75^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m/^[[0m     pub fn add(mut self, command: impl Into<String>) -> Self {
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9251684Z ^[[1m^[[94m76^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m         self.commands.push(command.into());
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9252772Z ^[[1m^[[94m77^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m         self
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9253533Z ^[[1m^[[94m78^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m     }
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9254186Z    ^[[1m^[[94m|^[[0m ^[[1m^[[33m|_____^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9255496Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9256737Z    ^[[1m^[[94m= ^[[0m^[[1mhelp^[[0m: consider implementing the trait `std::ops::Add` or choosing a less ambiguous method name
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9258502Z    ^[[1m^[[94m= ^[[0m^[[1mhelp^[[0m: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#should_implement_trait
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9260161Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(clippy::should_implement_trait)]` on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9621239Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9622136Z ^[[1m^[[33mwarning^[[0m^[[1m: manual implementation of `Option::map`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9696408Z    ^[[1m^[[94m--> ^[[0msrc/stream.rs:238:25
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9696909Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9697575Z ^[[1m^[[94m238^[[0m ^[[1m^[[94m|^[[0m       let stdout_handle = if let Some(stdout) = stdout {
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9698367Z     ^[[1m^[[94m|^[[0m ^[[1m^[[33m _________________________^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9699463Z ^[[1m^[[94m239^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m         Some(tokio::spawn(async move {
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9700391Z ^[[1m^[[94m240^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m             let mut reader = BufReader::new(stdout);
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9701302Z ^[[1m^[[94m241^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m             let mut buf = vec![0u8; 8192];
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9701951Z ^[[1m^[[94m...^[[0m   ^[[1m^[[33m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9702491Z ^[[1m^[[94m260^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m         None
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9703097Z ^[[1m^[[94m261^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m     };
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9703627Z     ^[[1m^[[94m|^[[0m ^[[1m^[[33m|_____^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9704099Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9705108Z     ^[[1m^[[94m= ^[[0m^[[1mhelp^[[0m: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#manual_map
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9706308Z     ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(clippy::manual_map)]` on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9706912Z ^[[1m^[[96mhelp^[[0m: try
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9707297Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9708148Z ^[[1m^[[94m238^[[0m ^[[92m~ ^[[0m    let stdout_handle = ^[[92mstdout.map(|stdout| tokio::spawn(async move {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9709432Z ^[[1m^[[94m239^[[0m ^[[92m+             let mut reader = BufReader::new(stdout);^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9710160Z ^[[1m^[[94m240^[[0m ^[[92m+             let mut buf = vec![0u8; 8192];^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9710776Z ^[[1m^[[94m241^[[0m ^[[92m+             loop {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9711430Z ^[[1m^[[94m242^[[0m ^[[92m+                 use tokio::io::AsyncReadExt;^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9712180Z ^[[1m^[[94m243^[[0m ^[[92m+                 match reader.read(&mut buf).await {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9712875Z ^[[1m^[[94m244^[[0m ^[[92m+                     Ok(0) => break,^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9713508Z ^[[1m^[[94m245^[[0m ^[[92m+                     Ok(n) => {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9714155Z ^[[1m^[[94m246^[[0m ^[[92m+                         if tx_stdout^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9715046Z ^[[1m^[[94m247^[[0m ^[[92m+                             .send(OutputChunk::Stdout(buf[..n].to_vec()))^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9715830Z ^[[1m^[[94m248^[[0m ^[[92m+                             .await^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9716464Z ^[[1m^[[94m249^[[0m ^[[92m+                             .is_err()^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9717088Z ^[[1m^[[94m250^[[0m ^[[92m+                         {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9717710Z ^[[1m^[[94m251^[[0m ^[[92m+                             break;^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9718316Z ^[[1m^[[94m252^[[0m ^[[92m+                         }^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9719083Z ^[[1m^[[94m253^[[0m ^[[92m+                     }^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9719710Z ^[[1m^[[94m254^[[0m ^[[92m+                     Err(_) => break,^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9720314Z ^[[1m^[[94m255^[[0m ^[[92m+                 }^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9720827Z ^[[1m^[[94m256^[[0m ^[[92m+             }^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9721329Z ^[[1m^[[94m257^[[0m ^[[92m~         }))^[[0m;
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9721789Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9721991Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9722518Z ^[[1m^[[33mwarning^[[0m^[[1m: manual implementation of `Option::map`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9723704Z    ^[[1m^[[94m--> ^[[0msrc/stream.rs:266:25
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9724162Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9724778Z ^[[1m^[[94m266^[[0m ^[[1m^[[94m|^[[0m       let stderr_handle = if let Some(stderr) = stderr {
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9725528Z     ^[[1m^[[94m|^[[0m ^[[1m^[[33m _________________________^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9726442Z ^[[1m^[[94m267^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m         Some(tokio::spawn(async move {
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9727425Z ^[[1m^[[94m268^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m             let mut reader = BufReader::new(stderr);
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9728257Z ^[[1m^[[94m269^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m             let mut buf = vec![0u8; 8192];
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9729105Z ^[[1m^[[94m...^[[0m   ^[[1m^[[33m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9729660Z ^[[1m^[[94m288^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m         None
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9730271Z ^[[1m^[[94m289^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m     };
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9730814Z     ^[[1m^[[94m|^[[0m ^[[1m^[[33m|_____^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9731275Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9732277Z     ^[[1m^[[94m= ^[[0m^[[1mhelp^[[0m: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#manual_map
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9733210Z ^[[1m^[[96mhelp^[[0m: try
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9733613Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9734458Z ^[[1m^[[94m266^[[0m ^[[92m~ ^[[0m    let stderr_handle = ^[[92mstderr.map(|stderr| tokio::spawn(async move {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9735454Z ^[[1m^[[94m267^[[0m ^[[92m+             let mut reader = BufReader::new(stderr);^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9736208Z ^[[1m^[[94m268^[[0m ^[[92m+             let mut buf = vec![0u8; 8192];^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9736849Z ^[[1m^[[94m269^[[0m ^[[92m+             loop {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9737537Z ^[[1m^[[94m270^[[0m ^[[92m+                 use tokio::io::AsyncReadExt;^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9738301Z ^[[1m^[[94m271^[[0m ^[[92m+                 match reader.read(&mut buf).await {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9739216Z ^[[1m^[[94m272^[[0m ^[[92m+                     Ok(0) => break,^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9739865Z ^[[1m^[[94m273^[[0m ^[[92m+                     Ok(n) => {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9740510Z ^[[1m^[[94m274^[[0m ^[[92m+                         if tx_stderr^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9741380Z ^[[1m^[[94m275^[[0m ^[[92m+                             .send(OutputChunk::Stderr(buf[..n].to_vec()))^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9742151Z ^[[1m^[[94m276^[[0m ^[[92m+                             .await^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9742796Z ^[[1m^[[94m277^[[0m ^[[92m+                             .is_err()^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9743391Z ^[[1m^[[94m278^[[0m ^[[92m+                         {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9744023Z ^[[1m^[[94m279^[[0m ^[[92m+                             break;^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9744639Z ^[[1m^[[94m280^[[0m ^[[92m+                         }^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9745202Z ^[[1m^[[94m281^[[0m ^[[92m+                     }^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9745817Z ^[[1m^[[94m282^[[0m ^[[92m+                     Err(_) => break,^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9746421Z ^[[1m^[[94m283^[[0m ^[[92m+                 }^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9746950Z ^[[1m^[[94m284^[[0m ^[[92m+             }^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9747455Z ^[[1m^[[94m285^[[0m ^[[92m~         }))^[[0m;
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9747902Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9748099Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9894464Z ^[[1m^[[33mwarning^[[0m^[[1m: unnecessary `if let` since only the `Ok` variant of the iterator element is used^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9895387Z   ^[[1m^[[94m--> ^[[0msrc/commands/ls.rs:70:21
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9895898Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9896502Z ^[[1m^[[94m70^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m/^[[0m                     for entry in entries {
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9897408Z ^[[1m^[[94m71^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m                         if let Ok(entry) = entry {
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9898497Z ^[[1m^[[94m72^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m                             let name = entry.file_name().to_string_lossy().to_string();
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9899521Z ^[[1m^[[94m...^[[0m  ^[[1m^[[33m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9900108Z ^[[1m^[[94m85^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m                     }
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9901241Z    ^[[1m^[[94m|^[[0m ^[[1m^[[33m|_____________________^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9901782Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9902420Z ^[[1m^[[96mhelp^[[0m: try `.flatten()` and remove the `if let` statement in the for loop
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9903196Z   ^[[1m^[[94m--> ^[[0msrc/commands/ls.rs:71:25
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9903704Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9904339Z ^[[1m^[[94m71^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[96m/^[[0m                         if let Ok(entry) = entry {
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9905391Z ^[[1m^[[94m72^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[96m|^[[0m                             let name = entry.file_name().to_string_lossy().to_string();
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9906182Z ^[[1m^[[94m...^[[0m  ^[[1m^[[96m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9906789Z ^[[1m^[[94m84^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[96m|^[[0m                         }
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9907466Z    ^[[1m^[[94m|^[[0m ^[[1m^[[96m|_________________________^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9908864Z    ^[[1m^[[94m= ^[[0m^[[1mhelp^[[0m: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#manual_flatten
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9910210Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(clippy::manual_flatten)]` on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9910833Z ^[[1m^[[96mhelp^[[0m: try
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9911234Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9911904Z ^[[1m^[[94m70^[[0m ^[[92m~ ^[[0m                    for entry in entries^[[92m.flatten()^[[0m ^[[92m{^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9912908Z ^[[1m^[[94m71^[[0m ^[[92m+                         let name = entry.file_name().to_string_lossy().to_string();^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9913665Z ^[[1m^[[94m72^[[0m ^[[92m+ ^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9914366Z ^[[1m^[[94m73^[[0m ^[[92m+                         // Skip hidden files unless -a is specified^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9915260Z ^[[1m^[[94m74^[[0m ^[[92m+                         if !show_all && name.starts_with('.') {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9916008Z ^[[1m^[[94m75^[[0m ^[[92m+                             continue;^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9916626Z ^[[1m^[[94m76^[[0m ^[[92m+                         }^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9917152Z ^[[1m^[[94m77^[[0m ^[[92m+ ^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9917740Z ^[[1m^[[94m78^[[0m ^[[92m+                         if long_format {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9919032Z ^[[1m^[[94m79^[[0m ^[[92m+                             entry_strs.push(format_entry(&entry.path(), true));^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9919881Z ^[[1m^[[94m80^[[0m ^[[92m+                         } else {^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9920612Z ^[[1m^[[94m81^[[0m ^[[92m+                             entry_strs.push(name);^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9921303Z ^[[1m^[[94m82^[[0m ^[[92m+                         }^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9921875Z ^[[1m^[[94m83^[[0m ^[[92m+                     }^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9922385Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:18.9922588Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0117021Z ^[[1m^[[33mwarning^[[0m^[[1m: useless use of `format!`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0117727Z   ^[[1m^[[94m--> ^[[0msrc/commands/sleep.rs:50:17
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0118261Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0119105Z ^[[1m^[[94m50^[[0m ^[[1m^[[94m|^[[0m                 format!("sleep: cancelled after partial sleep")
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0120532Z    ^[[1m^[[94m|^[[0m                 ^[[1m^[[33m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[[0m ^[[1m^[[33mhelp: consider using `.to_string()`: `"sleep: cancelled after partial sleep".to_string()`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0121527Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0122545Z    ^[[1m^[[94m= ^[[0m^[[1mhelp^[[0m: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#useless_format
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0123874Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(clippy::useless_format)]` on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0124327Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0491028Z ^[[1m^[[33mwarning^[[0m^[[1m: this can be `std::io::Error::other(_)`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0491788Z    ^[[1m^[[94m--> ^[[0msrc/lib.rs:292:23
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0492275Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0492920Z ^[[1m^[[94m292^[[0m ^[[1m^[[94m|^[[0m               Error::Io(std::io::Error::new(
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0493623Z     ^[[1m^[[94m|^[[0m ^[[1m^[[33m _______________________^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0494757Z ^[[1m^[[94m293^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m                 std::io::ErrorKind::Other,
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0495833Z ^[[1m^[[94m294^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m                 "Process not started",
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0496623Z ^[[1m^[[94m295^[[0m ^[[1m^[[94m|^[[0m ^[[1m^[[33m|^[[0m             ))
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0497225Z     ^[[1m^[[94m|^[[0m ^[[1m^[[33m|_____________^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0497910Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0499198Z     ^[[1m^[[94m= ^[[0m^[[1mhelp^[[0m: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#io_other_error
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0500541Z     ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(clippy::io_other_error)]` on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0501309Z ^[[1m^[[96mhelp^[[0m: use `std::io::Error::other`
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0501810Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0502526Z ^[[1m^[[94m292^[[0m ^[[92m~ ^[[0m            Error::Io(std::io::Error::^[[92mother^[[0m(
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0503333Z ^[[1m^[[94m293^[[0m ^[[92m~ ^[[0m                "Process not started",
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0503940Z     ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0504147Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.0849867Z ^[[1m^[[33mwarning^[[0m: `command-stream` (lib) generated 10 warnings (run `cargo clippy --fix --lib -p command-stream -- ` to apply 7 suggestions)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1180015Z ^[[1m^[[33mwarning^[[0m^[[1m: unused imports: `ProcessRunner` and `RunOptions`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1209536Z  ^[[1m^[[94m--> ^[[0msrc/main.rs:5:27
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1239264Z   ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1269752Z ^[[1m^[[94m5^[[0m ^[[1m^[[94m|^[[0m use command_stream::{run, ProcessRunner, RunOptions};
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1270918Z   ^[[1m^[[94m|^[[0m                           ^[[1m^[[33m^^^^^^^^^^^^^^[[0m  ^[[1m^[[33m^^^^^^^^^^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1271618Z   ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1272380Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1308935Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1329800Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `std::path::PathBuf`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1330634Z  ^[[1m^[[94m--> ^[[0mtests/process_runner.rs:7:5
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1331153Z   ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1331742Z ^[[1m^[[94m7^[[0m ^[[1m^[[94m|^[[0m use std::path::PathBuf;
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1332355Z   ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^^^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1332857Z   ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1333539Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1334084Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.1510453Z ^[[1m^[[33mwarning^[[0m: `command-stream` (bin "command-stream" test) generated 1 warning (run `cargo clippy --fix --bin "command-stream" -p command-stream --tests -- ` to apply 1 suggestion)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.2620925Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "process_runner") generated 1 warning (run `cargo clippy --fix --test "process_runner" -p command-stream -- ` to apply 1 suggestion)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.3150350Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `AsyncIterator`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.3169414Z  ^[[1m^[[94m--> ^[[0mtests/stream.rs:3:22
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.3169993Z   ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.3170901Z ^[[1m^[[94m3^[[0m ^[[1m^[[94m|^[[0m use command_stream::{AsyncIterator, OutputChunk, StreamingRunner};
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.3171697Z   ^[[1m^[[94m|^[[0m                      ^[[1m^[[33m^^^^^^^^^^^^^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.3172201Z   ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.3172869Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.3173361Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.3570043Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "stream") generated 1 warning
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5721610Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `cd`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5737689Z  ^[[1m^[[94m--> ^[[0mtests/builtin_commands.rs:6:20
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5739023Z   ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5740019Z ^[[1m^[[94m6^[[0m ^[[1m^[[94m|^[[0m     basename, cat, cd, cp, dirname, echo, env, exit, ls, mkdir, mv, pwd, rm, seq, sleep, test,
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5741055Z   ^[[1m^[[94m|^[[0m                    ^[[1m^[[33m^^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5742205Z   ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5743035Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5743720Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5744542Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `command_stream::utils::CommandResult`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5745438Z  ^[[1m^[[94m--> ^[[0mtests/builtin_commands.rs:9:5
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5746263Z   ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5746979Z ^[[1m^[[94m9^[[0m ^[[1m^[[94m|^[[0m use command_stream::utils::CommandResult;
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5750688Z   ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5751215Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5751896Z ^[[1m^[[33mwarning^[[0m^[[1m: unused imports: `PipelineExt`, `ProcessRunner`, and `RunOptions`^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5752800Z  ^[[1m^[[94m--> ^[[0mtests/pipeline.rs:3:32
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5753380Z   ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5754323Z ^[[1m^[[94m3^[[0m ^[[1m^[[94m|^[[0m use command_stream::{Pipeline, PipelineExt, ProcessRunner, RunOptions};
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5755563Z   ^[[1m^[[94m|^[[0m                                ^[[1m^[[33m^^^^^^^^^^^^[[0m  ^[[1m^[[33m^^^^^^^^^^^^^^[[0m  ^[[1m^[[33m^^^^^^^^^^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5756335Z   ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5757126Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.5757762Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.6196140Z ^[[1m^[[33mwarning^[[0m: `command-stream` (bin "command-stream") generated 1 warning (1 duplicate)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.6267064Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "pipeline") generated 1 warning (run `cargo clippy --fix --test "pipeline" -p command-stream -- ` to apply 1 suggestion)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.6450692Z ^[[1m^[[33mwarning^[[0m: `command-stream` (lib test) generated 10 warnings (10 duplicates)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.7138035Z ^[[1m^[[33mwarning^[[0m^[[1m: function `ctx_with_cwd` is never used^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.7138827Z   ^[[1m^[[94m--> ^[[0mtests/builtin_commands.rs:27:4
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.7139207Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.7139739Z ^[[1m^[[94m27^[[0m ^[[1m^[[94m|^[[0m fn ctx_with_cwd(args: Vec<&str>, cwd: PathBuf) -> CommandContext {
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.7140262Z    ^[[1m^[[94m|^[[0m    ^[[1m^[[33m^^^^^^^^^^^^^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.7140586Z    ^[[1m^[[94m|^[[0m
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.7141020Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.7141331Z 
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.7796909Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "builtin_commands") generated 3 warnings (run `cargo clippy --fix --test "builtin_commands" -p command-stream -- ` to apply 2 suggestions)
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.7798411Z ^[[1m^[[92m    Finished^[[0m `dev` profile [unoptimized + debuginfo] target(s) in 1.33s
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.8488948Z Post job cleanup.
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.9777314Z Cache hit occurred on the primary key Linux-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5, not saving cache.
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:19.9885221Z Post job cleanup.
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.0836854Z [command]/usr/bin/git version
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.0872629Z git version 2.54.0
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.0912449Z Temporarily overriding HOME='/home/runner/work/_temp/0ab6233b-23f2-4187-98cf-fedbdbb83131' before making global git config changes
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.0913627Z Adding repository directory to the temporary git global config as a safe directory
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.0925013Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.0958884Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.0991541Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.1226507Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.1249537Z http.https://github.com/.extraheader
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.1261627Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.1292567Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.1541056Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.1583056Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.1948548Z Cleaning up orphan processes
+Lint and format Rust	UNKNOWN STEP	2026-06-08T20:22:20.2235178Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test Rust (windows-latest)	UNKNOWN STEP	﻿2026-06-08T20:22:07.2638834Z Current runner version: '2.334.0'
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2666836Z ##[group]Runner Image Provisioner
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2667755Z Hosted Compute Agent
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2668475Z Version: 20260520.533
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2669129Z Commit: 189110e25284a9812c124fd27b339e2fb4f2f9db
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2670300Z Build Date: 2026-05-20T17:44:04Z
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2671393Z Worker ID: {aa10d16c-7c67-425a-8763-e68e8e9f1b84}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2672222Z Azure Region: westus
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2672866Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2674353Z ##[group]Operating System
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2675173Z Microsoft Windows Server 2025
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2675868Z 10.0.26100
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2676445Z Datacenter
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2677031Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2677627Z ##[group]Runner Image
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2678299Z Image: windows-2025-vs2026
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2678972Z Version: 20260525.121.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2682220Z Included Software: https://github.com/actions/runner-images/blob/win25-vs2026/20260525.121/images/windows/Windows2025-VS2026-Readme.md
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2684351Z Image Release: https://github.com/actions/runner-images/releases/tag/win25-vs2026%2F20260525.121
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2685594Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2689302Z ##[group]GITHUB_TOKEN Permissions
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2691666Z Actions: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2692314Z ArtifactMetadata: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2692993Z Attestations: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2693655Z Checks: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2694222Z CodeQuality: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2694852Z Contents: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2695442Z Deployments: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2696062Z Discussions: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2697000Z Issues: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2697573Z Metadata: read
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2698175Z Models: read
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2698804Z Packages: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2699468Z Pages: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2700072Z PullRequests: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2700727Z RepositoryProjects: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2701437Z SecurityEvents: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2702061Z Statuses: write
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2702707Z VulnerabilityAlerts: read
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2703374Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2705600Z Secret source: Actions
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2706442Z Prepare workflow directory
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.3277119Z Prepare all required actions
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.3322139Z Getting action download info
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:07.8328386Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.0011036Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.2097009Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.6694700Z Complete job name: Test Rust (windows-latest)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7964726Z ##[group]Run actions/checkout@v4
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7965913Z with:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7966554Z   repository: link-foundation/command-stream
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7973551Z   token: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7974126Z   ssh-strict: true
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7974717Z   ssh-user: git
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7975319Z   persist-credentials: true
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7975973Z   clean: true
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7976576Z   sparse-checkout-cone-mode: true
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7977267Z   fetch-depth: 1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7977860Z   fetch-tags: false
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7978466Z   show-progress: true
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7979080Z   lfs: false
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7979644Z   submodules: false
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7980249Z   set-safe-directory: true
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7981455Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7982010Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7982849Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7983612Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.7984192Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.9544063Z Syncing repository: link-foundation/command-stream
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.9546713Z ##[group]Getting Git version info
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:08.9550364Z Working directory is 'D:\a\command-stream\command-stream'
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.0267994Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.5726559Z git version 2.54.0.windows.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.5771588Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.5790112Z Temporarily overriding HOME='D:\a\_temp\a0457ca5-3efa-41f7-bcef-9aa615edde4e' before making global git config changes
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.5792804Z Adding repository directory to the temporary git global config as a safe directory
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.5800675Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\command-stream\command-stream
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.6085098Z Deleting the contents of 'D:\a\command-stream\command-stream'
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.6087958Z ##[group]Initializing the repository
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.6099523Z [command]"C:\Program Files\Git\bin\git.exe" init D:\a\command-stream\command-stream
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.6556172Z Initialized empty Git repository in D:/a/command-stream/command-stream/.git/
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.6597957Z [command]"C:\Program Files\Git\bin\git.exe" remote add origin https://github.com/link-foundation/command-stream
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.6863661Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.6865703Z ##[group]Disabling automatic garbage collection
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.6873034Z [command]"C:\Program Files\Git\bin\git.exe" config --local gc.auto 0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.7120827Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.7122338Z ##[group]Setting up auth
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.7133714Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:09.7392655Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:11.2155786Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:11.2424052Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:11.7093290Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:11.7357007Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:12.1837115Z [command]"C:\Program Files\Git\bin\git.exe" config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:12.2090506Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:12.2091107Z ##[group]Fetching the repository
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:12.2109029Z [command]"C:\Program Files\Git\bin\git.exe" -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +89d47cf62671f8e1c4813af51128b0b9e47b6fa6:refs/remotes/origin/main
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.0877092Z From https://github.com/link-foundation/command-stream
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.0877753Z  * [new ref]         89d47cf62671f8e1c4813af51128b0b9e47b6fa6 -> origin/main
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.1223641Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.1224263Z ##[group]Determining the checkout info
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.1225659Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.1238577Z [command]"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.1521024Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.1830180Z ##[group]Checking out the ref
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.1842405Z [command]"C:\Program Files\Git\bin\git.exe" checkout --progress --force -B main refs/remotes/origin/main
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.4014388Z Switched to a new branch 'main'
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.4029498Z branch 'main' set up to track 'origin/main'.
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.4090580Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.4384175Z [command]"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.4772198Z 89d47cf62671f8e1c4813af51128b0b9e47b6fa6
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5214291Z ##[group]Run dtolnay/rust-toolchain@stable
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5214633Z with:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5214797Z   toolchain: stable
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5214953Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5215114Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5215494Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5215718Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5215905Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5508484Z ##[group]Run : parse toolchain version
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5509044Z ^[[36;1m: parse toolchain version^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5509417Z ^[[36;1mif [[ -z $toolchain ]]; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5510198Z ^[[36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5511017Z ^[[36;1m  echo "'toolchain' is a required input" >&2^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5511404Z ^[[36;1m  exit 1^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5511862Z ^[[36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5512502Z ^[[36;1m  if [[ Windows == macOS ]]; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5513163Z ^[[36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5513805Z ^[[36;1m  else^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5514328Z ^[[36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5514900Z ^[[36;1m  fi^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5515305Z ^[[36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5516113Z ^[[36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5516652Z ^[[36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5517318Z ^[[36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5517971Z ^[[36;1melse^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5518281Z ^[[36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5518658Z ^[[36;1mfi^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5538221Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5538768Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5539004Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5539557Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5539951Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5540272Z   toolchain: stable
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.5540558Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6210363Z ##[group]Run : construct rustup command line
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6210661Z ^[[36;1m: construct rustup command line^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6211011Z ^[[36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6211498Z ^[[36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6211904Z ^[[36;1mecho "downgrade=" >> $GITHUB_OUTPUT^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6219831Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6220141Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6220314Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6220709Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6221197Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6221350Z   targets: 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6221496Z   components: 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6221651Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6849958Z ##[group]Run : set $CARGO_HOME
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6850207Z ^[[36;1m: set $CARGO_HOME^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6850479Z ^[[36;1mecho CARGO_HOME=${CARGO_HOME:-"$USERPROFILE\.cargo"} >> $GITHUB_ENV^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6858869Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6859187Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6859343Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6859867Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6860096Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.6862086Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7326932Z ##[group]Run : install rustup if needed on windows
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7327359Z ^[[36;1m: install rustup if needed on windows^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7327628Z ^[[36;1mif ! command -v rustup &>/dev/null; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7328256Z ^[[36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://win.rustup.rs/x86_64 --output 'D:\a\_temp\rustup-init.exe'^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7328926Z ^[[36;1m  'D:\a\_temp\rustup-init.exe' --default-toolchain none --no-modify-path -y^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7329278Z ^[[36;1m  echo "$CARGO_HOME\bin" >> $GITHUB_PATH^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7329504Z ^[[36;1mfi^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7337754Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7338077Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7338253Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7338607Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7338849Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7339019Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7339227Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7815832Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7816289Z ^[[36;1mrustup toolchain install stable --profile minimal --no-self-update^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7824165Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7824499Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7824662Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7825022Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7825258Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7825431Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7825653Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:14.7825842Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9769427Z info: syncing channel updates for stable-x86_64-pc-windows-msvc
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:18.4337444Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:18.4688589Z info: removing previous version of component clippy
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:18.4815446Z info: removing previous version of component rustfmt
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:18.4940793Z info: removing previous version of component rust-std for target x86_64-pc-windows-gnu
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:18.6057241Z info: removing previous version of component rust-std for target i686-pc-windows-msvc
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:18.6832177Z info: removing previous version of component cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7367586Z info: removing previous version of component rust-std
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8060553Z info: removing previous version of component rustc
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:19.1779499Z info: downloading 7 components
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7463461Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7716863Z   stable-x86_64-pc-windows-msvc updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.95.0 (59807616e 2026-04-14))
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7718582Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7935861Z ##[group]Run rustup default stable
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7936107Z ^[[36;1mrustup default stable^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7944075Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7944380Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7944530Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7944979Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7945220Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7945390Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.7945599Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9050716Z info: using existing install for stable-x86_64-pc-windows-msvc
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9137394Z info: default toolchain set to stable-x86_64-pc-windows-msvc
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9137673Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9310817Z   stable-x86_64-pc-windows-msvc unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9311109Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9489140Z ##[group]Run : create cachekey
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9489375Z ^[[36;1m: create cachekey^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9490561Z ^[[36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9491100Z ^[[36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9491483Z ^[[36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9499132Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9499437Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9499597Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9499962Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9500186Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9500361Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:30.9500571Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5976464Z ##[group]Run : disable incremental compilation
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5976756Z ^[[36;1m: disable incremental compilation^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5977019Z ^[[36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5977310Z ^[[36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5977540Z ^[[36;1mfi^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5985549Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5985867Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5986038Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5986357Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5986590Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5986761Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.5986965Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6389814Z ##[group]Run : enable colors in Cargo output
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6390091Z ^[[36;1m: enable colors in Cargo output^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6390342Z ^[[36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6390611Z ^[[36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6390837Z ^[[36;1mfi^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6397724Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6398040Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6398216Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6398520Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6398747Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6398931Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6399320Z   CARGO_INCREMENTAL: 0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6399631Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6794336Z ##[group]Run : enable Cargo sparse registry
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6794669Z ^[[36;1m: enable Cargo sparse registry^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6794964Z ^[[36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6796183Z ^[[36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "D:\a\_temp"/.implicit_cargo_registries_crates_io_protocol ]; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6797175Z ^[[36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6797663Z ^[[36;1m    touch "D:\a\_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6798099Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6798488Z ^[[36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6798882Z ^[[36;1m    touch "D:\a\_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6799234Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6799499Z ^[[36;1m  fi^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6799672Z ^[[36;1mfi^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6809697Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6810008Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6810213Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6810766Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6811305Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6811487Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6811729Z   CARGO_INCREMENTAL: 0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.6814152Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8523719Z ##[group]Run : work around spurious network errors in curl 8.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8524067Z ^[[36;1m: work around spurious network errors in curl 8.0^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8524500Z ^[[36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8524978Z ^[[36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8525332Z ^[[36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8525582Z ^[[36;1mfi^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8533864Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8534172Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8534324Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8534641Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8534857Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8535029Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8535236Z   CARGO_INCREMENTAL: 0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.8535417Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.9615544Z ##[group]Run rustc +stable --version --verbose
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.9615823Z ^[[36;1mrustc +stable --version --verbose^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.9623715Z shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.9624032Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.9624183Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.9624569Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.9624799Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.9624969Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.9625177Z   CARGO_INCREMENTAL: 0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:31.9625345Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.0290560Z rustc 1.96.0 (ac68faa20 2026-05-25)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.0291183Z binary: rustc
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.0291490Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.0291894Z commit-date: 2026-05-25
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.0292183Z host: x86_64-pc-windows-msvc
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.0292520Z release: 1.96.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.0292832Z LLVM version: 22.1.2
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1369857Z ##[group]Run actions/cache@v4
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1370104Z with:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1370314Z   path: ~/.cargo/registry
+Test Rust (windows-latest)	UNKNOWN STEP	~/.cargo/git
+Test Rust (windows-latest)	UNKNOWN STEP	rust/target
+Test Rust (windows-latest)	UNKNOWN STEP	
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1370682Z   key: Windows-cargo-d772d5ef62148b9647b7df8ad2e6112c4dbbe6dbea4c5acc334e4ea5c3fc0588
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1371037Z   restore-keys: Windows-cargo-
+Test Rust (windows-latest)	UNKNOWN STEP	
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1371235Z   enableCrossOsArchive: false
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1371436Z   fail-on-cache-miss: false
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1371609Z   lookup-only: false
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1371771Z   save-always: false
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1371915Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1372056Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1372355Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1372614Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1372777Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1372985Z   CARGO_INCREMENTAL: 0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.1373148Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:32.7205944Z Cache hit for: Windows-cargo-d772d5ef62148b9647b7df8ad2e6112c4dbbe6dbea4c5acc334e4ea5c3fc0588
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:34.0387338Z Received 33554432 of 179377678 (18.7%), 31.9 MBs/sec
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:35.1114342Z Received 134217728 of 179377678 (74.8%), 61.7 MBs/sec
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6325749Z Received 179377678 of 179377678 (100.0%), 65.9 MBs/sec
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6331698Z Cache Size: ~171 MB (179377678 B)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6391929Z [command]"C:\Program Files\Git\usr\bin\tar.exe" -xf D:/a/_temp/9f2239a7-e2fc-4903-8ead-cc93f2c05013/cache.tzst -P -C D:/a/command-stream/command-stream --force-local --use-compress-program "zstd -d"
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.8870259Z Cache restored successfully
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.9119709Z Cache restored from key: Windows-cargo-d772d5ef62148b9647b7df8ad2e6112c4dbbe6dbea4c5acc334e4ea5c3fc0588
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.9348474Z ##[group]Run cargo test --all-features --verbose
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.9348827Z ^[[36;1mcargo test --all-features --verbose^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.9691267Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.9691562Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.9691728Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.9692084Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.9692350Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.9692528Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.9692744Z   CARGO_INCREMENTAL: 0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:42.9692912Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8131869Z ^[[1m^[[92m       Fresh^[[0m unicode-ident v1.0.22
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8132229Z ^[[1m^[[92m       Fresh^[[0m cfg-if v1.0.4
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8132642Z ^[[1m^[[92m       Fresh^[[0m proc-macro2 v1.0.104
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8135064Z ^[[1m^[[92m       Fresh^[[0m windows-link v0.2.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8135941Z ^[[1m^[[92m       Fresh^[[0m quote v1.0.42
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8138356Z ^[[1m^[[92m       Fresh^[[0m memchr v2.7.6
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8139284Z ^[[1m^[[92m       Fresh^[[0m syn v2.0.111
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8140324Z ^[[1m^[[92m       Fresh^[[0m windows_x86_64_msvc v0.53.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8141520Z ^[[1m^[[92m       Fresh^[[0m windows-sys v0.61.2
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8142625Z ^[[1m^[[92m       Fresh^[[0m windows-targets v0.53.5
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8143457Z ^[[1m^[[92m       Fresh^[[0m scopeguard v1.2.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8144264Z ^[[1m^[[92m       Fresh^[[0m smallvec v1.15.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8145068Z ^[[1m^[[92m       Fresh^[[0m aho-corasick v1.1.4
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8145981Z ^[[1m^[[92m       Fresh^[[0m windows-sys v0.60.2
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8147226Z ^[[1m^[[92m       Fresh^[[0m parking_lot_core v0.9.12
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8148087Z ^[[1m^[[92m       Fresh^[[0m lock_api v0.4.14
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8149149Z ^[[1m^[[92m       Fresh^[[0m pin-project-lite v0.2.16
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8150033Z ^[[1m^[[92m       Fresh^[[0m regex-syntax v0.8.8
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8152228Z ^[[1m^[[92m       Fresh^[[0m autocfg v1.5.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8153084Z ^[[1m^[[92m       Fresh^[[0m socket2 v0.6.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8154003Z ^[[1m^[[92m       Fresh^[[0m regex-automata v0.4.13
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8156312Z ^[[1m^[[92m       Fresh^[[0m parking_lot v0.12.5
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8157226Z ^[[1m^[[92m       Fresh^[[0m mio v1.1.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8158108Z ^[[1m^[[92m       Fresh^[[0m tokio-macros v2.6.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8159200Z ^[[1m^[[92m       Fresh^[[0m cfg_aliases v0.2.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8163137Z ^[[1m^[[92m       Fresh^[[0m bytes v1.11.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8165485Z ^[[1m^[[92m       Fresh^[[0m tokio v1.48.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8167041Z ^[[1m^[[92m       Fresh^[[0m serde_core v1.0.228
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8172442Z ^[[1m^[[92m       Fresh^[[0m zmij v1.0.2
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8173302Z ^[[1m^[[92m       Fresh^[[0m num-traits v0.2.19
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8174165Z ^[[1m^[[92m       Fresh^[[0m libc v0.2.178
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8175196Z ^[[1m^[[92m       Fresh^[[0m serde_derive v1.0.228
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8176187Z ^[[1m^[[92m       Fresh^[[0m thiserror-impl v2.0.17
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8177277Z ^[[1m^[[92m       Fresh^[[0m env_home v0.1.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8178129Z ^[[1m^[[92m       Fresh^[[0m bitflags v2.10.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8179629Z ^[[1m^[[92m       Fresh^[[0m either v1.15.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8180440Z ^[[1m^[[92m       Fresh^[[0m itoa v1.0.17
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8183619Z ^[[1m^[[92m       Fresh^[[0m predicates-core v1.0.9
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8184155Z ^[[1m^[[92m       Fresh^[[0m winsafe v0.0.19
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8185373Z ^[[1m^[[92m       Fresh^[[0m futures-core v0.3.31
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8186041Z ^[[1m^[[92m       Fresh^[[0m once_cell v1.21.3
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8187302Z ^[[1m^[[92m       Fresh^[[0m which v7.0.3
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8188104Z ^[[1m^[[92m       Fresh^[[0m serde_json v1.0.148
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8189361Z ^[[1m^[[92m       Fresh^[[0m nix v0.29.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8190373Z ^[[1m^[[92m       Fresh^[[0m serde v1.0.228
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8191167Z ^[[1m^[[92m       Fresh^[[0m thiserror v2.0.17
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8192343Z ^[[1m^[[92m       Fresh^[[0m chrono v0.4.42
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8195796Z ^[[1m^[[92m       Fresh^[[0m regex v1.12.2
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8196307Z ^[[1m^[[92m       Fresh^[[0m filetime v0.2.26
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8196945Z ^[[1m^[[92m       Fresh^[[0m async-trait v0.1.89
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8197393Z ^[[1m^[[92m       Fresh^[[0m async-stream-impl v0.3.6
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8200791Z ^[[1m^[[92m       Fresh^[[0m glob v0.3.3
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8201317Z ^[[1m^[[92m       Fresh^[[0m termtree v0.5.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8202538Z ^[[1m^[[92m       Fresh^[[0m anstyle v1.0.13
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8203580Z ^[[1m^[[92m       Fresh^[[0m difflib v0.4.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8204472Z ^[[1m^[[92m       Fresh^[[0m predicates-tree v1.0.12
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8205457Z ^[[1m^[[92m       Fresh^[[0m async-stream v0.3.6
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8206448Z ^[[1m^[[92m       Fresh^[[0m predicates v3.1.3
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8207525Z ^[[1m^[[92m       Fresh^[[0m getrandom v0.3.4
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8208518Z ^[[1m^[[92m       Fresh^[[0m tokio-stream v0.1.17
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8209412Z ^[[1m^[[92m       Fresh^[[0m bstr v1.12.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8210471Z ^[[1m^[[92m       Fresh^[[0m wait-timeout v0.2.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8211288Z ^[[1m^[[92m       Fresh^[[0m fastrand v2.3.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8212228Z ^[[1m^[[92m       Fresh^[[0m tokio-test v0.4.4
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8214442Z ^[[1m^[[92m       Dirty^[[0m command-stream v0.9.5 (D:\a\command-stream\command-stream\rust): the file `src\commands\touch.rs` has changed (13425423734.384075000s, 5h 54m 43s after last build at 13425402451.236475600s)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8215820Z ^[[1m^[[92m   Compiling^[[0m command-stream v0.9.5 (D:\a\command-stream\command-stream\rust)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8216458Z ^[[1m^[[92m       Fresh^[[0m assert_cmd v2.1.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8216926Z ^[[1m^[[92m       Fresh^[[0m tempfile v3.24.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8232003Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name command_stream --edition=2021 src\lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=e229d81aedb34116 -C extra-filename=-f3cbbcb388f9e1e3 --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.8249006Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name command_stream --edition=2021 src\lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=f3c5f4c3167e3e5e -C extra-filename=-97916d2852bcd18c --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rmeta --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rmeta --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rmeta --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rmeta --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rmeta --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rmeta --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rmeta --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rmeta --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rmeta --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rmeta --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rmeta --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rmeta -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.9034253Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused import: `std::path::Path`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.9034947Z   ^[[1m^[[96m--> ^[[0msrc\commands\mod.rs:53:5
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.9035339Z    ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.9035797Z ^[[1m^[[96m53^[[0m ^[[1m^[[96m|^[[0m use std::path::Path;
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.9036237Z    ^[[1m^[[96m|^[[0m     ^[[1m^[[93m^^^^^^^^^^^^^^^^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.9036602Z    ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.9037179Z    ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:50.9037601Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2438002Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused variable: `e`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2438647Z   ^[[1m^[[96m--> ^[[0msrc\commands\touch.rs:33:24
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2439004Z    ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2439371Z ^[[1m^[[96m33^[[0m ^[[1m^[[96m|^[[0m             if let Err(e) =
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2440108Z    ^[[1m^[[96m|^[[0m                        ^[[1m^[[93m^^[[0m ^[[1m^[[93mhelp: if this is intentional, prefix it with an underscore: `_e`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2440709Z    ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2441255Z    ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2441683Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2991064Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused variable: `file_type`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2991663Z    ^[[1m^[[96m--> ^[[0msrc\commands\ls.rs:124:9
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2992033Z     ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2992888Z ^[[1m^[[96m124^[[0m ^[[1m^[[96m|^[[0m     let file_type = if metadata.is_dir() { "d" } else { "-" };
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2993791Z     ^[[1m^[[96m|^[[0m         ^[[1m^[[93m^^^^^^^^^^[[0m ^[[1m^[[93mhelp: if this is intentional, prefix it with an underscore: `_file_type`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.2995217Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.3348892Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: field `output_rx` is never read^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.3349525Z    ^[[1m^[[96m--> ^[[0msrc\lib.rs:184:5
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.3349884Z     ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.3350276Z ^[[1m^[[96m175^[[0m ^[[1m^[[96m|^[[0m pub struct ProcessRunner {
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.3350856Z     ^[[1m^[[96m|^[[0m            ^[[1m^[[96m-------------^[[0m ^[[1m^[[96mfield in this struct^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.3351326Z ^[[1m^[[96m...^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.3351976Z ^[[1m^[[96m184^[[0m ^[[1m^[[96m|^[[0m     output_rx: Option<mpsc::Receiver<StreamChunk>>,
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.3352498Z     ^[[1m^[[96m|^[[0m     ^[[1m^[[93m^^^^^^^^^^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.3352845Z     ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.3353398Z     ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:51.3353780Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:52.9014463Z ^[[1m^[[93mwarning^[[0m: `command-stream` (lib) generated 4 warnings (run `cargo fix --lib -p command-stream` to apply 3 suggestions)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:52.9056137Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name builtin_commands --edition=2021 tests\builtin_commands.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=a1d71a97756da732 -C extra-filename=-72dfe34a46d80ef2 --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:52.9992985Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name shell_parser --edition=2021 tests\shell_parser.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=50264555466cf62a -C extra-filename=-bbb42c4c7bece6a1 --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0135037Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused import: `cd`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0159620Z  ^[[1m^[[96m--> ^[[0mtests\builtin_commands.rs:6:20
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0188411Z   ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0190035Z ^[[1m^[[96m6^[[0m ^[[1m^[[96m|^[[0m     basename, cat, cd, cp, dirname, echo, env, exit, ls, mkdir, mv, pwd, rm, seq, sleep, test,
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0191067Z   ^[[1m^[[96m|^[[0m                    ^[[1m^[[93m^^^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0192398Z   ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0199620Z   ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0207159Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0208425Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused import: `command_stream::utils::CommandResult`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0209477Z  ^[[1m^[[96m--> ^[[0mtests\builtin_commands.rs:9:5
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0301157Z   ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0302666Z ^[[1m^[[96m9^[[0m ^[[1m^[[96m|^[[0m use command_stream::utils::CommandResult;
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0303455Z   ^[[1m^[[96m|^[[0m     ^[[1m^[[93m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.0303926Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.1527803Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name command_stream --edition=2021 src\main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=37279a68711445a8 --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2211905Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused imports: `ProcessRunner` and `RunOptions`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2304467Z  ^[[1m^[[96m--> ^[[0msrc\main.rs:5:27
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2306148Z   ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2307202Z ^[[1m^[[96m5^[[0m ^[[1m^[[96m|^[[0m use command_stream::{run, ProcessRunner, RunOptions};
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2307863Z   ^[[1m^[[96m|^[[0m                           ^[[1m^[[93m^^^^^^^^^^^^^^[[0m  ^[[1m^[[93m^^^^^^^^^^^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2308709Z   ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2368249Z   ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2384431Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2508828Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: function `ctx_with_cwd` is never used^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2510070Z   ^[[1m^[[96m--> ^[[0mtests\builtin_commands.rs:27:4
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2510765Z    ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2528801Z ^[[1m^[[96m27^[[0m ^[[1m^[[96m|^[[0m fn ctx_with_cwd(args: Vec<&str>, cwd: PathBuf) -> CommandContext {
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2643866Z    ^[[1m^[[96m|^[[0m    ^[[1m^[[93m^^^^^^^^^^^^^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2703851Z    ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2840480Z    ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:53.2861714Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.0559820Z ^[[1m^[[93mwarning^[[0m: `command-stream` (bin "command-stream") generated 1 warning (run `cargo fix --bin "command-stream" -p command-stream` to apply 1 suggestion)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.0630004Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name macros --edition=2021 tests\macros.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=6d64613f050d6cd5 -C extra-filename=-cabb1a5be04d016f --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.0655357Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name utils --edition=2021 tests\utils.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=b7438cb5064b0342 -C extra-filename=-9f3a7a93e65803f8 --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.0668490Z ^[[1m^[[93mwarning^[[0m: `command-stream` (lib test) generated 4 warnings (4 duplicates)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.0682343Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name pipeline --edition=2021 tests\pipeline.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=cf6bfb4c4b3ff898 -C extra-filename=-575ce539fc44aeff --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.0896154Z ^[[1m^[[93mwarning^[[0m: `command-stream` (test "builtin_commands") generated 3 warnings (run `cargo fix --test "builtin_commands" -p command-stream` to apply 2 suggestions)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.0922937Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name command_stream --edition=2021 src\main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=4744d65645c20e9e -C extra-filename=-6ee8b45096d3f3f2 --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.1472998Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused imports: `PipelineExt`, `ProcessRunner`, and `RunOptions`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.1528111Z  ^[[1m^[[96m--> ^[[0mtests\pipeline.rs:3:32
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.1595218Z   ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.1703015Z ^[[1m^[[96m3^[[0m ^[[1m^[[96m|^[[0m use command_stream::{Pipeline, PipelineExt, ProcessRunner, RunOptions};
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.1862442Z   ^[[1m^[[96m|^[[0m                                ^[[1m^[[93m^^^^^^^^^^^^[[0m  ^[[1m^[[93m^^^^^^^^^^^^^^[[0m  ^[[1m^[[93m^^^^^^^^^^^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.2087017Z   ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.2179487Z   ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.2201130Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.4687669Z ^[[1m^[[93mwarning^[[0m: `command-stream` (bin "command-stream" test) generated 1 warning (1 duplicate)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.4732645Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name process_runner --edition=2021 tests\process_runner.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=4ec986a5096da761 -C extra-filename=-3b31ff35e06942f5 --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.5572932Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused import: `std::path::PathBuf`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.5592445Z  ^[[1m^[[96m--> ^[[0mtests\process_runner.rs:7:5
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.5632511Z   ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.5664206Z ^[[1m^[[96m7^[[0m ^[[1m^[[96m|^[[0m use std::path::PathBuf;
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.5666916Z   ^[[1m^[[96m|^[[0m     ^[[1m^[[93m^^^^^^^^^^^^^^^^^^^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.5668655Z   ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.5916582Z   ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:56.5973816Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:57.2134174Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name events --edition=2021 tests\events.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=73a4a09475d1754e -C extra-filename=-03c23da7c5dbab4e --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.3119557Z ^[[1m^[[93mwarning^[[0m: `command-stream` (test "pipeline") generated 1 warning (run `cargo fix --test "pipeline" -p command-stream` to apply 1 suggestion)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.3420634Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name stream --edition=2021 tests\stream.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=90ccc78ed941b75a -C extra-filename=-8e44ef4d1f909e57 --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.4837521Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused import: `AsyncIterator`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.4843184Z  ^[[1m^[[96m--> ^[[0mtests\stream.rs:3:22
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.4843727Z   ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.4844550Z ^[[1m^[[96m3^[[0m ^[[1m^[[96m|^[[0m use command_stream::{AsyncIterator, OutputChunk, StreamingRunner};
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.4845168Z   ^[[1m^[[96m|^[[0m                      ^[[1m^[[93m^^^^^^^^^^^^^^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.4845694Z   ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.4846289Z   ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.4846852Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.6243919Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name virtual_commands --edition=2021 tests\virtual_commands.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=50f12dfd4b9bea01 -C extra-filename=-82dd968047556f15 --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.7358885Z ^[[1m^[[93mwarning^[[0m: `command-stream` (test "process_runner") generated 1 warning (run `cargo fix --test "process_runner" -p command-stream` to apply 1 suggestion)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:58.7404771Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe --crate-name state --edition=2021 tests\state.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" -C metadata=4aaaa8fa5d485eb9 -C extra-filename=-fd5663c4734d7d59 --out-dir D:\a\command-stream\command-stream\rust\target\debug\deps -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:22:59.6652570Z ^[[1m^[[93mwarning^[[0m: `command-stream` (test "stream") generated 1 warning
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2643427Z ^[[1m^[[92m    Finished^[[0m `test` profile [unoptimized + debuginfo] target(s) in 9.66s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2719762Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\command_stream-f3cbbcb388f9e1e3.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2810386Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2810767Z running 112 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2816290Z test ansi::tests::test_ansi_config_default ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2818312Z test ansi::tests::test_ansi_config_strip_control_only ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2853168Z test ansi::tests::test_strip_ansi ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2854791Z test ansi::tests::test_ansi_config_strip_all ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2855886Z test ansi::tests::test_strip_all ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2856818Z test ansi::tests::test_ansi_config_strip_ansi_only ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2857624Z test ansi::tests::test_strip_control_chars ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2859628Z test ansi::tests::test_strip_control_chars_preserves_whitespace ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2862453Z test ansi::tests::test_strip_ansi_multiple_codes ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2869308Z test commands::basename::tests::test_basename_simple ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2869919Z test commands::basename::tests::test_basename_with_suffix ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2870586Z test commands::basename::tests::test_basename_no_path ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2873974Z test commands::cat::tests::test_cat_stdin ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2875164Z test commands::cat::tests::test_cat_nonexistent ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2878010Z test commands::cat::tests::test_cat_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2885639Z test commands::cd::tests::test_cd_to_nonexistent ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2887993Z test commands::cat::tests::test_cat_multiple_files ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2890845Z test commands::cd::tests::test_cd_to_temp ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2897220Z test commands::dirname::tests::test_dirname_just_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2912700Z test commands::cp::tests::test_cp_directory_without_recursive ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2913279Z test commands::dirname::tests::test_dirname_root ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2920055Z test commands::dirname::tests::test_dirname_simple ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2920610Z test commands::echo::tests::test_echo_empty ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2928892Z test commands::echo::tests::test_echo_simple ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2929689Z test commands::env::tests::test_env ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2930327Z test commands::cp::tests::test_cp_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2933667Z test commands::exit::tests::test_exit_default ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2934335Z test commands::exit::tests::test_exit_with_code ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2935134Z test commands::cp::tests::test_cp_directory_recursive ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2937533Z test commands::ls::tests::test_ls_current_dir ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2940242Z test commands::mkdir::tests::test_mkdir_missing_operand ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2958159Z test commands::ls::tests::test_ls_with_path ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2961082Z test commands::mkdir::tests::test_mkdir_simple ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2965769Z test commands::ls::tests::test_ls_hidden_files ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2979796Z test commands::mv::tests::test_mv_nonexistent ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2984055Z test commands::mkdir::tests::test_mkdir_with_parents ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2986334Z test commands::pwd::tests::test_pwd ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2988664Z test commands::mv::tests::test_mv_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2989147Z test commands::r#false::tests::test_false ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2991587Z test commands::r#true::tests::test_true ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2993682Z test commands::mv::tests::test_mv_directory ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2996789Z test commands::rm::tests::test_rm_nonexistent_force ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.2999358Z test commands::rm::tests::test_rm_nonexistent_no_force ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3002044Z test commands::seq::tests::test_seq_descending ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3005028Z test commands::seq::tests::test_seq_single_arg ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3007167Z test commands::seq::tests::test_seq_three_args ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3007786Z test commands::rm::tests::test_rm_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3010235Z test commands::seq::tests::test_seq_two_args ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3012809Z test commands::sleep::tests::test_sleep_invalid ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3013598Z test commands::seq::tests::test_seq_zero_increment ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3014332Z test commands::rm::tests::test_rm_directory_recursive ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3015679Z test commands::sleep::tests::test_sleep_negative ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3017988Z test commands::test::tests::test_empty_string ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3021331Z test commands::test::tests::test_file_not_exists ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3024643Z test commands::test::tests::test_non_empty_string ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3027422Z test commands::test::tests::test_numeric_comparison ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3029318Z test commands::test::tests::test_file_exists ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3031144Z test commands::test::tests::test_string_equality ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3032482Z test commands::test::tests::test_string_inequality ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3035423Z test commands::touch::tests::test_touch_missing_operand ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3046186Z test commands::touch::tests::test_touch_existing_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3047832Z test commands::touch::tests::test_touch_new_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3071102Z test commands::which::tests::test_which_existing_command ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3074427Z test commands::yes::tests::test_yes_custom_string ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3077969Z test commands::yes::tests::test_yes_with_cancellation ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3081501Z test events::tests::test_emit_basic ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3085037Z test events::tests::test_listener_count ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3087999Z test events::tests::test_multiple_events ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3090838Z test events::tests::test_off ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3093688Z test events::tests::test_once ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3106352Z test quote::tests::test_needs_quoting ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3114480Z test quote::tests::test_quote_all ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3116380Z test quote::tests::test_quote_already_quoted ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3118089Z test quote::tests::test_quote_empty ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3129004Z test commands::which::tests::test_which_nonexistent_command ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3129537Z test quote::tests::test_quote_safe_chars ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3134745Z test quote::tests::test_quote_with_newlines ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3139648Z test quote::tests::test_quote_special_chars ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3140144Z test quote::tests::test_quote_with_tabs ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3141934Z test shell_parser::tests::test_needs_real_shell ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3142859Z test shell_parser::tests::test_parse_pipeline ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3144294Z test commands::sleep::tests::test_sleep_zero ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3144864Z test shell_parser::tests::test_parse_sequence ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3145953Z test shell_parser::tests::test_parse_simple_command ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3147168Z test shell_parser::tests::test_parse_subshell ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3148659Z test shell_parser::tests::test_parse_with_redirect ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3149293Z test shell_parser::tests::test_tokenize_simple_command ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3150388Z test shell_parser::tests::test_tokenize_with_operators ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3151113Z test shell_parser::tests::test_tokenize_with_pipe ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3151601Z test shell_parser::tests::test_tokenize_with_quotes ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3154472Z test state::tests::test_global_state_reset ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3155557Z test state::tests::test_global_state_virtual_commands ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3156642Z test state::tests::test_global_state_runners ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3157885Z test state::tests::test_shell_settings_default ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3158729Z test state::tests::test_shell_settings_set ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3160186Z test trace::tests::test_trace_disabled_by_default ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3161066Z test trace::tests::test_trace_enabled_by_verbose ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3163270Z test trace::tests::test_trace_explicit_false_overrides_verbose ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3164590Z test utils::tests::test_command_result_error ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3165450Z test trace::tests::test_trace_explicit_true ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3166675Z test utils::tests::test_command_result_error_with_code ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3167200Z test utils::tests::test_command_result_success ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3167697Z test utils::tests::test_invalid_argument_error ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3168232Z test utils::tests::test_missing_operand_error ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3168997Z test utils::tests::test_reexported_ansi_config ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3170519Z test utils::tests::test_resolve_path_absolute ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3172455Z test utils::tests::test_resolve_path_relative ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3174576Z test utils::tests::test_validate_args_missing ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3175065Z test utils::tests::test_reexported_ansi_utils ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3176543Z test utils::tests::test_validate_args_success ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.3177689Z test utils::tests::test_reexported_quote ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4092537Z test commands::sleep::tests::test_sleep_short ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4092842Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4093524Z test result: ok. 112 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4093816Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4115764Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\command_stream-6ee8b45096d3f3f2.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4196812Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4197163Z running 0 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4197508Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4197804Z test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4198089Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4210382Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\builtin_commands-72dfe34a46d80ef2.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4285900Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4286284Z running 45 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4303170Z test test_cat_nonexistent_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4304370Z test test_basename_with_suffix ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4305213Z test test_basename ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4305749Z test test_cat_from_stdin ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4309699Z test test_dirname ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4313388Z test test_echo_basic ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4320194Z test test_echo_empty ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4325177Z test test_echo_with_e_flag ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4333763Z test test_cat_read_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4339920Z test test_echo_with_n_flag ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4343419Z test test_env_list ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4346181Z test test_exit_default ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4350561Z test test_exit_with_code ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4351479Z test test_false_command ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4352131Z test test_cp_copy_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4356637Z test test_cp_recursive ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4376736Z test test_ls_with_l_flag ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4379166Z test test_mkdir_create_directory ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4385604Z test test_ls_with_a_flag ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4388871Z test test_ls_list_directory ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4394152Z test test_pwd_returns_current_directory ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4408605Z test test_mv_rename_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4409192Z test test_mkdir_with_p_flag ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4413270Z test test_rm_fail_on_directory ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4413888Z test test_rm_force ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4418306Z test test_seq_range ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4420389Z test test_mv_to_directory ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4423381Z test test_seq_simple ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4425867Z test test_seq_with_increment ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4432491Z test test_rm_recursive ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4433180Z test test_rm_remove_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4436671Z test test_test_file_not_exists ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4441208Z test test_test_file_exists ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4444397Z test test_test_string_empty ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4445500Z test test_test_is_directory ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4448721Z test test_test_string_equals ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4449113Z test test_test_string_not_empty ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4452505Z test test_test_is_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4453836Z test test_test_string_not_equals ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4456803Z test test_true_command ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4460061Z test test_which_builtin ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4464268Z test test_touch_create_file ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4464514Z test test_yes_with_cancel ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.4568304Z test test_touch_update_timestamp ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5514475Z test test_sleep ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5514635Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5515045Z test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5515509Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5534516Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\events-03c23da7c5dbab4e.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5615767Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5615977Z running 8 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5633581Z test test_stream_emitter_different_events ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5634982Z test test_stream_emitter_multiple_listeners ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5635748Z test test_stream_emitter_creation ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5636344Z test test_event_data_variants ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5637311Z test test_stream_emitter_off ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5639193Z test test_stream_emitter_on_emit ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5640367Z test test_stream_emitter_once ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5640885Z test test_stream_emitter_remove_all_listeners ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5641129Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5641328Z test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5641604Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5654539Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\macros-cabb1a5be04d016f.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5731436Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5731642Z running 9 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5754244Z test test_cmd_macro_simple ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5782272Z test test_cmd_macro_with_interpolation ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5782712Z test test_cmd_macro_with_numbers ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5783786Z test test_cmd_macro_with_special_chars ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5784657Z test test_cmd_macro_with_multiple_interpolations ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5787426Z test test_cs_macro_alias ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5787758Z test test_s_macro_alias ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5789379Z test test_sh_macro_alias ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5792295Z test test_s_macro_with_interpolation ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5792555Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5792764Z test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5793033Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5807702Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\pipeline-575ce539fc44aeff.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5881186Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5881369Z running 7 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5900630Z test test_pipeline_empty ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5901748Z test test_pipeline_failure_propagation ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5902179Z test test_pipeline_builder_pattern ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5903249Z test test_pipeline_simple ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.5905942Z test test_pipeline_with_stdin ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6431301Z test test_pipeline_two_commands ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6671761Z test test_pipeline_three_commands ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6672049Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6672271Z test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6672552Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6688391Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\process_runner-3b31ff35e06942f5.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6764146Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6764367Z running 23 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6785158Z test test_create_and_run ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6785535Z test test_command_with_arguments ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6789596Z test test_exec_with_options ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6790194Z test test_echo_with_multiple_words ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6792264Z test test_custom_working_directory ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6794070Z test test_exit_code_zero ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6794912Z test test_exit_code_nonzero ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6797307Z test test_false_command_returns_nonzero ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6798422Z test test_process_runner_basic ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6802018Z test test_process_runner_is_finished ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6802394Z test test_process_runner_result ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6807633Z test test_process_runner_with_capture ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6808147Z test test_simple_echo ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6812220Z test test_stdin_content ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6812584Z test test_stderr_capture ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6816489Z test test_virtual_echo ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6816835Z test test_true_command_returns_zero ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6820368Z test test_virtual_false ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6820696Z test test_virtual_pwd ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.6825086Z test test_virtual_true ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.7028802Z test test_custom_environment_variable ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:00.7351378Z test test_virtual_sleep ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.6948527Z test test_kill_process ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.6948746Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.6948964Z test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 10.02s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.6949249Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.6970601Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\shell_parser-bbb42c4c7bece6a1.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7053124Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7053300Z running 30 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7057833Z test test_needs_real_shell_here_document ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7058279Z test test_needs_real_shell_glob_patterns ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7059553Z test test_needs_real_shell_command_substitution ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7060582Z test test_needs_real_shell_combined_redirect ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7061703Z test test_needs_real_shell_simple_commands ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7062424Z test test_needs_real_shell_stderr_redirect ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7063242Z test test_needs_real_shell_variable_expansion ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7063883Z test test_parse_command_with_quoted_args ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7065588Z test test_parse_pipeline ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7066127Z test test_parse_complex_pipeline_and_sequence ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7067543Z test test_parse_sequence_mixed ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7068296Z test test_parse_sequence_with_and ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7068966Z test test_parse_sequence_with_or ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7069678Z test test_parse_simple_command ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7070055Z test test_parse_subshell_with_sequence ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7072091Z test test_parse_subshell ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7072491Z test test_parse_with_redirect_append ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7073922Z test test_tokenize_double_quoted_string ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7074875Z test test_parse_with_redirect_out ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7075730Z test test_tokenize_mixed_operators ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7076766Z test test_tokenize_simple_command ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7077504Z test test_tokenize_single_quoted_string ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7077893Z test test_tokenize_with_and_operator ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7079267Z test test_tokenize_with_append_redirect ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7079852Z test test_tokenize_with_input_redirect ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7080715Z test test_tokenize_with_or_operator ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7081797Z test test_tokenize_with_parentheses ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7082221Z test test_tokenize_with_pipe ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7082556Z test test_tokenize_with_redirect ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7082912Z test test_tokenize_with_semicolon ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7083125Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7083439Z test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7083864Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7099597Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\state-fd5663c4734d7d59.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7175913Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7176211Z running 13 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7180689Z test test_global_state_default ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7189842Z test test_global_state_initial_cwd ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7190678Z test test_global_state_runner_registration ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7191274Z test test_global_state_shell_settings ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7191747Z test test_global_state_reset ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7206967Z test test_global_state_virtual_commands ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7207968Z test test_global_state_signal_handlers ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7208312Z test test_shell_settings_default ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7208634Z test test_global_state_with_shell_settings ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7208989Z test test_shell_settings_enable_disable ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7209342Z test test_shell_settings_reset ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7209966Z test test_shell_settings_set_long_names ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7210237Z test test_shell_settings_set_short_flags ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7210521Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7210725Z test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7210989Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7215229Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\stream-8e44ef4d1f909e57.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7293254Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7293471Z running 8 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7429088Z test test_streaming_exit_code ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7437840Z test test_streaming_collect_stdout ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7438344Z test test_output_stream_chunks ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7444270Z test test_streaming_runner_basic ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7536438Z test test_streaming_runner_cwd ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7709664Z test test_streaming_runner_with_stdin ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7928438Z test test_streaming_runner_env ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7939614Z test test_streaming_stderr ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7939831Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7940142Z test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.06s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7940602Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.7957587Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\utils-9f3a7a93e65803f8.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8038760Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8039306Z running 35 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8043505Z test test_ansi_config_default ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8044847Z test test_ansi_config_process_preserve_all ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8046629Z test test_command_result_error ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8048409Z test test_ansi_config_process_strip_control_only ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8049573Z test test_command_result_error_with_code ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8051358Z test test_command_result_success ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8052766Z test test_command_result_success_empty ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8056431Z test test_missing_operand_error ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8056959Z test test_invalid_argument_error ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8059814Z test test_quote_already_double_quoted ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8060599Z test test_quote_already_single_quoted ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8063679Z test test_quote_empty_string ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8072897Z test test_quote_path ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8074305Z test test_quote_newline ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8074709Z test test_ansi_config_process_strip_ansi_only ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8076818Z test test_ansi_config_process_strip_all ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8081523Z test test_quote_simple_string ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8083920Z test test_quote_with_single_quote ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8086452Z test test_quote_special_characters ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8086955Z test test_resolve_path_absolute ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8089130Z test test_quote_with_spaces ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8090698Z test test_quote_safe_characters ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8091238Z test test_resolve_path_relative_with_cwd ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8091657Z test test_resolve_path_relative_without_cwd ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8097221Z test test_strip_all ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8098380Z test test_strip_ansi_basic ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8099054Z test test_strip_ansi_color_codes ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8099929Z test test_strip_ansi_multiple ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8101537Z test test_strip_control_chars_basic ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8103300Z test test_strip_control_chars_preserve_carriage_return ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8104026Z test test_strip_control_chars_preserve_newline ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8104921Z test test_strip_control_chars_preserve_tab ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8105542Z test test_strip_ansi_no_sequences ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8106114Z test test_validate_args_insufficient ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8106490Z test test_validate_args_sufficient ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8106648Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8107096Z test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8107367Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8122745Z ^[[1m^[[92m     Running^[[0m `D:\a\command-stream\command-stream\rust\target\debug\deps\virtual_commands-82dd968047556f15.exe`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8202498Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8202722Z running 20 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8207041Z test test_command_context_is_cancelled_default ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8208421Z test test_command_context_new ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8209135Z test test_command_context_is_cancelled_with_fn ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8209546Z test test_command_context_get_cwd ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8210254Z test test_command_context_with_cwd ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8220564Z test test_enable_virtual_commands ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8223431Z test test_disable_virtual_commands ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8224053Z test test_execute_virtual_echo ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8224621Z test test_execute_echo_with_n_flag ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8225331Z test test_execute_virtual_exit ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8228293Z test test_execute_virtual_false ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.8228985Z test test_execute_virtual_pwd ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9329280Z test test_execute_virtual_sleep ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9329854Z test test_execute_virtual_true ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9331261Z test test_execute_virtual_which ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9332319Z test test_process_runner_virtual_echo ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9332734Z test test_registry_contains ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9334459Z test test_registry_new ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9334912Z test test_process_runner_virtual_pwd ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9335277Z test test_virtual_commands_default_enabled ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9335541Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9335844Z test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9336131Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9354733Z ^[[1m^[[92m   Doc-tests^[[0m command_stream
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:10.9364232Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustdoc.exe --edition=2021 --crate-type lib --color always --crate-name command_stream --test src\lib.rs --test-run-directory D:\a\command-stream\command-stream\rust -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps -C embed-bitcode=no --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" --error-format human`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:11.0299872Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:11.0300383Z running 13 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:11.0304900Z test src\events.rs - events::StreamEmitter::on (line 93) ... ignored
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:11.1413831Z test src\lib.rs - (line 38) - compile ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:11.1489863Z test src\macros.rs - macros (line 17) - compile ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:11.3374172Z test src\pipeline.rs - pipeline (line 9) - compile ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:11.3606534Z test src\macros.rs - macros::cmd (line 84) - compile ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:12.0057823Z test src\ansi.rs - ansi::AnsiUtils::strip_control_chars (line 37) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:12.1083031Z test src\ansi.rs - ansi::AnsiUtils::strip_ansi (line 17) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:12.2674722Z test src\stream.rs - stream (line 8) - compile ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:12.3115098Z test src\quote.rs - quote::quote (line 13) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:12.5335690Z test src\quote.rs - quote::needs_quoting (line 88) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.0610533Z test src\quote.rs - quote::quote_all (line 67) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.1192154Z test src\trace.rs - trace::trace_lazy (line 55) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.1342857Z test src\trace.rs - trace::trace (line 33) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.1343115Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.1343335Z test result: ok. 12 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.10s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.1343607Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.4023496Z ##[group]Run cargo test --doc --all-features --verbose
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.4023869Z ^[[36;1mcargo test --doc --all-features --verbose^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.4072722Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.4073015Z env:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.4073177Z   CARGO_TERM_COLOR: always
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.4073506Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.4073743Z   CARGO_TOKEN: ***
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.4074012Z   CARGO_HOME: C:\Users\runneradmin\.cargo
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.4074353Z   CARGO_INCREMENTAL: 0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.4074615Z ##[endgroup]
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7307542Z ^[[1m^[[92m       Fresh^[[0m unicode-ident v1.0.22
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7310058Z ^[[1m^[[92m       Fresh^[[0m proc-macro2 v1.0.104
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7311069Z ^[[1m^[[92m       Fresh^[[0m windows-link v0.2.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7311924Z ^[[1m^[[92m       Fresh^[[0m cfg-if v1.0.4
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7312790Z ^[[1m^[[92m       Fresh^[[0m quote v1.0.42
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7313712Z ^[[1m^[[92m       Fresh^[[0m memchr v2.7.6
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7315795Z ^[[1m^[[92m       Fresh^[[0m syn v2.0.111
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7316780Z ^[[1m^[[92m       Fresh^[[0m windows_x86_64_msvc v0.53.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7317668Z ^[[1m^[[92m       Fresh^[[0m windows-sys v0.61.2
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7318600Z ^[[1m^[[92m       Fresh^[[0m windows-targets v0.53.5
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7319405Z ^[[1m^[[92m       Fresh^[[0m smallvec v1.15.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7320275Z ^[[1m^[[92m       Fresh^[[0m scopeguard v1.2.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7321488Z ^[[1m^[[92m       Fresh^[[0m aho-corasick v1.1.4
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7321975Z ^[[1m^[[92m       Fresh^[[0m windows-sys v0.60.2
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7323311Z ^[[1m^[[92m       Fresh^[[0m lock_api v0.4.14
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7324181Z ^[[1m^[[92m       Fresh^[[0m parking_lot_core v0.9.12
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7324968Z ^[[1m^[[92m       Fresh^[[0m regex-syntax v0.8.8
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7325853Z ^[[1m^[[92m       Fresh^[[0m autocfg v1.5.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7328237Z ^[[1m^[[92m       Fresh^[[0m pin-project-lite v0.2.16
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7329105Z ^[[1m^[[92m       Fresh^[[0m regex-automata v0.4.13
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7331331Z ^[[1m^[[92m       Fresh^[[0m socket2 v0.6.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7332192Z ^[[1m^[[92m       Fresh^[[0m parking_lot v0.12.5
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7333030Z ^[[1m^[[92m       Fresh^[[0m mio v1.1.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7333953Z ^[[1m^[[92m       Fresh^[[0m tokio-macros v2.6.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7336142Z ^[[1m^[[92m       Fresh^[[0m bytes v1.11.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7337010Z ^[[1m^[[92m       Fresh^[[0m cfg_aliases v0.2.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7339045Z ^[[1m^[[92m       Fresh^[[0m tokio v1.48.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7341784Z ^[[1m^[[92m       Fresh^[[0m serde_core v1.0.228
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7345182Z ^[[1m^[[92m       Fresh^[[0m predicates-core v1.0.9
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7348859Z ^[[1m^[[92m       Fresh^[[0m futures-core v0.3.31
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7349669Z ^[[1m^[[92m       Fresh^[[0m num-traits v0.2.19
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7350512Z ^[[1m^[[92m       Fresh^[[0m libc v0.2.178
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7351382Z ^[[1m^[[92m       Fresh^[[0m zmij v1.0.2
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7352179Z ^[[1m^[[92m       Fresh^[[0m thiserror-impl v2.0.17
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7353265Z ^[[1m^[[92m       Fresh^[[0m serde_derive v1.0.228
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7354346Z ^[[1m^[[92m       Fresh^[[0m async-stream-impl v0.3.6
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7355407Z ^[[1m^[[92m       Fresh^[[0m itoa v1.0.17
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7356170Z ^[[1m^[[92m       Fresh^[[0m either v1.15.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7356940Z ^[[1m^[[92m       Fresh^[[0m bitflags v2.10.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7357742Z ^[[1m^[[92m       Fresh^[[0m difflib v0.4.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7358537Z ^[[1m^[[92m       Fresh^[[0m env_home v0.1.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7359307Z ^[[1m^[[92m       Fresh^[[0m anstyle v1.0.13
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7360176Z ^[[1m^[[92m       Fresh^[[0m once_cell v1.21.3
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7362374Z ^[[1m^[[92m       Fresh^[[0m winsafe v0.0.19
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7363263Z ^[[1m^[[92m       Fresh^[[0m termtree v0.5.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7364209Z ^[[1m^[[92m       Fresh^[[0m predicates v3.1.3
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7367142Z ^[[1m^[[92m       Fresh^[[0m which v7.0.3
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7367629Z ^[[1m^[[92m       Fresh^[[0m predicates-tree v1.0.12
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7367919Z ^[[1m^[[92m       Fresh^[[0m serde_json v1.0.148
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7369467Z ^[[1m^[[92m       Fresh^[[0m nix v0.29.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7370473Z ^[[1m^[[92m       Fresh^[[0m async-stream v0.3.6
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7371079Z ^[[1m^[[92m       Fresh^[[0m serde v1.0.228
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7372154Z ^[[1m^[[92m       Fresh^[[0m thiserror v2.0.17
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7373157Z ^[[1m^[[92m       Fresh^[[0m chrono v0.4.42
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7374358Z ^[[1m^[[92m       Fresh^[[0m getrandom v0.3.4
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7375695Z ^[[1m^[[92m       Fresh^[[0m tokio-stream v0.1.17
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7376616Z ^[[1m^[[92m       Fresh^[[0m regex v1.12.2
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7377703Z ^[[1m^[[92m       Fresh^[[0m bstr v1.12.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7378685Z ^[[1m^[[92m       Fresh^[[0m filetime v0.2.26
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7379761Z ^[[1m^[[92m       Fresh^[[0m async-trait v0.1.89
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7381377Z ^[[1m^[[92m       Fresh^[[0m wait-timeout v0.2.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7382448Z ^[[1m^[[92m       Fresh^[[0m glob v0.3.3
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7383532Z ^[[1m^[[92m       Fresh^[[0m fastrand v2.3.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7384648Z ^[[1m^[[92m       Fresh^[[0m assert_cmd v2.1.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7385956Z ^[[1m^[[92m       Fresh^[[0m tokio-test v0.4.4
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7389100Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused import: `std::path::Path`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7389696Z   ^[[1m^[[96m--> ^[[0msrc\commands\mod.rs:53:5
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7390038Z    ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7390409Z ^[[1m^[[96m53^[[0m ^[[1m^[[96m|^[[0m use std::path::Path;
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7390745Z    ^[[1m^[[96m|^[[0m     ^[[1m^[[93m^^^^^^^^^^^^^^^^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7391168Z    ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7391695Z    ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7392110Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7392257Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused variable: `e`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7392549Z   ^[[1m^[[96m--> ^[[0msrc\commands\touch.rs:33:24
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7392774Z    ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7392995Z ^[[1m^[[96m33^[[0m ^[[1m^[[96m|^[[0m             if let Err(e) =
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7393438Z    ^[[1m^[[96m|^[[0m                        ^[[1m^[[93m^^[[0m ^[[1m^[[93mhelp: if this is intentional, prefix it with an underscore: `_e`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7394090Z    ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7394707Z    ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7395155Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7395383Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: unused variable: `file_type`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7395778Z    ^[[1m^[[96m--> ^[[0msrc\commands\ls.rs:124:9
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7396112Z     ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7396781Z ^[[1m^[[96m124^[[0m ^[[1m^[[96m|^[[0m     let file_type = if metadata.is_dir() { "d" } else { "-" };
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7397359Z     ^[[1m^[[96m|^[[0m         ^[[1m^[[93m^^^^^^^^^^[[0m ^[[1m^[[93mhelp: if this is intentional, prefix it with an underscore: `_file_type`^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7397650Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7397830Z ^[[1m^[[93mwarning^[[0m^[[1m^[[97m: field `output_rx` is never read^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7398125Z    ^[[1m^[[96m--> ^[[0msrc\lib.rs:184:5
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7398352Z     ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7398589Z ^[[1m^[[96m175^[[0m ^[[1m^[[96m|^[[0m pub struct ProcessRunner {
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7398931Z     ^[[1m^[[96m|^[[0m            ^[[1m^[[96m-------------^[[0m ^[[1m^[[96mfield in this struct^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7399223Z ^[[1m^[[96m...^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7399562Z ^[[1m^[[96m184^[[0m ^[[1m^[[96m|^[[0m     output_rx: Option<mpsc::Receiver<StreamChunk>>,
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7399889Z     ^[[1m^[[96m|^[[0m     ^[[1m^[[93m^^^^^^^^^^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7400108Z     ^[[1m^[[96m|^[[0m
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7401640Z     ^[[1m^[[96m= ^[[0m^[[1m^[[97mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7402140Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7403076Z ^[[1m^[[92m       Fresh^[[0m tempfile v3.24.0
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7403879Z ^[[1m^[[93mwarning^[[0m: `command-stream` (lib) generated 4 warnings (run `cargo fix --lib -p command-stream` to apply 3 suggestions)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7404711Z ^[[1m^[[92m       Fresh^[[0m command-stream v0.9.5 (D:\a\command-stream\command-stream\rust)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7405383Z ^[[1m^[[92m    Finished^[[0m `test` profile [unoptimized + debuginfo] target(s) in 0.09s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7452629Z ^[[1m^[[92m   Doc-tests^[[0m command_stream
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.7461494Z ^[[1m^[[92m     Running^[[0m `C:\Users\runneradmin\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustdoc.exe --edition=2021 --crate-type lib --color always --crate-name command_stream --test src\lib.rs --test-run-directory D:\a\command-stream\command-stream\rust -L native=C:\Users\runneradmin\.cargo\registry\src\index.crates.io-1949cf8c6b5b557f\windows_x86_64_msvc-0.53.1\lib --extern assert_cmd=D:\a\command-stream\command-stream\rust\target\debug\deps\libassert_cmd-dca197f08fcdd0b4.rlib --extern async_trait=D:\a\command-stream\command-stream\rust\target\debug\deps\async_trait-f85d91168a0c9ab7.dll --extern chrono=D:\a\command-stream\command-stream\rust\target\debug\deps\libchrono-3aedc36e6b1c7806.rlib --extern command_stream=D:\a\command-stream\command-stream\rust\target\debug\deps\libcommand_stream-97916d2852bcd18c.rlib --extern filetime=D:\a\command-stream\command-stream\rust\target\debug\deps\libfiletime-5a6bddbb6bdca50d.rlib --extern glob=D:\a\command-stream\command-stream\rust\target\debug\deps\libglob-2e2cf4d75ff2d305.rlib --extern libc=D:\a\command-stream\command-stream\rust\target\debug\deps\liblibc-b4dc192506590325.rlib --extern nix=D:\a\command-stream\command-stream\rust\target\debug\deps\libnix-669fc398f0832068.rlib --extern once_cell=D:\a\command-stream\command-stream\rust\target\debug\deps\libonce_cell-db8fdc1ebbf3db2b.rlib --extern regex=D:\a\command-stream\command-stream\rust\target\debug\deps\libregex-87e57c5fff91b6c4.rlib --extern serde=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde-1fc3f30e3037d8bf.rlib --extern serde_json=D:\a\command-stream\command-stream\rust\target\debug\deps\libserde_json-e65d220842d9f6e3.rlib --extern tempfile=D:\a\command-stream\command-stream\rust\target\debug\deps\libtempfile-5956ac53e7c18362.rlib --extern thiserror=D:\a\command-stream\command-stream\rust\target\debug\deps\libthiserror-a165183600caf4df.rlib --extern tokio=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio-cb85aeb17f2c01ea.rlib --extern tokio_test=D:\a\command-stream\command-stream\rust\target\debug\deps\libtokio_test-abba2624c7baa38a.rlib --extern which=D:\a\command-stream\command-stream\rust\target\debug\deps\libwhich-517f70f2a782170f.rlib -L dependency=D:\a\command-stream\command-stream\rust\target\debug\deps -C embed-bitcode=no --cfg "feature=\"default\"" --cfg "feature=\"json\"" --cfg "feature=\"serde\"" --cfg "feature=\"serde_json\"" --check-cfg cfg(docsrs,test) --check-cfg "cfg(feature, values(\"default\", \"json\", \"serde\", \"serde_json\"))" --error-format human`
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.8353058Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.8353590Z running 13 tests
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.8358726Z test src\events.rs - events::StreamEmitter::on (line 93) ... ignored
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.9473946Z test src\lib.rs - (line 38) - compile ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:13.9519074Z test src\macros.rs - macros (line 17) - compile ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:14.1378639Z test src\pipeline.rs - pipeline (line 9) - compile ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:14.1650342Z test src\macros.rs - macros::cmd (line 84) - compile ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:14.7513246Z test src\ansi.rs - ansi::AnsiUtils::strip_control_chars (line 37) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:14.8843934Z test src\ansi.rs - ansi::AnsiUtils::strip_ansi (line 17) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:15.0378976Z test src\stream.rs - stream (line 8) - compile ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:15.2300399Z test src\quote.rs - quote::needs_quoting (line 88) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:15.3401376Z test src\quote.rs - quote::quote (line 13) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:15.9025759Z test src\quote.rs - quote::quote_all (line 67) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:15.9550982Z test src\trace.rs - trace::trace (line 33) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:15.9763247Z test src\trace.rs - trace::trace_lazy (line 55) ... ok
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:15.9763960Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:15.9764175Z test result: ok. 12 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.14s
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:15.9764475Z 
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:16.1780834Z Post job cleanup.
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:16.3234989Z Cache hit occurred on the primary key Windows-cargo-d772d5ef62148b9647b7df8ad2e6112c4dbbe6dbea4c5acc334e4ea5c3fc0588, not saving cache.
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:16.3446489Z Post job cleanup.
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:16.5033325Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:16.5262538Z git version 2.54.0.windows.1
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:16.5324335Z Temporarily overriding HOME='D:\a\_temp\bb658413-b67a-4820-b5ac-e2c7a4e8a7f0' before making global git config changes
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:16.5324925Z Adding repository directory to the temporary git global config as a safe directory
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:16.5333907Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\command-stream\command-stream
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:16.5618360Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:16.5879922Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:17.0526564Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:17.0769623Z http.https://github.com/.extraheader
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:17.0826769Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all http.https://github.com/.extraheader
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:17.1091146Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:17.5709549Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:17.5973779Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:18.0439523Z Cleaning up orphan processes
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:18.0615090Z Terminate orphan process: pid (6204) (vctip)
+Test Rust (windows-latest)	UNKNOWN STEP	2026-06-08T20:23:18.0635287Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test Rust (ubuntu-latest)	UNKNOWN STEP	﻿2026-06-08T20:22:05.3683750Z Current runner version: '2.334.0'
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3707716Z ##[group]Runner Image Provisioner
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3708579Z Hosted Compute Agent
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3709314Z Version: 20260520.533
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3709969Z Commit: 189110e25284a9812c124fd27b339e2fb4f2f9db
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3710687Z Build Date: 2026-05-20T17:44:04Z
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3711735Z Worker ID: {fa99a646-f1a9-4e20-8c5c-7c935098cb4c}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3712480Z Azure Region: westus3
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3713529Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3715030Z ##[group]Operating System
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3715675Z Ubuntu
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3716301Z 24.04.4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3716827Z LTS
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3717419Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3718013Z ##[group]Runner Image
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3718650Z Image: ubuntu-24.04
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3719301Z Version: 20260525.161.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3720567Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260525.161/images/ubuntu/Ubuntu2404-Readme.md
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3722700Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260525.161
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3723695Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3726613Z ##[group]GITHUB_TOKEN Permissions
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3728873Z Actions: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3729623Z ArtifactMetadata: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3730300Z Attestations: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3731312Z Checks: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3731963Z CodeQuality: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3732537Z Contents: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3733190Z Deployments: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3733765Z Discussions: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3734355Z Issues: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3734931Z Metadata: read
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3735537Z Models: read
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3736185Z Packages: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3736855Z Pages: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3737448Z PullRequests: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3738098Z RepositoryProjects: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3738732Z SecurityEvents: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3739415Z Statuses: write
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3740009Z VulnerabilityAlerts: read
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3740657Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3743234Z Secret source: Actions
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3744008Z Prepare workflow directory
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.4332815Z Prepare all required actions
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:05.4369207Z Getting action download info
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.0087264Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.1368900Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.3724532Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6228777Z Complete job name: Test Rust (ubuntu-latest)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6890678Z ##[group]Run actions/checkout@v4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6892044Z with:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6892577Z   repository: link-foundation/command-stream
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6896908Z   token: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6897357Z   ssh-strict: true
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6897826Z   ssh-user: git
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6898282Z   persist-credentials: true
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6898784Z   clean: true
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6899242Z   sparse-checkout-cone-mode: true
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6899820Z   fetch-depth: 1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6900258Z   fetch-tags: false
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6900723Z   show-progress: true
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6901411Z   lfs: false
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6901875Z   submodules: false
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6902339Z   set-safe-directory: true
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6903200Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6903668Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6904339Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6904930Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.6905368Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.7992716Z Syncing repository: link-foundation/command-stream
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.7994598Z ##[group]Getting Git version info
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.7995416Z Working directory is '/home/runner/work/command-stream/command-stream'
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.7996493Z [command]/usr/bin/git version
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8083878Z git version 2.54.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8109397Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8129685Z Temporarily overriding HOME='/home/runner/work/_temp/646a8912-591a-44e3-9430-58a1766eb863' before making global git config changes
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8131533Z Adding repository directory to the temporary git global config as a safe directory
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8134902Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8184188Z Deleting the contents of '/home/runner/work/command-stream/command-stream'
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8187345Z ##[group]Initializing the repository
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8191897Z [command]/usr/bin/git init /home/runner/work/command-stream/command-stream
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8295380Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8296621Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8297805Z hint: to use in all of your new repositories, which will suppress this warning,
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8298719Z hint: call:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8299211Z hint:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8299829Z hint: 	git config --global init.defaultBranch <name>
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8300603Z hint:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8301914Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8303326Z hint: 'development'. The just-created branch can be renamed via this command:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8304260Z hint:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8304773Z hint: 	git branch -m <name>
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8305363Z hint:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8306155Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8307750Z Initialized empty Git repository in /home/runner/work/command-stream/command-stream/.git/
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8312715Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/command-stream
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8349991Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8351193Z ##[group]Disabling automatic garbage collection
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8354074Z [command]/usr/bin/git config --local gc.auto 0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8380781Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8381725Z ##[group]Setting up auth
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8387417Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8418436Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8760548Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8790529Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8999031Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.9035486Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.9248539Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.9280581Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.9282046Z ##[group]Fetching the repository
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:06.9288775Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +89d47cf62671f8e1c4813af51128b0b9e47b6fa6:refs/remotes/origin/main
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.2328673Z From https://github.com/link-foundation/command-stream
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.2329688Z  * [new ref]         89d47cf62671f8e1c4813af51128b0b9e47b6fa6 -> origin/main
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.2370224Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.2370807Z ##[group]Determining the checkout info
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.2373114Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.2378028Z [command]/usr/bin/git sparse-checkout disable
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.2421656Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.2445695Z ##[group]Checking out the ref
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.2449526Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3169044Z Switched to a new branch 'main'
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3170624Z branch 'main' set up to track 'origin/main'.
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3182285Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3221128Z [command]/usr/bin/git log -1 --format=%H
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3242664Z 89d47cf62671f8e1c4813af51128b0b9e47b6fa6
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3618760Z ##[group]Run dtolnay/rust-toolchain@stable
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3619183Z with:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3619439Z   toolchain: stable
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3619693Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3619945Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3620544Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3621126Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3621394Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3738270Z ##[group]Run : parse toolchain version
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3738735Z ^[[36;1m: parse toolchain version^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3739092Z ^[[36;1mif [[ -z $toolchain ]]; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3739704Z ^[[36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3740359Z ^[[36;1m  echo "'toolchain' is a required input" >&2^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3740722Z ^[[36;1m  exit 1^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3741325Z ^[[36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3741873Z ^[[36;1m  if [[ Linux == macOS ]]; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3742513Z ^[[36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3743115Z ^[[36;1m  else^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3743591Z ^[[36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3744122Z ^[[36;1m  fi^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3744491Z ^[[36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3745100Z ^[[36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3745630Z ^[[36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3746227Z ^[[36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3746794Z ^[[36;1melse^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3747107Z ^[[36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3747474Z ^[[36;1mfi^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3778228Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3778666Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3778921Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3779378Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3779755Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3780040Z   toolchain: stable
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3780300Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3911236Z ##[group]Run : construct rustup command line
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3911672Z ^[[36;1m: construct rustup command line^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3912197Z ^[[36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3912916Z ^[[36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3913496Z ^[[36;1mecho "downgrade=" >> $GITHUB_OUTPUT^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3937749Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3938166Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3938415Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3938871Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3939235Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3939485Z   targets: 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3939719Z   components: 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.3939960Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4019016Z ##[group]Run : set $CARGO_HOME
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4019507Z ^[[36;1m: set $CARGO_HOME^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4019893Z ^[[36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4044601Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4045087Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4045340Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4045790Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4046151Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4046403Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4122881Z ##[group]Run : install rustup if needed
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4123459Z ^[[36;1m: install rustup if needed^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4123841Z ^[[36;1mif ! command -v rustup &>/dev/null; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4124683Z ^[[36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4125526Z ^[[36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4125884Z ^[[36;1mfi^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4149730Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4150138Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4150381Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4150815Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4151446Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4151722Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4152029Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4229782Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4230419Z ^[[36;1mrustup toolchain install stable --profile minimal --no-self-update^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4255146Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4255545Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4255790Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4256230Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4256590Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4256862Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4257176Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.4257486Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.6307985Z info: syncing channel updates for stable-x86_64-unknown-linux-gnu
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.9774244Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.9916015Z info: removing previous version of component clippy
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.9933382Z info: removing previous version of component rustfmt
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.9945934Z info: removing previous version of component cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:08.9991677Z info: removing previous version of component rust-std
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:09.0041881Z info: removing previous version of component rustc
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:09.0094446Z info: downloading 5 components
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0733105Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0808069Z   stable-x86_64-unknown-linux-gnu updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.95.0 (59807616e 2026-04-14))
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0809020Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0900261Z ##[group]Run rustup default stable
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0900625Z ^[[36;1mrustup default stable^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0928171Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0928580Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0928814Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0929267Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0929603Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0929846Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.0930135Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1028601Z info: using existing install for stable-x86_64-unknown-linux-gnu
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1035435Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1035890Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1103848Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1104442Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1142947Z ##[group]Run : create cachekey
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1143259Z ^[[36;1m: create cachekey^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1143782Z ^[[36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1144742Z ^[[36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1145268Z ^[[36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1171553Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1171920Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1172128Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1172555Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1172868Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1173097Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1173544Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1515706Z ##[group]Run : disable incremental compilation
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1516100Z ^[[36;1m: disable incremental compilation^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1516437Z ^[[36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1516782Z ^[[36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1517073Z ^[[36;1mfi^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1543551Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1543906Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1544111Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1544527Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1544851Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1545078Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1545335Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1636417Z ##[group]Run : enable colors in Cargo output
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1636751Z ^[[36;1m: enable colors in Cargo output^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1637074Z ^[[36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1637430Z ^[[36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1637725Z ^[[36;1mfi^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1661920Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1662273Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1662477Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1662853Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1663167Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1663393Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1663648Z   CARGO_INCREMENTAL: 0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1663865Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1733700Z ##[group]Run : enable Cargo sparse registry
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1734043Z ^[[36;1m: enable Cargo sparse registry^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1734414Z ^[[36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1735137Z ^[[36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1735915Z ^[[36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1736506Z ^[[36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1737054Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1737573Z ^[[36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1738169Z ^[[36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1738698Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1739048Z ^[[36;1m  fi^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1739242Z ^[[36;1mfi^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1764143Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1764493Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1764695Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1765074Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1765395Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1765617Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1765881Z   CARGO_INCREMENTAL: 0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.1766097Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2086805Z ##[group]Run : work around spurious network errors in curl 8.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2087275Z ^[[36;1m: work around spurious network errors in curl 8.0^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2087845Z ^[[36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2088627Z ^[[36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2089094Z ^[[36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2089419Z ^[[36;1mfi^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2117026Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2117387Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2117596Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2118017Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2118491Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2118736Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2118996Z   CARGO_INCREMENTAL: 0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2119214Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2312997Z ##[group]Run rustc +stable --version --verbose
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2313367Z ^[[36;1mrustc +stable --version --verbose^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2339688Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2340084Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2340290Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2340690Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2341296Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2341529Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2341793Z   CARGO_INCREMENTAL: 0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2342026Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2495069Z rustc 1.96.0 (ac68faa20 2026-05-25)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2495764Z binary: rustc
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2496159Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2496776Z commit-date: 2026-05-25
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2497365Z host: x86_64-unknown-linux-gnu
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2497887Z release: 1.96.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.2498321Z LLVM version: 22.1.2
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3137273Z ##[group]Run actions/cache@v4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3137586Z with:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3137857Z   path: ~/.cargo/registry
+Test Rust (ubuntu-latest)	UNKNOWN STEP	~/.cargo/git
+Test Rust (ubuntu-latest)	UNKNOWN STEP	rust/target
+Test Rust (ubuntu-latest)	UNKNOWN STEP	
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3138363Z   key: Linux-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3138882Z   restore-keys: Linux-cargo-
+Test Rust (ubuntu-latest)	UNKNOWN STEP	
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3139156Z   enableCrossOsArchive: false
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3139423Z   fail-on-cache-miss: false
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3139722Z   lookup-only: false
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3139948Z   save-always: false
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3140159Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3140358Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3140830Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3141404Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3141635Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3141901Z   CARGO_INCREMENTAL: 0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.3142130Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:17.7085230Z Cache hit for: Linux-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:18.9466431Z Received 16777216 of 249180146 (6.7%), 16.0 MBs/sec
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:19.9471997Z Received 134217728 of 249180146 (53.9%), 64.0 MBs/sec
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:20.6341678Z Received 249180146 of 249180146 (100.0%), 88.4 MBs/sec
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:20.6344426Z Cache Size: ~238 MB (249180146 B)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:20.6385298Z [command]/usr/bin/tar -xf /home/runner/work/_temp/811d1187-f770-4ff6-9ae4-c3fa774220b5/cache.tzst -P -C /home/runner/work/command-stream/command-stream --use-compress-program unzstd
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.1679456Z Cache restored successfully
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.3143805Z Cache restored from key: Linux-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.3254707Z ##[group]Run cargo test --all-features --verbose
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.3255112Z ^[[36;1mcargo test --all-features --verbose^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.3282753Z shell: /usr/bin/bash -e {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.3283020Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.3283219Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.3283807Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.3284163Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.3284390Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.3284651Z   CARGO_INCREMENTAL: 0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.3284876Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4266119Z ^[[1m^[[92m       Fresh^[[0m unicode-ident v1.0.22
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4266897Z ^[[1m^[[92m       Fresh^[[0m libc v0.2.178
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4267420Z ^[[1m^[[92m       Fresh^[[0m cfg-if v1.0.4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4267879Z ^[[1m^[[92m       Fresh^[[0m proc-macro2 v1.0.104
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4268320Z ^[[1m^[[92m       Fresh^[[0m memchr v2.7.6
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4271715Z ^[[1m^[[92m       Fresh^[[0m scopeguard v1.2.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4281985Z ^[[1m^[[92m       Fresh^[[0m quote v1.0.42
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4282675Z ^[[1m^[[92m       Fresh^[[0m smallvec v1.15.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4283313Z ^[[1m^[[92m       Fresh^[[0m aho-corasick v1.1.4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4283946Z ^[[1m^[[92m       Fresh^[[0m syn v2.0.111
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4284574Z ^[[1m^[[92m       Fresh^[[0m parking_lot_core v0.9.12
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4285207Z ^[[1m^[[92m       Fresh^[[0m lock_api v0.4.14
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4285765Z ^[[1m^[[92m       Fresh^[[0m errno v0.3.14
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4286381Z ^[[1m^[[92m       Fresh^[[0m pin-project-lite v0.2.16
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4286752Z ^[[1m^[[92m       Fresh^[[0m autocfg v1.5.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4287112Z ^[[1m^[[92m       Fresh^[[0m regex-syntax v0.8.8
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4287463Z ^[[1m^[[92m       Fresh^[[0m bitflags v2.10.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4287805Z ^[[1m^[[92m       Fresh^[[0m regex-automata v0.4.13
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4288175Z ^[[1m^[[92m       Fresh^[[0m signal-hook-registry v1.4.8
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4288531Z ^[[1m^[[92m       Fresh^[[0m parking_lot v0.12.5
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4288874Z ^[[1m^[[92m       Fresh^[[0m tokio-macros v2.6.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4289201Z ^[[1m^[[92m       Fresh^[[0m socket2 v0.6.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4289513Z ^[[1m^[[92m       Fresh^[[0m mio v1.1.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4289829Z ^[[1m^[[92m       Fresh^[[0m cfg_aliases v0.2.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4290142Z ^[[1m^[[92m       Fresh^[[0m bytes v1.11.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4290518Z ^[[1m^[[92m       Fresh^[[0m linux-raw-sys v0.11.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4291300Z ^[[1m^[[92m       Fresh^[[0m tokio v1.48.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4292169Z ^[[1m^[[92m       Fresh^[[0m rustix v1.1.3
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4293038Z ^[[1m^[[92m       Fresh^[[0m serde_core v1.0.228
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4293882Z ^[[1m^[[92m       Fresh^[[0m num-traits v0.2.19
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4294581Z ^[[1m^[[92m       Fresh^[[0m zmij v1.0.2
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4295170Z ^[[1m^[[92m       Fresh^[[0m thiserror-impl v2.0.17
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4295782Z ^[[1m^[[92m       Fresh^[[0m serde_derive v1.0.228
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4296342Z ^[[1m^[[92m       Fresh^[[0m itoa v1.0.17
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4296901Z ^[[1m^[[92m       Fresh^[[0m futures-core v0.3.31
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4297470Z ^[[1m^[[92m       Fresh^[[0m either v1.15.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4298004Z ^[[1m^[[92m       Fresh^[[0m env_home v0.1.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4298704Z ^[[1m^[[92m       Fresh^[[0m once_cell v1.21.3
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4299556Z ^[[1m^[[92m       Fresh^[[0m predicates-core v1.0.9
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4300499Z ^[[1m^[[92m       Fresh^[[0m iana-time-zone v0.1.64
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4301338Z ^[[1m^[[92m       Fresh^[[0m chrono v0.4.42
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4301927Z ^[[1m^[[92m       Fresh^[[0m which v7.0.3
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4302527Z ^[[1m^[[92m       Fresh^[[0m serde_json v1.0.148
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4303323Z ^[[1m^[[92m       Fresh^[[0m thiserror v2.0.17
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4304133Z ^[[1m^[[92m       Fresh^[[0m nix v0.29.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4304685Z ^[[1m^[[92m       Fresh^[[0m serde v1.0.228
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4305222Z ^[[1m^[[92m       Fresh^[[0m regex v1.12.2
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4305788Z ^[[1m^[[92m       Fresh^[[0m async-trait v0.1.89
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4306711Z ^[[1m^[[92m       Fresh^[[0m async-stream-impl v0.3.6
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4307352Z ^[[1m^[[92m       Fresh^[[0m filetime v0.2.26
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4307903Z ^[[1m^[[92m       Fresh^[[0m difflib v0.4.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4308441Z ^[[1m^[[92m       Fresh^[[0m glob v0.3.3
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4308941Z ^[[1m^[[92m       Fresh^[[0m anstyle v1.0.13
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4309254Z ^[[1m^[[92m       Fresh^[[0m termtree v0.5.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4309589Z ^[[1m^[[92m       Fresh^[[0m predicates-tree v1.0.12
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4309939Z ^[[1m^[[92m       Fresh^[[0m predicates v3.1.3
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4310269Z ^[[1m^[[92m       Fresh^[[0m async-stream v0.3.6
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4310759Z ^[[1m^[[92m       Fresh^[[0m getrandom v0.3.4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4311370Z ^[[1m^[[92m       Fresh^[[0m tokio-stream v0.1.17
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4311693Z ^[[1m^[[92m       Fresh^[[0m bstr v1.12.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4312005Z ^[[1m^[[92m       Fresh^[[0m wait-timeout v0.2.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4312589Z ^[[1m^[[92m       Fresh^[[0m fastrand v2.3.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4312945Z ^[[1m^[[92m       Fresh^[[0m tokio-test v0.4.4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4313265Z ^[[1m^[[92m       Fresh^[[0m assert_cmd v2.1.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4313822Z ^[[1m^[[92m   Compiling^[[0m command-stream v0.9.5 (/home/runner/work/command-stream/command-stream/rust)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4314353Z ^[[1m^[[92m       Fresh^[[0m tempfile v3.24.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4324317Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name command_stream --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=2e8a5d5a6f4f26ef -C extra-filename=-cd1f126963559215 --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rmeta --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rmeta --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rmeta --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rmeta --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rmeta --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rmeta --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rmeta --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rmeta --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rmeta --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rmeta --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rmeta --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rmeta`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4344286Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name command_stream --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=6ea7b838d5d57ee6 -C extra-filename=-dcc693b97e14b9d6 --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4723211Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `std::path::Path`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4724316Z   ^[[1m^[[94m--> ^[[0msrc/commands/mod.rs:53:5
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4725255Z    ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4725991Z ^[[1m^[[94m53^[[0m ^[[1m^[[94m|^[[0m use std::path::Path;
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4726732Z    ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4727341Z    ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4728190Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.4728883Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7126886Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `e`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7127743Z   ^[[1m^[[94m--> ^[[0msrc/commands/touch.rs:33:24
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7128394Z    ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7129086Z ^[[1m^[[94m33^[[0m ^[[1m^[[94m|^[[0m             if let Err(e) =
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7130380Z    ^[[1m^[[94m|^[[0m                        ^[[1m^[[33m^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_e`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7131655Z    ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7132527Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7133285Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7555674Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `file_type`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7556682Z    ^[[1m^[[94m--> ^[[0msrc/commands/ls.rs:124:9
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7557444Z     ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7558372Z ^[[1m^[[94m124^[[0m ^[[1m^[[94m|^[[0m     let file_type = if metadata.is_dir() { "d" } else { "-" };
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7559932Z     ^[[1m^[[94m|^[[0m         ^[[1m^[[33m^^^^^^^^^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_file_type`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7561107Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7824316Z ^[[1m^[[33mwarning^[[0m^[[1m: field `output_rx` is never read^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7825063Z    ^[[1m^[[94m--> ^[[0msrc/lib.rs:184:5
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7825554Z     ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7826089Z ^[[1m^[[94m175^[[0m ^[[1m^[[94m|^[[0m pub struct ProcessRunner {
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7826895Z     ^[[1m^[[94m|^[[0m            ^[[1m^[[94m-------------^[[0m ^[[1m^[[94mfield in this struct^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7827552Z ^[[1m^[[94m...^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7828405Z ^[[1m^[[94m184^[[0m ^[[1m^[[94m|^[[0m     output_rx: Option<mpsc::Receiver<StreamChunk>>,
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7829181Z     ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7829958Z     ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7830664Z     ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7831447Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5454430Z ^[[1m^[[33mwarning^[[0m: `command-stream` (lib) generated 4 warnings (run `cargo fix --lib -p command-stream` to apply 3 suggestions)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5483950Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name command_stream --edition=2021 src/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=6e621bd55db59885 -C extra-filename=-f067b6fad89d6b7d --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5747954Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name pipeline --edition=2021 tests/pipeline.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=677fff7d7268ceb7 -C extra-filename=-c57dc26c60cb50ff --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5799777Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name shell_parser --edition=2021 tests/shell_parser.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=33707f05fd482da2 -C extra-filename=-025c33ffe2352dc0 --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5846211Z ^[[1m^[[33mwarning^[[0m^[[1m: unused imports: `ProcessRunner` and `RunOptions`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5862088Z  ^[[1m^[[94m--> ^[[0msrc/main.rs:5:27
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5862784Z   ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5863957Z ^[[1m^[[94m5^[[0m ^[[1m^[[94m|^[[0m use command_stream::{run, ProcessRunner, RunOptions};
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5865129Z   ^[[1m^[[94m|^[[0m                           ^[[1m^[[33m^^^^^^^^^^^^^^[[0m  ^[[1m^[[33m^^^^^^^^^^^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5865987Z   ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5867084Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5867949Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.6142819Z ^[[1m^[[33mwarning^[[0m^[[1m: unused imports: `PipelineExt`, `ProcessRunner`, and `RunOptions`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.6172300Z  ^[[1m^[[94m--> ^[[0mtests/pipeline.rs:3:32
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.6173285Z   ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.6202516Z ^[[1m^[[94m3^[[0m ^[[1m^[[94m|^[[0m use command_stream::{Pipeline, PipelineExt, ProcessRunner, RunOptions};
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.6231968Z   ^[[1m^[[94m|^[[0m                                ^[[1m^[[33m^^^^^^^^^^^^[[0m  ^[[1m^[[33m^^^^^^^^^^^^^^[[0m  ^[[1m^[[33m^^^^^^^^^^^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.6261541Z   ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.6262724Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.6291340Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.7335787Z ^[[1m^[[33mwarning^[[0m: `command-stream` (bin "command-stream" test) generated 1 warning (run `cargo fix --bin "command-stream" -p command-stream --tests` to apply 1 suggestion)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.7384128Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name events --edition=2021 tests/events.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=02faec81d15cde8c -C extra-filename=-8a4cd5f9350272e4 --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:23.9514947Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name macros --edition=2021 tests/macros.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=4a0de9a9b94d6351 -C extra-filename=-9f6a5e1b6fd23b30 --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4412800Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "pipeline") generated 1 warning (run `cargo fix --test "pipeline" -p command-stream` to apply 1 suggestion)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4449394Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name state --edition=2021 tests/state.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=0fcfed6ade2faab2 -C extra-filename=-b17e626b66642584 --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5391971Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name virtual_commands --edition=2021 tests/virtual_commands.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=7d6c5e5971e7fa47 -C extra-filename=-adeea1b5e623bec8 --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.0334627Z ^[[1m^[[33mwarning^[[0m: `command-stream` (lib test) generated 4 warnings (4 duplicates)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.0377196Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name stream --edition=2021 tests/stream.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=224da2cadcb5c9e0 -C extra-filename=-6f236615fc02e9df --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.0834519Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name builtin_commands --edition=2021 tests/builtin_commands.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=b22286d27e04debf -C extra-filename=-55545df01c49d42a --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1212599Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `AsyncIterator`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1241795Z  ^[[1m^[[94m--> ^[[0mtests/stream.rs:3:22
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1242632Z   ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1272706Z ^[[1m^[[94m3^[[0m ^[[1m^[[94m|^[[0m use command_stream::{AsyncIterator, OutputChunk, StreamingRunner};
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1301806Z   ^[[1m^[[94m|^[[0m                      ^[[1m^[[33m^^^^^^^^^^^^^^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1331606Z   ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1332690Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1361457Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1440486Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name command_stream --edition=2021 src/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=79977f8a030d5dfe -C extra-filename=-dd8091cc52212f1f --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1487952Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `cd`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1488685Z  ^[[1m^[[94m--> ^[[0mtests/builtin_commands.rs:6:20
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1489252Z   ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1490133Z ^[[1m^[[94m6^[[0m ^[[1m^[[94m|^[[0m     basename, cat, cd, cp, dirname, echo, env, exit, ls, mkdir, mv, pwd, rm, seq, sleep, test,
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1491381Z   ^[[1m^[[94m|^[[0m                    ^[[1m^[[33m^^^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1491905Z   ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1492648Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1493216Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1493928Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `command_stream::utils::CommandResult`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1494700Z  ^[[1m^[[94m--> ^[[0mtests/builtin_commands.rs:9:5
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1495183Z   ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1495740Z ^[[1m^[[94m9^[[0m ^[[1m^[[94m|^[[0m use command_stream::utils::CommandResult;
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1496427Z   ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.1496798Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.3415162Z ^[[1m^[[33mwarning^[[0m^[[1m: function `ctx_with_cwd` is never used^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.3442755Z   ^[[1m^[[94m--> ^[[0mtests/builtin_commands.rs:27:4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.3471676Z    ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.3474664Z ^[[1m^[[94m27^[[0m ^[[1m^[[94m|^[[0m fn ctx_with_cwd(args: Vec<&str>, cwd: PathBuf) -> CommandContext {
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.3475842Z    ^[[1m^[[94m|^[[0m    ^[[1m^[[33m^^^^^^^^^^^^^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.3476627Z    ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.3477543Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.3478262Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.6534085Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name utils --edition=2021 tests/utils.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=1068bf09ec7d3267 -C extra-filename=-455f4be47d336ce0 --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.6985024Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "stream") generated 1 warning
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.7032553Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name process_runner --edition=2021 tests/process_runner.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=5b353321e8ac98c5 -C extra-filename=-50d1aa8df905759f --out-dir /home/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.7484751Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `std::path::PathBuf`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.7485888Z  ^[[1m^[[94m--> ^[[0mtests/process_runner.rs:7:5
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.7511717Z   ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.7542678Z ^[[1m^[[94m7^[[0m ^[[1m^[[94m|^[[0m use std::path::PathBuf;
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.7601691Z   ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^^^^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.7631673Z   ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.7632743Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.7661384Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:25.9155594Z ^[[1m^[[33mwarning^[[0m: `command-stream` (bin "command-stream") generated 1 warning (1 duplicate)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.2466820Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "builtin_commands") generated 3 warnings (run `cargo fix --test "builtin_commands" -p command-stream` to apply 2 suggestions)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3633911Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "process_runner") generated 1 warning (run `cargo fix --test "process_runner" -p command-stream` to apply 1 suggestion)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3635564Z ^[[1m^[[92m    Finished^[[0m `test` profile [unoptimized + debuginfo] target(s) in 4.02s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3687950Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/command_stream-dcc693b97e14b9d6`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3701880Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3702073Z running 112 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3706320Z test ansi::tests::test_ansi_config_default ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3707332Z test ansi::tests::test_ansi_config_strip_control_only ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3712965Z test ansi::tests::test_ansi_config_strip_ansi_only ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3716691Z test ansi::tests::test_ansi_config_strip_all ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3717710Z test ansi::tests::test_strip_all ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3718902Z test ansi::tests::test_strip_control_chars ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3719728Z test ansi::tests::test_strip_ansi ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3720634Z test ansi::tests::test_strip_control_chars_preserves_whitespace ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3722155Z test ansi::tests::test_strip_ansi_multiple_codes ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3723080Z test commands::basename::tests::test_basename_no_path ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3724000Z test commands::basename::tests::test_basename_simple ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3725093Z test commands::basename::tests::test_basename_with_suffix ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3727468Z test commands::cat::tests::test_cat_nonexistent ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3728378Z test commands::cat::tests::test_cat_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3728989Z test commands::cat::tests::test_cat_multiple_files ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3729663Z test commands::cat::tests::test_cat_stdin ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3730310Z test commands::cd::tests::test_cd_to_nonexistent ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3735285Z test commands::cd::tests::test_cd_to_temp ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3735953Z test commands::cp::tests::test_cp_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3737994Z test commands::dirname::tests::test_dirname_root ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3739750Z test commands::dirname::tests::test_dirname_just_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3745703Z test commands::cp::tests::test_cp_directory_recursive ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3746498Z test commands::dirname::tests::test_dirname_simple ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3747187Z test commands::echo::tests::test_echo_empty ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3749419Z test commands::cp::tests::test_cp_directory_without_recursive ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3750169Z test commands::echo::tests::test_echo_simple ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3750566Z test commands::exit::tests::test_exit_default ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3751180Z test commands::exit::tests::test_exit_with_code ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3751555Z test commands::ls::tests::test_ls_current_dir ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3751889Z test commands::env::tests::test_env ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3752256Z test commands::mkdir::tests::test_mkdir_missing_operand ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3752673Z test commands::ls::tests::test_ls_with_path ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3753075Z test commands::ls::tests::test_ls_hidden_files ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3761428Z test commands::mkdir::tests::test_mkdir_simple ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3762106Z test commands::mkdir::tests::test_mkdir_with_parents ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3762703Z test commands::mv::tests::test_mv_directory ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3763048Z test commands::mv::tests::test_mv_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3764414Z test commands::mv::tests::test_mv_nonexistent ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3766297Z test commands::pwd::tests::test_pwd ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3767922Z test commands::r#false::tests::test_false ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3769631Z test commands::r#true::tests::test_true ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3770602Z test commands::rm::tests::test_rm_nonexistent_force ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3773677Z test commands::rm::tests::test_rm_directory_recursive ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3777821Z test commands::rm::tests::test_rm_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3778565Z test commands::rm::tests::test_rm_nonexistent_no_force ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3779285Z test commands::seq::tests::test_seq_descending ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3779849Z test commands::seq::tests::test_seq_single_arg ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3780250Z test commands::seq::tests::test_seq_zero_increment ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3780623Z test commands::seq::tests::test_seq_three_args ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3781232Z test commands::seq::tests::test_seq_two_args ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3781741Z test commands::sleep::tests::test_sleep_invalid ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3782655Z test commands::test::tests::test_empty_string ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3783468Z test commands::sleep::tests::test_sleep_negative ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3786814Z test commands::test::tests::test_file_not_exists ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3787735Z test commands::test::tests::test_file_exists ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3788525Z test commands::test::tests::test_numeric_comparison ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3789258Z test commands::test::tests::test_non_empty_string ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3790587Z test commands::test::tests::test_string_equality ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3792648Z test commands::test::tests::test_string_inequality ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3793296Z test commands::sleep::tests::test_sleep_zero ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3794018Z test commands::touch::tests::test_touch_missing_operand ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3798154Z test commands::touch::tests::test_touch_existing_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3800391Z test commands::which::tests::test_which_existing_command ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3804014Z test commands::which::tests::test_which_nonexistent_command ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3804813Z test commands::touch::tests::test_touch_new_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3805605Z test commands::yes::tests::test_yes_custom_string ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3806351Z test commands::yes::tests::test_yes_with_cancellation ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3807032Z test events::tests::test_emit_basic ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3807620Z test events::tests::test_listener_count ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3808278Z test events::tests::test_multiple_events ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3808867Z test events::tests::test_off ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3809398Z test events::tests::test_once ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3809980Z test quote::tests::test_quote_already_quoted ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3810586Z test quote::tests::test_quote_empty ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3822708Z test quote::tests::test_quote_all ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3825017Z test quote::tests::test_needs_quoting ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3828635Z test quote::tests::test_quote_with_newlines ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3832974Z test quote::tests::test_quote_with_tabs ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3833852Z test shell_parser::tests::test_needs_real_shell ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3835098Z test shell_parser::tests::test_parse_pipeline ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3835873Z test shell_parser::tests::test_parse_sequence ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3839772Z test quote::tests::test_quote_special_chars ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3840638Z test quote::tests::test_quote_safe_chars ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3841884Z test shell_parser::tests::test_parse_simple_command ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3842562Z test shell_parser::tests::test_parse_subshell ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3843209Z test shell_parser::tests::test_parse_with_redirect ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3843929Z test shell_parser::tests::test_tokenize_simple_command ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3844765Z test shell_parser::tests::test_tokenize_with_operators ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3845637Z test shell_parser::tests::test_tokenize_with_pipe ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3846147Z test shell_parser::tests::test_tokenize_with_quotes ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3846562Z test state::tests::test_global_state_reset ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3847478Z test state::tests::test_global_state_runners ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3848655Z test state::tests::test_global_state_virtual_commands ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3850021Z test state::tests::test_shell_settings_default ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3851325Z test state::tests::test_shell_settings_set ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3852024Z test trace::tests::test_trace_disabled_by_default ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3852733Z test trace::tests::test_trace_enabled_by_verbose ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3853526Z test trace::tests::test_trace_explicit_false_overrides_verbose ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3854294Z test trace::tests::test_trace_explicit_true ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3855009Z test utils::tests::test_command_result_error_with_code ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3855729Z test utils::tests::test_command_result_error ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3856395Z test utils::tests::test_command_result_success ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3857057Z test utils::tests::test_invalid_argument_error ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3857732Z test utils::tests::test_missing_operand_error ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3858586Z test utils::tests::test_reexported_ansi_config ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3859771Z test utils::tests::test_resolve_path_absolute ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3860489Z test utils::tests::test_reexported_ansi_utils ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3861394Z test utils::tests::test_reexported_quote ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3861988Z test utils::tests::test_resolve_path_relative ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3862357Z test utils::tests::test_validate_args_success ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.3862698Z test utils::tests::test_validate_args_missing ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4793859Z test commands::sleep::tests::test_sleep_short ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4795098Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4795982Z test result: ok. 112 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4797165Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4799366Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/command_stream-f067b6fad89d6b7d`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4809436Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4809632Z running 0 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4809866Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4810285Z test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4811062Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4812890Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/builtin_commands-55545df01c49d42a`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4822531Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4822700Z running 45 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4827856Z test test_cat_from_stdin ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4828556Z test test_basename ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4833682Z test test_cat_nonexistent_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4834370Z test test_basename_with_suffix ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4834902Z test test_cp_copy_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4842161Z test test_cat_read_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4842733Z test test_cp_recursive ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4843145Z test test_dirname ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4847193Z test test_echo_basic ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4847675Z test test_echo_empty ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4848137Z test test_echo_with_e_flag ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4848698Z test test_echo_with_n_flag ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4849968Z test test_false_command ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4861067Z test test_env_list ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4861542Z test test_exit_default ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4861981Z test test_exit_with_code ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4862360Z test test_ls_with_a_flag ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4862632Z test test_ls_list_directory ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4862913Z test test_ls_with_l_flag ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4863196Z test test_mkdir_create_directory ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4863751Z test test_mv_rename_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4864248Z test test_mkdir_with_p_flag ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4869045Z test test_pwd_returns_current_directory ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4869795Z test test_rm_fail_on_directory ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4870659Z test test_rm_force ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4872060Z test test_rm_recursive ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4872820Z test test_mv_to_directory ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4873589Z test test_seq_range ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4874307Z test test_seq_simple ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4875045Z test test_rm_remove_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4875883Z test test_seq_with_increment ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4876623Z test test_test_file_not_exists ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4877296Z test test_test_file_exists ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4878567Z test test_test_string_empty ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4883256Z test test_test_is_directory ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4884232Z test test_test_string_equals ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4885015Z test test_test_is_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4885561Z test test_test_string_not_empty ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4886122Z test test_test_string_not_equals ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4886737Z test test_touch_create_file ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4887426Z test test_true_command ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4889938Z test test_which_builtin ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4890507Z test test_yes_with_cancel ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.4988925Z test test_touch_update_timestamp ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5886899Z test test_sleep ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5887233Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5887773Z test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5888394Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5891551Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/events-8a4cd5f9350272e4`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5901528Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5901866Z running 8 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5909082Z test test_event_data_variants ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5909968Z test test_stream_emitter_creation ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5910815Z test test_stream_emitter_different_events ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5911982Z test test_stream_emitter_multiple_listeners ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5914334Z test test_stream_emitter_on_emit ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5915163Z test test_stream_emitter_remove_all_listeners ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5916045Z test test_stream_emitter_off ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5916797Z test test_stream_emitter_once ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5918086Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/macros-9f6a5e1b6fd23b30`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5918797Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5919225Z test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5919713Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5928966Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5929113Z running 9 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5935171Z test test_cmd_macro_simple ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5942024Z test test_cmd_macro_with_interpolation ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5942804Z test test_cmd_macro_with_special_chars ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5947311Z test test_cmd_macro_with_multiple_interpolations ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5947933Z test test_cs_macro_alias ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5948423Z test test_s_macro_alias ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5948971Z test test_cmd_macro_with_numbers ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5949668Z test test_sh_macro_alias ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5951095Z test test_s_macro_with_interpolation ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5951369Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5951641Z test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5952009Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5954670Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/pipeline-c57dc26c60cb50ff`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5964795Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5964947Z running 7 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5970275Z test test_pipeline_empty ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5971401Z test test_pipeline_failure_propagation ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5972312Z test test_pipeline_builder_pattern ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5973044Z test test_pipeline_simple ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5973820Z test test_pipeline_with_stdin ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.5994303Z test test_pipeline_two_commands ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6026103Z test test_pipeline_three_commands ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6026496Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6026946Z test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6027617Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6029647Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/process_runner-50d1aa8df905759f`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6039062Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6039232Z running 23 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6048121Z test test_create_and_run ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6053258Z test test_command_with_arguments ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6058116Z test test_custom_working_directory ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6058534Z test test_echo_with_multiple_words ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6058848Z test test_exec_with_options ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6059128Z test test_exit_code_nonzero ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6059395Z test test_exit_code_zero ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6059696Z test test_false_command_returns_nonzero ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6060047Z test test_process_runner_basic ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6060592Z test test_process_runner_is_finished ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6061620Z test test_process_runner_result ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6062652Z test test_process_runner_with_capture ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6063384Z test test_stderr_capture ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6063919Z test test_simple_echo ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6064661Z test test_stdin_content ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6065175Z test test_true_command_returns_zero ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6065671Z test test_virtual_echo ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6067077Z test test_virtual_false ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6068969Z test test_virtual_pwd ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6071486Z test test_virtual_true ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6107834Z test test_custom_environment_variable ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:26.6581036Z test test_virtual_sleep ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6070609Z test test_kill_process ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6071324Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6071748Z test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 10.00s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6072273Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6076971Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/shell_parser-025c33ffe2352dc0`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6087447Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6087769Z running 30 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6090790Z test test_needs_real_shell_combined_redirect ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6092050Z test test_needs_real_shell_command_substitution ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6092765Z test test_needs_real_shell_glob_patterns ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6093533Z test test_needs_real_shell_here_document ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6094227Z test test_needs_real_shell_variable_expansion ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6094899Z test test_needs_real_shell_stderr_redirect ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6095531Z test test_needs_real_shell_simple_commands ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6096154Z test test_parse_command_with_quoted_args ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6096757Z test test_parse_sequence_with_and ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6098940Z test test_parse_complex_pipeline_and_sequence ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6099493Z test test_parse_pipeline ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6099988Z test test_parse_sequence_mixed ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6100654Z test test_parse_sequence_with_or ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6101558Z test test_parse_simple_command ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6102073Z test test_parse_subshell ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6102592Z test test_parse_subshell_with_sequence ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6103132Z test test_parse_with_redirect_append ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6103880Z test test_parse_with_redirect_out ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6104422Z test test_tokenize_simple_command ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6104956Z test test_tokenize_double_quoted_string ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6105503Z test test_tokenize_mixed_operators ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6106032Z test test_tokenize_single_quoted_string ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6106572Z test test_tokenize_with_and_operator ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6107101Z test test_tokenize_with_or_operator ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6107635Z test test_tokenize_with_append_redirect ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6108230Z test test_tokenize_with_input_redirect ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6108785Z test test_tokenize_with_parentheses ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6109290Z test test_tokenize_with_pipe ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6109766Z test test_tokenize_with_redirect ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6110272Z test test_tokenize_with_semicolon ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6110601Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6111225Z test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6111882Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6112629Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/state-b17e626b66642584`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6119302Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6119471Z running 13 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6122450Z test test_global_state_default ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6126860Z test test_global_state_initial_cwd ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6127980Z test test_global_state_runner_registration ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6129628Z test test_global_state_reset ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6130606Z test test_global_state_shell_settings ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6131633Z test test_global_state_signal_handlers ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6132221Z test test_global_state_with_shell_settings ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6132770Z test test_shell_settings_default ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6133294Z test test_global_state_virtual_commands ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6133916Z test test_shell_settings_enable_disable ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6134439Z test test_shell_settings_reset ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6135194Z test test_shell_settings_set_long_names ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6135747Z test test_shell_settings_set_short_flags ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6136117Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6136552Z test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6137182Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6138050Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/stream-6f236615fc02e9df`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6144799Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6144977Z running 8 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6164191Z test test_output_stream_chunks ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6164961Z test test_streaming_runner_basic ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6172141Z test test_streaming_collect_stdout ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6172715Z test test_streaming_exit_code ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6192388Z test test_streaming_runner_cwd ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6193043Z test test_streaming_runner_env ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6195242Z test test_streaming_stderr ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6195717Z test test_streaming_runner_with_stdin ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6196100Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6196385Z test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6196758Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6199003Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/utils-455f4be47d336ce0`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6208967Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6209115Z running 35 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6212686Z test test_ansi_config_default ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6213417Z test test_ansi_config_process_preserve_all ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6214325Z test test_ansi_config_process_strip_control_only ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6215157Z test test_command_result_error ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6215881Z test test_command_result_error_with_code ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6216694Z test test_command_result_success_empty ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6217451Z test test_invalid_argument_error ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6218200Z test test_missing_operand_error ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6219234Z test test_quote_already_double_quoted ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6221201Z test test_ansi_config_process_strip_all ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6222097Z test test_ansi_config_process_strip_ansi_only ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6222959Z test test_command_result_success ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6223718Z test test_quote_already_single_quoted ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6232190Z test test_quote_empty_string ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6232747Z test test_quote_newline ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6242176Z test test_quote_path ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6242695Z test test_quote_safe_characters ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6243237Z test test_quote_simple_string ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6246838Z test test_quote_special_characters ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6247454Z test test_quote_with_single_quote ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6248015Z test test_resolve_path_absolute ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6253826Z test test_resolve_path_relative_with_cwd ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6254816Z test test_resolve_path_relative_without_cwd ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6255707Z test test_quote_with_spaces ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6256468Z test test_strip_all ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6257150Z test test_strip_ansi_basic ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6257870Z test test_strip_ansi_color_codes ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6262362Z test test_strip_control_chars_basic ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6263246Z test test_strip_control_chars_preserve_carriage_return ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6263864Z test test_strip_ansi_no_sequences ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6264176Z test test_strip_ansi_multiple ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6264702Z test test_validate_args_sufficient ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6265044Z test test_strip_control_chars_preserve_newline ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6265390Z test test_strip_control_chars_preserve_tab ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6265713Z test test_validate_args_insufficient ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6265918Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6266443Z test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6266803Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6268483Z ^[[1m^[[92m     Running^[[0m `/home/runner/work/command-stream/command-stream/rust/target/debug/deps/virtual_commands-adeea1b5e623bec8`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6277746Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6277891Z running 20 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6281190Z test test_command_context_get_cwd ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6281842Z test test_command_context_is_cancelled_with_fn ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6283466Z test test_command_context_is_cancelled_default ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6284069Z test test_command_context_with_cwd ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6284624Z test test_command_context_new ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6290840Z test test_disable_virtual_commands ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6296551Z test test_enable_virtual_commands ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6297132Z test test_execute_echo_with_n_flag ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6297765Z test test_execute_virtual_echo ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6301879Z test test_execute_virtual_exit ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6302389Z test test_execute_virtual_false ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6302774Z test test_execute_virtual_pwd ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6303068Z test test_execute_virtual_true ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6303354Z test test_execute_virtual_which ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6303638Z test test_registry_contains ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6303908Z test test_registry_new ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7310642Z test test_execute_virtual_sleep ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7311728Z test test_process_runner_virtual_echo ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7313136Z test test_virtual_commands_default_enabled ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7313854Z test test_process_runner_virtual_pwd ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7314277Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7314783Z test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7315264Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7316466Z ^[[1m^[[92m   Doc-tests^[[0m command_stream
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7329741Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustdoc --edition=2021 --crate-type lib --color always --crate-name command_stream --test src/lib.rs --test-run-directory /home/runner/work/command-stream/command-stream/rust --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps -C embed-bitcode=no --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' --error-format human`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7801306Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7801770Z running 13 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7804728Z test src/events.rs - events::StreamEmitter::on (line 93) ... ignored
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.8425052Z test src/lib.rs - (line 38) - compile ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.8474680Z test src/macros.rs - macros (line 17) - compile ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.8946236Z test src/pipeline.rs - pipeline (line 9) - compile ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:36.9094589Z test src/macros.rs - macros::cmd (line 84) - compile ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.0503038Z test src/ansi.rs - ansi::AnsiUtils::strip_control_chars (line 37) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.1132216Z test src/ansi.rs - ansi::AnsiUtils::strip_ansi (line 17) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.1518492Z test src/stream.rs - stream (line 8) - compile ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.2212390Z test src/quote.rs - quote::needs_quoting (line 88) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.2442363Z test src/quote.rs - quote::quote (line 13) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4061208Z test src/trace.rs - trace::trace (line 33) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4150340Z test src/quote.rs - quote::quote_all (line 67) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4369236Z test src/trace.rs - trace::trace_lazy (line 55) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4369940Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4370503Z test result: ok. 12 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.66s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4371647Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4437854Z ##[group]Run cargo test --doc --all-features --verbose
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4438306Z ^[[36;1mcargo test --doc --all-features --verbose^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4463565Z shell: /usr/bin/bash -e {0}
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4463821Z env:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4464019Z   CARGO_TERM_COLOR: always
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4464407Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4464719Z   CARGO_TOKEN: ***
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4464942Z   CARGO_HOME: /home/runner/.cargo
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4465198Z   CARGO_INCREMENTAL: 0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.4465421Z ##[endgroup]
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5050713Z ^[[1m^[[92m       Fresh^[[0m libc v0.2.178
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5051787Z ^[[1m^[[92m       Fresh^[[0m unicode-ident v1.0.22
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5052516Z ^[[1m^[[92m       Fresh^[[0m cfg-if v1.0.4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5053165Z ^[[1m^[[92m       Fresh^[[0m memchr v2.7.6
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5053868Z ^[[1m^[[92m       Fresh^[[0m proc-macro2 v1.0.104
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5054596Z ^[[1m^[[92m       Fresh^[[0m smallvec v1.15.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5055344Z ^[[1m^[[92m       Fresh^[[0m scopeguard v1.2.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5056033Z ^[[1m^[[92m       Fresh^[[0m quote v1.0.42
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5056677Z ^[[1m^[[92m       Fresh^[[0m lock_api v0.4.14
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5057397Z ^[[1m^[[92m       Fresh^[[0m parking_lot_core v0.9.12
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5058147Z ^[[1m^[[92m       Fresh^[[0m aho-corasick v1.1.4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5058828Z ^[[1m^[[92m       Fresh^[[0m syn v2.0.111
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5059459Z ^[[1m^[[92m       Fresh^[[0m errno v0.3.14
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5060100Z ^[[1m^[[92m       Fresh^[[0m autocfg v1.5.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5060713Z ^[[1m^[[92m       Fresh^[[0m regex-syntax v0.8.8
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5061632Z ^[[1m^[[92m       Fresh^[[0m bitflags v2.10.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5062311Z ^[[1m^[[92m       Fresh^[[0m pin-project-lite v0.2.16
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5062956Z ^[[1m^[[92m       Fresh^[[0m tokio-macros v2.6.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5063544Z ^[[1m^[[92m       Fresh^[[0m regex-automata v0.4.13
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5064173Z ^[[1m^[[92m       Fresh^[[0m signal-hook-registry v1.4.8
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5064798Z ^[[1m^[[92m       Fresh^[[0m parking_lot v0.12.5
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5065616Z ^[[1m^[[92m       Fresh^[[0m mio v1.1.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5066127Z ^[[1m^[[92m       Fresh^[[0m socket2 v0.6.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5066676Z ^[[1m^[[92m       Fresh^[[0m cfg_aliases v0.2.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5067249Z ^[[1m^[[92m       Fresh^[[0m linux-raw-sys v0.11.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5067802Z ^[[1m^[[92m       Fresh^[[0m bytes v1.11.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5068311Z ^[[1m^[[92m       Fresh^[[0m rustix v1.1.3
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5068822Z ^[[1m^[[92m       Fresh^[[0m tokio v1.48.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5069349Z ^[[1m^[[92m       Fresh^[[0m serde_core v1.0.228
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5069918Z ^[[1m^[[92m       Fresh^[[0m futures-core v0.3.31
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5070507Z ^[[1m^[[92m       Fresh^[[0m predicates-core v1.0.9
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5071288Z ^[[1m^[[92m       Fresh^[[0m num-traits v0.2.19
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5071817Z ^[[1m^[[92m       Fresh^[[0m zmij v1.0.2
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5072445Z ^[[1m^[[92m       Fresh^[[0m serde_derive v1.0.228
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5073084Z ^[[1m^[[92m       Fresh^[[0m async-stream-impl v0.3.6
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5073710Z ^[[1m^[[92m       Fresh^[[0m thiserror-impl v2.0.17
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5074263Z ^[[1m^[[92m       Fresh^[[0m either v1.15.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5074757Z ^[[1m^[[92m       Fresh^[[0m itoa v1.0.17
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5075081Z ^[[1m^[[92m       Fresh^[[0m termtree v0.5.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5075389Z ^[[1m^[[92m       Fresh^[[0m difflib v0.4.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5075687Z ^[[1m^[[92m       Fresh^[[0m anstyle v1.0.13
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5076004Z ^[[1m^[[92m       Fresh^[[0m once_cell v1.21.3
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5076318Z ^[[1m^[[92m       Fresh^[[0m env_home v0.1.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5076677Z ^[[1m^[[92m       Fresh^[[0m iana-time-zone v0.1.64
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5077004Z ^[[1m^[[92m       Fresh^[[0m which v7.0.3
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5077318Z ^[[1m^[[92m       Fresh^[[0m chrono v0.4.42
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5077665Z ^[[1m^[[92m       Fresh^[[0m serde_json v1.0.148
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5078023Z ^[[1m^[[92m       Fresh^[[0m predicates-tree v1.0.12
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5078616Z ^[[1m^[[92m       Fresh^[[0m predicates v3.1.3
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5078969Z ^[[1m^[[92m       Fresh^[[0m async-stream v0.3.6
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5079297Z ^[[1m^[[92m       Fresh^[[0m serde v1.0.228
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5079607Z ^[[1m^[[92m       Fresh^[[0m thiserror v2.0.17
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5079919Z ^[[1m^[[92m       Fresh^[[0m nix v0.29.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5080221Z ^[[1m^[[92m       Fresh^[[0m getrandom v0.3.4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5080545Z ^[[1m^[[92m       Fresh^[[0m tokio-stream v0.1.17
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5081086Z ^[[1m^[[92m       Fresh^[[0m bstr v1.12.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5081418Z ^[[1m^[[92m       Fresh^[[0m regex v1.12.2
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5081731Z ^[[1m^[[92m       Fresh^[[0m async-trait v0.1.89
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5082048Z ^[[1m^[[92m       Fresh^[[0m filetime v0.2.26
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5082365Z ^[[1m^[[92m       Fresh^[[0m wait-timeout v0.2.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5082685Z ^[[1m^[[92m       Fresh^[[0m fastrand v2.3.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5082980Z ^[[1m^[[92m       Fresh^[[0m glob v0.3.3
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5083287Z ^[[1m^[[92m       Fresh^[[0m tokio-test v0.4.4
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5083853Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `std::path::Path`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5084245Z   ^[[1m^[[94m--> ^[[0msrc/commands/mod.rs:53:5
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5084534Z    ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5084850Z ^[[1m^[[94m53^[[0m ^[[1m^[[94m|^[[0m use std::path::Path;
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5085211Z    ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5085511Z    ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5085928Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5086267Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5086453Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `e`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5097745Z   ^[[1m^[[94m--> ^[[0msrc/commands/touch.rs:33:24
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5098304Z    ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5098748Z ^[[1m^[[94m33^[[0m ^[[1m^[[94m|^[[0m             if let Err(e) =
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5099369Z    ^[[1m^[[94m|^[[0m                        ^[[1m^[[33m^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_e`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5100074Z    ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5100537Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5101153Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5101398Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `file_type`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5101793Z    ^[[1m^[[94m--> ^[[0msrc/commands/ls.rs:124:9
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5102101Z     ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5102512Z ^[[1m^[[94m124^[[0m ^[[1m^[[94m|^[[0m     let file_type = if metadata.is_dir() { "d" } else { "-" };
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5103248Z     ^[[1m^[[94m|^[[0m         ^[[1m^[[33m^^^^^^^^^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_file_type`^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5103672Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5103878Z ^[[1m^[[33mwarning^[[0m^[[1m: field `output_rx` is never read^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5104258Z    ^[[1m^[[94m--> ^[[0msrc/lib.rs:184:5
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5104537Z     ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5104855Z ^[[1m^[[94m175^[[0m ^[[1m^[[94m|^[[0m pub struct ProcessRunner {
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5105338Z     ^[[1m^[[94m|^[[0m            ^[[1m^[[94m-------------^[[0m ^[[1m^[[94mfield in this struct^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5105718Z ^[[1m^[[94m...^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5106175Z ^[[1m^[[94m184^[[0m ^[[1m^[[94m|^[[0m     output_rx: Option<mpsc::Receiver<StreamChunk>>,
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5106621Z     ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5107134Z     ^[[1m^[[94m|^[[0m
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5107708Z     ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5108032Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5108173Z ^[[1m^[[92m       Fresh^[[0m assert_cmd v2.1.1
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5108511Z ^[[1m^[[92m       Fresh^[[0m tempfile v3.24.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5109166Z ^[[1m^[[33mwarning^[[0m: `command-stream` (lib) generated 4 warnings (run `cargo fix --lib -p command-stream` to apply 3 suggestions)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5110152Z ^[[1m^[[92m       Fresh^[[0m command-stream v0.9.5 (/home/runner/work/command-stream/command-stream/rust)
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5110810Z ^[[1m^[[92m    Finished^[[0m `test` profile [unoptimized + debuginfo] target(s) in 0.04s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5111433Z ^[[1m^[[92m   Doc-tests^[[0m command_stream
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5122551Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustdoc --edition=2021 --crate-type lib --color always --crate-name command_stream --test src/lib.rs --test-run-directory /home/runner/work/command-stream/command-stream/rust --extern assert_cmd=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-e52e48642b473a59.rlib --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-25af62ef852c13f1.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-a696dd4767533fa7.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-cd1f126963559215.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-6d7642e2f9f8bde0.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-ddf34b48c2f727a7.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-7a49c4074e502b3b.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-de25de586ff8d1fb.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-7551b3a1dae149bb.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-3f4827befad472b3.rlib --extern serde=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-46203e8a6c9e58c4.rlib --extern serde_json=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-85fcef24435a3155.rlib --extern tempfile=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-9f5406b362cb6593.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-e62624a28117d3cb.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-0354b47b7111be41.rlib --extern tokio_test=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-c8bf71467468b09a.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-f1ef33cf79378bd0.rlib -L dependency=/home/runner/work/command-stream/command-stream/rust/target/debug/deps -C embed-bitcode=no --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' --error-format human`
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5571133Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5571376Z running 13 tests
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.5579763Z test src/events.rs - events::StreamEmitter::on (line 93) ... ignored
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.6189633Z test src/lib.rs - (line 38) - compile ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.6226292Z test src/macros.rs - macros (line 17) - compile ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.6796378Z test src/pipeline.rs - pipeline (line 9) - compile ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.6829345Z test src/macros.rs - macros::cmd (line 84) - compile ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.8593446Z test src/ansi.rs - ansi::AnsiUtils::strip_ansi (line 17) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.8632027Z test src/ansi.rs - ansi::AnsiUtils::strip_control_chars (line 37) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:37.9072314Z test src/stream.rs - stream (line 8) - compile ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.0232288Z test src/quote.rs - quote::needs_quoting (line 88) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.0592427Z test src/quote.rs - quote::quote (line 13) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.1585695Z test src/quote.rs - quote::quote_all (line 67) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.1845153Z test src/trace.rs - trace::trace (line 33) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.2328764Z test src/trace.rs - trace::trace_lazy (line 55) ... ok
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.2329292Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.2329707Z test result: ok. 12 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.68s
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.2330107Z 
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.2974097Z Post job cleanup.
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.4263895Z Cache hit occurred on the primary key Linux-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5, not saving cache.
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.4369239Z Post job cleanup.
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5319397Z [command]/usr/bin/git version
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5355195Z git version 2.54.0
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5397085Z Temporarily overriding HOME='/home/runner/work/_temp/f106f6d8-a7a4-4269-9f0d-6ee5031eff3f' before making global git config changes
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5398436Z Adding repository directory to the temporary git global config as a safe directory
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5409012Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5441731Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5472377Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5689121Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5713312Z http.https://github.com/.extraheader
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5725141Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5754117Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5966421Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.5995796Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.6310749Z Cleaning up orphan processes
+Test Rust (ubuntu-latest)	UNKNOWN STEP	2026-06-08T20:22:38.6583938Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Test Rust (macos-latest)	UNKNOWN STEP	﻿2026-06-08T20:22:03.3653170Z Current runner version: '2.334.0'
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3666610Z ##[group]Runner Image Provisioner
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3667080Z Hosted Compute Agent
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3667430Z Version: 20260520.533
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3667800Z Commit: 189110e25284a9812c124fd27b339e2fb4f2f9db
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3668340Z Build Date: 2026-05-20T17:44:04Z
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3668740Z Worker ID: {b5bd2183-7d89-4913-a778-442a17da4f49}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3669170Z Azure Region: westus
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3669520Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3670350Z ##[group]Operating System
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3670760Z macOS
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3671100Z 15.7.7
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3671410Z 24G720
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3671890Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3672240Z ##[group]Runner Image
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3672620Z Image: macos-15-arm64
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3673090Z Version: 20260527.0100.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3673890Z Included Software: https://github.com/actions/runner-images/blob/macos-15-arm64/20260527.0100/images/macos/macos-15-arm64-Readme.md
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3674910Z Image Release: https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260527.0100
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3675550Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3677520Z ##[group]GITHUB_TOKEN Permissions
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3678700Z Actions: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3679070Z ArtifactMetadata: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3679450Z Attestations: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3679810Z Checks: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3680150Z CodeQuality: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3680500Z Contents: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3680840Z Deployments: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3681190Z Discussions: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3681540Z Issues: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3681870Z Metadata: read
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3682210Z Models: read
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3682550Z Packages: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3682930Z Pages: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3683270Z PullRequests: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3683640Z RepositoryProjects: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3684030Z SecurityEvents: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3684420Z Statuses: write
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3684790Z VulnerabilityAlerts: read
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3685180Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3686590Z Secret source: Actions
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3687030Z Prepare workflow directory
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.3995470Z Prepare all required actions
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.4020250Z Getting action download info
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:03.7502140Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.0011750Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.5455920Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7366810Z Complete job name: Test Rust (macos-latest)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7873180Z ##[group]Run actions/checkout@v4
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7873820Z with:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7874190Z   repository: link-foundation/command-stream
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7877310Z   token: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7877660Z   ssh-strict: true
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7877990Z   ssh-user: git
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7878330Z   persist-credentials: true
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7878690Z   clean: true
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7879030Z   sparse-checkout-cone-mode: true
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7879410Z   fetch-depth: 1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7879730Z   fetch-tags: false
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7880050Z   show-progress: true
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7880370Z   lfs: false
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7880680Z   submodules: false
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7881090Z   set-safe-directory: true
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7881610Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7881930Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7882390Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7882800Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:04.7883120Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.0628430Z Syncing repository: link-foundation/command-stream
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.0629840Z ##[group]Getting Git version info
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.0630400Z Working directory is '/Users/runner/work/command-stream/command-stream'
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.0631950Z [command]/opt/homebrew/bin/git version
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.0869280Z git version 2.54.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.0893130Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.0899130Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/d20a675e-fa24-43ec-a433-8c6f34fafad5/.gitconfig'
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.0909650Z Temporarily overriding HOME='/Users/runner/work/_temp/d20a675e-fa24-43ec-a433-8c6f34fafad5' before making global git config changes
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.0910660Z Adding repository directory to the temporary git global config as a safe directory
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.0913550Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/command-stream/command-stream
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1004660Z Deleting the contents of '/Users/runner/work/command-stream/command-stream'
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1006840Z ##[group]Initializing the repository
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1011240Z [command]/opt/homebrew/bin/git init /Users/runner/work/command-stream/command-stream
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1186890Z hint: Using 'master' as the name for the initial branch. This default branch name
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1188080Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1188860Z hint: to use in all of your new repositories, which will suppress this warning,
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1189420Z hint: call:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1189740Z hint:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1190150Z hint: 	git config --global init.defaultBranch <name>
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1190590Z hint:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1191030Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1191690Z hint: 'development'. The just-created branch can be renamed via this command:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1192230Z hint:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1192550Z hint: 	git branch -m <name>
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1192940Z hint:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1193410Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1194170Z Initialized empty Git repository in /Users/runner/work/command-stream/command-stream/.git/
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1195610Z [command]/opt/homebrew/bin/git remote add origin https://github.com/link-foundation/command-stream
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1256790Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1267420Z ##[group]Disabling automatic garbage collection
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1268360Z [command]/opt/homebrew/bin/git config --local gc.auto 0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1335340Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1337000Z ##[group]Setting up auth
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1339330Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.1409460Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.2619410Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.2667220Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3242610Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3291660Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3909930Z [command]/opt/homebrew/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3964430Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3965200Z ##[group]Fetching the repository
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:05.3970030Z [command]/opt/homebrew/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +89d47cf62671f8e1c4813af51128b0b9e47b6fa6:refs/remotes/origin/main
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8107830Z From https://github.com/link-foundation/command-stream
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8109140Z  * [new ref]         89d47cf62671f8e1c4813af51128b0b9e47b6fa6 -> origin/main
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8175880Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8176810Z ##[group]Determining the checkout info
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8177830Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8179500Z [command]/opt/homebrew/bin/git sparse-checkout disable
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8241460Z [command]/opt/homebrew/bin/git config --local --unset-all extensions.worktreeConfig
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8291030Z ##[group]Checking out the ref
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:06.8292350Z [command]/opt/homebrew/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:06.9664970Z Switched to a new branch 'main'
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:06.9767620Z branch 'main' set up to track 'origin/main'.
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.0071680Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.0374200Z [command]/opt/homebrew/bin/git log -1 --format=%H
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.0411720Z 89d47cf62671f8e1c4813af51128b0b9e47b6fa6
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.0954230Z ##[group]Run dtolnay/rust-toolchain@stable
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.0955180Z with:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.0955850Z   toolchain: stable
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.0956560Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.0957310Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.0958550Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.0959480Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.0960200Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1085180Z ##[group]Run : parse toolchain version
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1086210Z ^[[36;1m: parse toolchain version^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1087020Z ^[[36;1mif [[ -z $toolchain ]]; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1088370Z ^[[36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1089890Z ^[[36;1m  echo "'toolchain' is a required input" >&2^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1090770Z ^[[36;1m  exit 1^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1091730Z ^[[36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1093010Z ^[[36;1m  if [[ macOS == macOS ]]; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1094580Z ^[[36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1096020Z ^[[36;1m  else^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1097140Z ^[[36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1098650Z ^[[36;1m  fi^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1099520Z ^[[36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1101030Z ^[[36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1102360Z ^[[36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1103800Z ^[[36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1105190Z ^[[36;1melse^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1105930Z ^[[36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1106830Z ^[[36;1mfi^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1157120Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1158120Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1158770Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1159890Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1160780Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1161460Z   toolchain: stable
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1162130Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1500500Z ##[group]Run : construct rustup command line
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1501500Z ^[[36;1m: construct rustup command line^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1502800Z ^[[36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1504490Z ^[[36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1505830Z ^[[36;1mecho "downgrade=" >> $GITHUB_OUTPUT^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1543980Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1544940Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1546120Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1547200Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1548040Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1548690Z   targets: 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1549280Z   components: 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1549900Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1858550Z ##[group]Run : set $CARGO_HOME
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1859400Z ^[[36;1m: set $CARGO_HOME^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1860330Z ^[[36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1897760Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1898720Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1899330Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1900410Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1901280Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.1901910Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2166120Z ##[group]Run : install rustup if needed
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2167440Z ^[[36;1m: install rustup if needed^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2168320Z ^[[36;1mif ! command -v rustup &>/dev/null; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2170310Z ^[[36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2172280Z ^[[36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2173130Z ^[[36;1mfi^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2209260Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2210270Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2210930Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2212000Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2212820Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2213520Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2214270Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2456860Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2458540Z ^[[36;1mrustup toolchain install stable --profile minimal --no-self-update^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2496560Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2497530Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2498360Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2499370Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2500200Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2500840Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2501610Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.2502330Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.5706140Z info: syncing channel updates for stable-aarch64-apple-darwin
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.7017120Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.7218190Z info: removing previous version of component clippy
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.7327470Z info: removing previous version of component rustfmt
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.7432160Z info: removing previous version of component cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.7534200Z info: removing previous version of component rust-std
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.7636330Z info: removing previous version of component rustc
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:07.7739230Z info: downloading 5 components
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.8213830Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9526050Z   stable-aarch64-apple-darwin updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.95.0 (59807616e 2026-04-14))
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9527600Z info: self-update is disabled for this build of rustup
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9528230Z info: any updates to rustup will need to be fetched with your system package manager
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9528660Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9747820Z ##[group]Run rustup default stable
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9748250Z ^[[36;1mrustup default stable^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9845700Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9845980Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9846260Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9846790Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9847090Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9847380Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:14.9847580Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0321150Z info: using existing install for stable-aarch64-apple-darwin
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0339050Z info: default toolchain set to stable-aarch64-apple-darwin
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0339310Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0439300Z   stable-aarch64-apple-darwin unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0439790Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0474580Z ##[group]Run : create cachekey
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0475000Z ^[[36;1m: create cachekey^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0475600Z ^[[36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0476190Z ^[[36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0476720Z ^[[36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0510920Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0511220Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0511470Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0512410Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0512800Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0513060Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.0513430Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1280500Z ##[group]Run : disable incremental compilation
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1280910Z ^[[36;1m: disable incremental compilation^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1281330Z ^[[36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1281700Z ^[[36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1282060Z ^[[36;1mfi^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1336280Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1336680Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1336970Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1337450Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1337860Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1338080Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1338340Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1673740Z ##[group]Run : enable colors in Cargo output
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1674350Z ^[[36;1m: enable colors in Cargo output^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1674740Z ^[[36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1675150Z ^[[36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1675400Z ^[[36;1mfi^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1715520Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1715910Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1716180Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1716620Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1716990Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1717340Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1717580Z   CARGO_INCREMENTAL: 0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.1717790Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2049010Z ##[group]Run : enable Cargo sparse registry
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2049350Z ^[[36;1m: enable Cargo sparse registry^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2049700Z ^[[36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2050330Z ^[[36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/Users/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2051020Z ^[[36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2051540Z ^[[36;1m    touch "/Users/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2052020Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2052460Z ^[[36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2052970Z ^[[36;1m    touch "/Users/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2053440Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2053740Z ^[[36;1m  fi^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2053880Z ^[[36;1mfi^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2094950Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2095280Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2095460Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2095960Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2096720Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2096920Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2097180Z   CARGO_INCREMENTAL: 0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2097370Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2773460Z ##[group]Run : work around spurious network errors in curl 8.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2773890Z ^[[36;1m: work around spurious network errors in curl 8.0^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2774410Z ^[[36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2774940Z ^[[36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2775330Z ^[[36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2775600Z ^[[36;1mfi^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2813930Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2814250Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2814910Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2815380Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2815760Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2815970Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2816200Z   CARGO_INCREMENTAL: 0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.2816380Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3239490Z ##[group]Run rustc +stable --version --verbose
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3239840Z ^[[36;1mrustc +stable --version --verbose^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3278740Z shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3279060Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3279270Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3279750Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3280040Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3280240Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3280500Z   CARGO_INCREMENTAL: 0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3280690Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3820630Z rustc 1.96.0 (ac68faa20 2026-05-25)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3821600Z binary: rustc
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3822650Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3823750Z commit-date: 2026-05-25
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3824550Z host: aarch64-apple-darwin
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3825330Z release: 1.96.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.3826110Z LLVM version: 22.1.2
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4790250Z ##[group]Run actions/cache@v4
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4790590Z with:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4790780Z   path: ~/.cargo/registry
+Test Rust (macos-latest)	UNKNOWN STEP	~/.cargo/git
+Test Rust (macos-latest)	UNKNOWN STEP	rust/target
+Test Rust (macos-latest)	UNKNOWN STEP	
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4791190Z   key: macOS-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4791540Z   restore-keys: macOS-cargo-
+Test Rust (macos-latest)	UNKNOWN STEP	
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4791750Z   enableCrossOsArchive: false
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4791960Z   fail-on-cache-miss: false
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4792140Z   lookup-only: false
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4792310Z   save-always: false
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4792480Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4792630Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4792990Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4793230Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4793410Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4793640Z   CARGO_INCREMENTAL: 0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.4793850Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:15.7058940Z Cache hit for: macOS-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:16.5937170Z Received 114778961 of 114778961 (100.0%), 131.9 MBs/sec
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:16.5945660Z Cache Size: ~109 MB (114778961 B)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:16.5982570Z [command]/opt/homebrew/bin/gtar -xf /Users/runner/work/_temp/947e863d-516b-46ba-95d8-fae34d958693/cache.tzst -P -C /Users/runner/work/command-stream/command-stream --delay-directory-restore --use-compress-program unzstd
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.6653070Z Cache restored successfully
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.6932290Z Cache restored from key: macOS-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.7008010Z ##[group]Run cargo test --all-features --verbose
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.7008350Z ^[[36;1mcargo test --all-features --verbose^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.7048710Z shell: /bin/bash -e {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.7048970Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.7049570Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.7050730Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.7051110Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.7051300Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.7051530Z   CARGO_INCREMENTAL: 0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.7051740Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9867200Z ^[[1m^[[92m       Fresh^[[0m libc v0.2.178
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9869070Z ^[[1m^[[92m       Fresh^[[0m unicode-ident v1.0.22
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9869530Z ^[[1m^[[92m       Fresh^[[0m proc-macro2 v1.0.104
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9869910Z ^[[1m^[[92m       Fresh^[[0m cfg-if v1.0.4
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9870280Z ^[[1m^[[92m       Fresh^[[0m quote v1.0.42
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9870630Z ^[[1m^[[92m       Fresh^[[0m errno v0.3.14
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9871110Z ^[[1m^[[92m       Fresh^[[0m memchr v2.7.6
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9875050Z ^[[1m^[[92m       Fresh^[[0m syn v2.0.111
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9875450Z ^[[1m^[[92m       Fresh^[[0m smallvec v1.15.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9875830Z ^[[1m^[[92m       Fresh^[[0m scopeguard v1.2.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9876350Z ^[[1m^[[92m       Fresh^[[0m aho-corasick v1.1.4
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9876820Z ^[[1m^[[92m       Fresh^[[0m parking_lot_core v0.9.12
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9877210Z ^[[1m^[[92m       Fresh^[[0m lock_api v0.4.14
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9887160Z ^[[1m^[[92m       Fresh^[[0m bitflags v2.10.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9887450Z ^[[1m^[[92m       Fresh^[[0m regex-syntax v0.8.8
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9887820Z ^[[1m^[[92m       Fresh^[[0m autocfg v1.5.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9888200Z ^[[1m^[[92m       Fresh^[[0m pin-project-lite v0.2.16
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9888600Z ^[[1m^[[92m       Fresh^[[0m regex-automata v0.4.13
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9888960Z ^[[1m^[[92m       Fresh^[[0m parking_lot v0.12.5
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9889290Z ^[[1m^[[92m       Fresh^[[0m tokio-macros v2.6.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9889680Z ^[[1m^[[92m       Fresh^[[0m signal-hook-registry v1.4.8
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9889950Z ^[[1m^[[92m       Fresh^[[0m mio v1.1.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9890210Z ^[[1m^[[92m       Fresh^[[0m socket2 v0.6.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9890450Z ^[[1m^[[92m       Fresh^[[0m bytes v1.11.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9890730Z ^[[1m^[[92m       Fresh^[[0m cfg_aliases v0.2.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9891050Z ^[[1m^[[92m       Fresh^[[0m tokio v1.48.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9891320Z ^[[1m^[[92m       Fresh^[[0m serde_core v1.0.228
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9891600Z ^[[1m^[[92m       Fresh^[[0m rustix v1.1.3
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9891890Z ^[[1m^[[92m       Fresh^[[0m core-foundation-sys v0.8.7
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9892190Z ^[[1m^[[92m       Fresh^[[0m iana-time-zone v0.1.64
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9892540Z ^[[1m^[[92m       Fresh^[[0m num-traits v0.2.19
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9892800Z ^[[1m^[[92m       Fresh^[[0m zmij v1.0.2
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9893160Z ^[[1m^[[92m       Fresh^[[0m serde_derive v1.0.228
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9893470Z ^[[1m^[[92m       Fresh^[[0m thiserror-impl v2.0.17
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9893750Z ^[[1m^[[92m       Fresh^[[0m predicates-core v1.0.9
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9894100Z ^[[1m^[[92m       Fresh^[[0m either v1.15.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9894390Z ^[[1m^[[92m       Fresh^[[0m futures-core v0.3.31
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9894640Z ^[[1m^[[92m       Fresh^[[0m env_home v0.1.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9894970Z ^[[1m^[[92m       Fresh^[[0m once_cell v1.21.3
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9895280Z ^[[1m^[[92m       Fresh^[[0m itoa v1.0.17
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9895520Z ^[[1m^[[92m       Fresh^[[0m which v7.0.3
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9895770Z ^[[1m^[[92m       Fresh^[[0m serde_json v1.0.148
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9896050Z ^[[1m^[[92m       Fresh^[[0m serde v1.0.228
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9896310Z ^[[1m^[[92m       Fresh^[[0m thiserror v2.0.17
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9896550Z ^[[1m^[[92m       Fresh^[[0m chrono v0.4.42
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9896780Z ^[[1m^[[92m       Fresh^[[0m nix v0.29.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9897120Z ^[[1m^[[92m       Fresh^[[0m regex v1.12.2
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9897510Z ^[[1m^[[92m       Fresh^[[0m async-stream-impl v0.3.6
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9898250Z ^[[1m^[[92m       Fresh^[[0m async-trait v0.1.89
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9898610Z ^[[1m^[[92m       Fresh^[[0m filetime v0.2.26
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9898870Z ^[[1m^[[92m       Fresh^[[0m anstyle v1.0.13
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9899120Z ^[[1m^[[92m       Fresh^[[0m difflib v0.4.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9899620Z ^[[1m^[[92m       Fresh^[[0m glob v0.3.3
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9899890Z ^[[1m^[[92m       Fresh^[[0m termtree v0.5.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9900190Z ^[[1m^[[92m       Fresh^[[0m predicates-tree v1.0.12
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9900510Z ^[[1m^[[92m       Fresh^[[0m predicates v3.1.3
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9900780Z ^[[1m^[[92m       Fresh^[[0m async-stream v0.3.6
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9901060Z ^[[1m^[[92m       Fresh^[[0m getrandom v0.3.4
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9901440Z ^[[1m^[[92m       Fresh^[[0m tokio-stream v0.1.17
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9901710Z ^[[1m^[[92m       Fresh^[[0m bstr v1.12.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9901970Z ^[[1m^[[92m       Fresh^[[0m wait-timeout v0.2.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9902250Z ^[[1m^[[92m       Fresh^[[0m fastrand v2.3.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9902510Z ^[[1m^[[92m       Fresh^[[0m tokio-test v0.4.4
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9902790Z ^[[1m^[[92m       Fresh^[[0m assert_cmd v2.1.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9903070Z ^[[1m^[[92m       Fresh^[[0m tempfile v3.24.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9905840Z ^[[1m^[[92m       Dirty^[[0m command-stream v0.9.5 (/Users/runner/work/command-stream/command-stream/rust): the file `src/pipeline.rs` has changed (1780950126.957633484s, 5h 55m 10s after last build at 1780928816.299279236s)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9909490Z ^[[1m^[[92m   Compiling^[[0m command-stream v0.9.5 (/Users/runner/work/command-stream/command-stream/rust)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9919820Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name command_stream --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=3dc89d11bb10e3ca -C extra-filename=-85b79358287b4796 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:17.9935770Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name command_stream --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=50ccbeebf239b433 -C extra-filename=-f141f708f55db615 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rmeta --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rmeta --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rmeta --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rmeta --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rmeta --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rmeta --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rmeta --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rmeta --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rmeta --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rmeta --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rmeta --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rmeta`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.2932180Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `std::path::Path`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.2932860Z   ^[[1m^[[94m--> ^[[0msrc/commands/mod.rs:53:5
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.2934580Z    ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.2935030Z ^[[1m^[[94m53^[[0m ^[[1m^[[94m|^[[0m use std::path::Path;
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.2935480Z    ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.2935760Z    ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.2936200Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.2936520Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7454970Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `e`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7462900Z   ^[[1m^[[94m--> ^[[0msrc/commands/touch.rs:33:24
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7492090Z    ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7510360Z ^[[1m^[[94m33^[[0m ^[[1m^[[94m|^[[0m             if let Err(e) =
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7510980Z    ^[[1m^[[94m|^[[0m                        ^[[1m^[[33m^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_e`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7511440Z    ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7511920Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7512270Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7866330Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `file_type`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7921430Z    ^[[1m^[[94m--> ^[[0msrc/commands/ls.rs:124:9
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7953790Z     ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7966450Z ^[[1m^[[94m124^[[0m ^[[1m^[[94m|^[[0m     let file_type = if metadata.is_dir() { "d" } else { "-" };
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7967300Z     ^[[1m^[[94m|^[[0m         ^[[1m^[[33m^^^^^^^^^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_file_type`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.7968030Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8092460Z ^[[1m^[[33mwarning^[[0m^[[1m: field `output_rx` is never read^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8093160Z    ^[[1m^[[94m--> ^[[0msrc/lib.rs:184:5
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8093510Z     ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8093870Z ^[[1m^[[94m175^[[0m ^[[1m^[[94m|^[[0m pub struct ProcessRunner {
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8094470Z     ^[[1m^[[94m|^[[0m            ^[[1m^[[94m-------------^[[0m ^[[1m^[[94mfield in this struct^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8094890Z ^[[1m^[[94m...^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8095360Z ^[[1m^[[94m184^[[0m ^[[1m^[[94m|^[[0m     output_rx: Option<mpsc::Receiver<StreamChunk>>,
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8095710Z     ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8095980Z     ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8096330Z     ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:18.8096590Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:19.7918020Z ^[[1m^[[33mwarning^[[0m: `command-stream` (lib) generated 4 warnings (run `cargo fix --lib -p command-stream` to apply 3 suggestions)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:19.7940690Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name command_stream --edition=2021 src/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=bfc68d4dcdeace19 -C extra-filename=-4c8fad20734372a1 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:19.7958770Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name command_stream --edition=2021 src/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type bin --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=84220a010ce8eccb -C extra-filename=-be542467cec69e08 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:19.8200770Z ^[[1m^[[33mwarning^[[0m^[[1m: unused imports: `ProcessRunner` and `RunOptions`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:19.8202250Z  ^[[1m^[[94m--> ^[[0msrc/main.rs:5:27
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:19.8202680Z   ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:19.8203350Z ^[[1m^[[94m5^[[0m ^[[1m^[[94m|^[[0m use command_stream::{run, ProcessRunner, RunOptions};
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:19.8204020Z   ^[[1m^[[94m|^[[0m                           ^[[1m^[[33m^^^^^^^^^^^^^^[[0m  ^[[1m^[[33m^^^^^^^^^^^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:19.8204450Z   ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:19.8204910Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:19.8206380Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.5994510Z ^[[1m^[[33mwarning^[[0m: `command-stream` (bin "command-stream" test) generated 1 warning (1 duplicate)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.6034500Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name macros --edition=2021 tests/macros.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=95fb9c029b97e806 -C extra-filename=-6fa646a6778371d3 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.6173180Z ^[[1m^[[33mwarning^[[0m: `command-stream` (bin "command-stream") generated 1 warning (run `cargo fix --bin "command-stream" -p command-stream` to apply 1 suggestion)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.6188820Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name builtin_commands --edition=2021 tests/builtin_commands.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=66240bb99ca5b07e -C extra-filename=-d9cc4cc5186fd823 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.6492940Z ^[[1m^[[33mwarning^[[0m: `command-stream` (lib test) generated 4 warnings (4 duplicates)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.6508790Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name pipeline --edition=2021 tests/pipeline.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=bd2947160e1d43fa -C extra-filename=-279b74f7e62bb1e4 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.6618340Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `cd`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.6719490Z  ^[[1m^[[94m--> ^[[0mtests/builtin_commands.rs:6:20
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.6821530Z   ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.6922900Z ^[[1m^[[94m6^[[0m ^[[1m^[[94m|^[[0m     basename, cat, cd, cp, dirname, echo, env, exit, ls, mkdir, mv, pwd, rm, seq, sleep, test,
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7026100Z   ^[[1m^[[94m|^[[0m                    ^[[1m^[[33m^^^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7126990Z   ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7227740Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7327770Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7428990Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `command_stream::utils::CommandResult`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7529440Z  ^[[1m^[[94m--> ^[[0mtests/builtin_commands.rs:9:5
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7602490Z   ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7703630Z ^[[1m^[[94m9^[[0m ^[[1m^[[94m|^[[0m use command_stream::utils::CommandResult;
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7803790Z   ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.7903740Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.8005180Z ^[[1m^[[33mwarning^[[0m^[[1m: unused imports: `PipelineExt`, `ProcessRunner`, and `RunOptions`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.8105760Z  ^[[1m^[[94m--> ^[[0mtests/pipeline.rs:3:32
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.8206770Z   ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.8315710Z ^[[1m^[[94m3^[[0m ^[[1m^[[94m|^[[0m use command_stream::{Pipeline, PipelineExt, ProcessRunner, RunOptions};
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.8417510Z   ^[[1m^[[94m|^[[0m                                ^[[1m^[[33m^^^^^^^^^^^^[[0m  ^[[1m^[[33m^^^^^^^^^^^^^^[[0m  ^[[1m^[[33m^^^^^^^^^^^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.8529040Z   ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.8659440Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.8774070Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.8889620Z ^[[1m^[[33mwarning^[[0m^[[1m: function `ctx_with_cwd` is never used^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.9002830Z   ^[[1m^[[94m--> ^[[0mtests/builtin_commands.rs:27:4
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.9103940Z    ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.9350800Z ^[[1m^[[94m27^[[0m ^[[1m^[[94m|^[[0m fn ctx_with_cwd(args: Vec<&str>, cwd: PathBuf) -> CommandContext {
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.9351350Z    ^[[1m^[[94m|^[[0m    ^[[1m^[[33m^^^^^^^^^^^^^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.9463830Z    ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.9580080Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:22.9681880Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.1678320Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "pipeline") generated 1 warning (run `cargo fix --test "pipeline" -p command-stream` to apply 1 suggestion)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.1789760Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name events --edition=2021 tests/events.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=776891e60a6dc94f -C extra-filename=-31652c60d0380046 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.2210730Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name stream --edition=2021 tests/stream.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=f44ce24ca03a09a0 -C extra-filename=-ff7f3a894d248d20 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.2761320Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `AsyncIterator`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.2762560Z  ^[[1m^[[94m--> ^[[0mtests/stream.rs:3:22
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.2821790Z   ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.2943280Z ^[[1m^[[94m3^[[0m ^[[1m^[[94m|^[[0m use command_stream::{AsyncIterator, OutputChunk, StreamingRunner};
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.3044490Z   ^[[1m^[[94m|^[[0m                      ^[[1m^[[33m^^^^^^^^^^^^^^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.3145560Z   ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.3246740Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.3347620Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.3641390Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "builtin_commands") generated 3 warnings (run `cargo fix --test "builtin_commands" -p command-stream` to apply 2 suggestions)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.3751950Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name process_runner --edition=2021 tests/process_runner.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=c36fdb0908622b5b -C extra-filename=-a622080a6bc6a654 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.3861930Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `std::path::PathBuf`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.3961650Z  ^[[1m^[[94m--> ^[[0mtests/process_runner.rs:7:5
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.4062830Z   ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.4163850Z ^[[1m^[[94m7^[[0m ^[[1m^[[94m|^[[0m use std::path::PathBuf;
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.4264220Z   ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^^^^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.4365510Z   ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.4466310Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.4570310Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.5997480Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "stream") generated 1 warning
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.6008140Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name utils --edition=2021 tests/utils.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=e417bc9d10f06588 -C extra-filename=-129d82f690348e14 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.7112240Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name state --edition=2021 tests/state.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=dae6e8c54fdfafd4 -C extra-filename=-4c3d804b1a1db235 --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:23.8792100Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name shell_parser --edition=2021 tests/shell_parser.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=0a21e39aa60df7f3 -C extra-filename=-05c50bf1851579ee --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.0461610Z ^[[1m^[[33mwarning^[[0m: `command-stream` (test "process_runner") generated 1 warning (run `cargo fix --test "process_runner" -p command-stream` to apply 1 suggestion)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.0473590Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc --crate-name virtual_commands --edition=2021 tests/virtual_commands.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --emit=dep-info,link -C embed-bitcode=no -C debuginfo=2 -C split-debuginfo=unpacked --test --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=bc97e9d99f946901 -C extra-filename=-a9acb435784019ca --out-dir /Users/runner/work/command-stream/command-stream/rust/target/debug/deps -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4411030Z ^[[1m^[[92m    Finished^[[0m `test` profile [unoptimized + debuginfo] target(s) in 6.64s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4448910Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/command_stream-85b79358287b4796`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4491840Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4493510Z running 112 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4497160Z test ansi::tests::test_ansi_config_default ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4498630Z test ansi::tests::test_ansi_config_strip_control_only ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4511660Z test ansi::tests::test_ansi_config_strip_ansi_only ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4517040Z test ansi::tests::test_strip_all ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4517420Z test ansi::tests::test_ansi_config_strip_all ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4517790Z test ansi::tests::test_strip_control_chars ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4518230Z test ansi::tests::test_strip_control_chars_preserves_whitespace ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4550480Z test ansi::tests::test_strip_ansi ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4550870Z test ansi::tests::test_strip_ansi_multiple_codes ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4551230Z test commands::basename::tests::test_basename_no_path ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4551670Z test commands::basename::tests::test_basename_simple ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4552020Z test commands::basename::tests::test_basename_with_suffix ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4552450Z test commands::cat::tests::test_cat_nonexistent ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4552790Z test commands::cat::tests::test_cat_stdin ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4553080Z test commands::cd::tests::test_cd_to_nonexistent ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4553430Z test commands::cd::tests::test_cd_to_temp ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4553700Z test commands::cat::tests::test_cat_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4553990Z test commands::cat::tests::test_cat_multiple_files ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4554420Z test commands::cp::tests::test_cp_directory_recursive ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4554810Z test commands::cp::tests::test_cp_directory_without_recursive ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4555160Z test commands::dirname::tests::test_dirname_just_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4555480Z test commands::dirname::tests::test_dirname_root ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4555850Z test commands::dirname::tests::test_dirname_simple ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4556140Z test commands::echo::tests::test_echo_empty ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4556410Z test commands::echo::tests::test_echo_simple ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4556700Z test commands::exit::tests::test_exit_default ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4556960Z test commands::env::tests::test_env ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4557260Z test commands::exit::tests::test_exit_with_code ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4557550Z test commands::cp::tests::test_cp_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4558060Z test commands::ls::tests::test_ls_current_dir ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4558420Z test commands::mkdir::tests::test_mkdir_missing_operand ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4558810Z test commands::ls::tests::test_ls_with_path ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4559150Z test commands::ls::tests::test_ls_hidden_files ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4559530Z test commands::mkdir::tests::test_mkdir_simple ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4559870Z test commands::mkdir::tests::test_mkdir_with_parents ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4560290Z test commands::mv::tests::test_mv_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4560710Z test commands::mv::tests::test_mv_nonexistent ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4569150Z test commands::pwd::tests::test_pwd ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4569550Z test commands::r#false::tests::test_false ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4569900Z test commands::mv::tests::test_mv_directory ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4570180Z test commands::r#true::tests::test_true ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4570480Z test commands::rm::tests::test_rm_nonexistent_force ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4570800Z test commands::rm::tests::test_rm_nonexistent_no_force ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4571120Z test commands::seq::tests::test_seq_descending ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4571740Z test commands::rm::tests::test_rm_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4572050Z test commands::rm::tests::test_rm_directory_recursive ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4572360Z test commands::seq::tests::test_seq_single_arg ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4572770Z test commands::seq::tests::test_seq_two_args ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4573060Z test commands::seq::tests::test_seq_three_args ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4573360Z test commands::seq::tests::test_seq_zero_increment ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4573650Z test commands::sleep::tests::test_sleep_invalid ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4573940Z test commands::sleep::tests::test_sleep_negative ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4574230Z test commands::test::tests::test_empty_string ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4574540Z test commands::test::tests::test_file_exists ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4574820Z test commands::test::tests::test_file_not_exists ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4575120Z test commands::test::tests::test_non_empty_string ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4575430Z test commands::test::tests::test_numeric_comparison ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4575740Z test commands::test::tests::test_string_equality ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4576030Z test commands::test::tests::test_string_inequality ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4576350Z test commands::touch::tests::test_touch_existing_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4576690Z test commands::touch::tests::test_touch_missing_operand ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4577250Z test commands::touch::tests::test_touch_new_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4577550Z test commands::sleep::tests::test_sleep_zero ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4577860Z test commands::which::tests::test_which_existing_command ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4578220Z test commands::which::tests::test_which_nonexistent_command ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4578570Z test commands::yes::tests::test_yes_custom_string ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4578900Z test commands::yes::tests::test_yes_with_cancellation ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4579210Z test events::tests::test_emit_basic ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4579490Z test events::tests::test_listener_count ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4579770Z test events::tests::test_multiple_events ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4580020Z test events::tests::test_off ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4580290Z test events::tests::test_once ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4593880Z test quote::tests::test_needs_quoting ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4596880Z test quote::tests::test_quote_all ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4597150Z test quote::tests::test_quote_empty ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4597400Z test quote::tests::test_quote_already_quoted ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4597690Z test quote::tests::test_quote_special_chars ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4597960Z test quote::tests::test_quote_with_newlines ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4598220Z test quote::tests::test_quote_safe_chars ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4598510Z test shell_parser::tests::test_needs_real_shell ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4598780Z test quote::tests::test_quote_with_tabs ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4599050Z test shell_parser::tests::test_parse_pipeline ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4599320Z test shell_parser::tests::test_parse_sequence ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4599610Z test shell_parser::tests::test_parse_simple_command ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4599890Z test shell_parser::tests::test_parse_subshell ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4600180Z test shell_parser::tests::test_parse_with_redirect ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4600480Z test shell_parser::tests::test_tokenize_simple_command ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4600790Z test shell_parser::tests::test_tokenize_with_operators ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4601080Z test shell_parser::tests::test_tokenize_with_pipe ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4601360Z test shell_parser::tests::test_tokenize_with_quotes ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4601640Z test state::tests::test_global_state_reset ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4601890Z test state::tests::test_global_state_runners ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4602150Z test state::tests::test_shell_settings_default ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4602740Z test state::tests::test_global_state_virtual_commands ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4603030Z test state::tests::test_shell_settings_set ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4603290Z test trace::tests::test_trace_disabled_by_default ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4603560Z test trace::tests::test_trace_enabled_by_verbose ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4603980Z test trace::tests::test_trace_explicit_false_overrides_verbose ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4604280Z test trace::tests::test_trace_explicit_true ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4604530Z test utils::tests::test_command_result_error ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4604820Z test utils::tests::test_command_result_error_with_code ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4605110Z test utils::tests::test_command_result_success ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4605370Z test utils::tests::test_invalid_argument_error ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4605630Z test utils::tests::test_missing_operand_error ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4605900Z test utils::tests::test_reexported_ansi_config ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4606170Z test utils::tests::test_reexported_ansi_utils ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4606520Z test utils::tests::test_reexported_quote ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4606780Z test utils::tests::test_resolve_path_absolute ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4607060Z test utils::tests::test_validate_args_missing ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4607320Z test utils::tests::test_resolve_path_relative ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.4607590Z test utils::tests::test_validate_args_success ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5584380Z test commands::sleep::tests::test_sleep_short ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5584880Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5585420Z test result: ok. 112 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5586000Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5588100Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/command_stream-4c8fad20734372a1`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5636610Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5636970Z running 0 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5637270Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5637700Z test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5638220Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5638980Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/builtin_commands-d9cc4cc5186fd823`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5684960Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5685160Z running 45 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5693610Z test test_basename ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5736190Z test test_basename_with_suffix ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5736680Z test test_cat_from_stdin ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5737060Z test test_cat_nonexistent_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5737460Z test test_cat_read_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5737840Z test test_dirname ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5738180Z test test_cp_copy_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5738670Z test test_echo_basic ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5739380Z test test_echo_empty ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5739730Z test test_cp_recursive ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5740090Z test test_echo_with_n_flag ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5740490Z test test_echo_with_e_flag ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5740850Z test test_exit_default ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5741180Z test test_env_list ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5741510Z test test_exit_with_code ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5741850Z test test_false_command ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5742210Z test test_ls_with_a_flag ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5742550Z test test_ls_with_l_flag ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5742930Z test test_ls_list_directory ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5743490Z test test_mkdir_with_p_flag ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5743860Z test test_mkdir_create_directory ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5745650Z test test_pwd_returns_current_directory ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5746070Z test test_mv_rename_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5746400Z test test_rm_force ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5747000Z test test_rm_fail_on_directory ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5747460Z test test_mv_to_directory ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5748140Z test test_seq_range ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5748480Z test test_rm_recursive ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5749230Z test test_seq_simple ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5749590Z test test_rm_remove_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5749950Z test test_seq_with_increment ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5750320Z test test_test_file_not_exists ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5750850Z test test_test_file_exists ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5751200Z test test_test_is_directory ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5751570Z test test_test_string_empty ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5751920Z test test_test_string_equals ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5752360Z test test_test_string_not_empty ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5752990Z test test_test_is_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5753240Z test test_test_string_not_equals ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5753520Z test test_touch_create_file ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5753780Z test test_true_command ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5754020Z test test_which_builtin ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.5754260Z test test_yes_with_cancel ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6431180Z test test_touch_update_timestamp ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6842770Z test test_sleep ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6843180Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6843810Z test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6844680Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6847780Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/events-31652c60d0380046`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6929980Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6931020Z running 8 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6947480Z test test_stream_emitter_creation ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6948330Z test test_event_data_variants ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6948900Z test test_stream_emitter_different_events ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6951100Z test test_stream_emitter_multiple_listeners ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6951830Z test test_stream_emitter_off ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6952520Z test test_stream_emitter_on_emit ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6953040Z test test_stream_emitter_once ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6953660Z test test_stream_emitter_remove_all_listeners ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6954080Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6954550Z test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6955210Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.6956160Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/macros-6fa646a6778371d3`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7025710Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7026730Z running 9 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7058820Z test test_cmd_macro_simple ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7077180Z test test_cmd_macro_with_numbers ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7078070Z test test_cmd_macro_with_interpolation ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7078530Z test test_cs_macro_alias ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7078970Z test test_cmd_macro_with_multiple_interpolations ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7079470Z test test_s_macro_alias ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7079860Z test test_cmd_macro_with_special_chars ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7080300Z test test_sh_macro_alias ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7080700Z test test_s_macro_with_interpolation ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7080980Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7081350Z test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7081860Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7082850Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/pipeline-279b74f7e62bb1e4`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7140060Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7141080Z running 7 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7155340Z test test_pipeline_builder_pattern ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7155880Z test test_pipeline_empty ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7156300Z test test_pipeline_failure_propagation ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7158050Z test test_pipeline_simple ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7158820Z test test_pipeline_with_stdin ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7241520Z test test_pipeline_two_commands ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7332410Z test test_pipeline_three_commands ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7332650Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7333500Z test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7333880Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7335110Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/process_runner-a622080a6bc6a654`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7374580Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7375530Z running 23 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7384540Z test test_command_with_arguments ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7385610Z test test_create_and_run ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7389000Z test test_echo_with_multiple_words ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7390200Z test test_exec_with_options ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7390610Z test test_exit_code_nonzero ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7391070Z test test_exit_code_zero ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7391690Z test test_false_command_returns_nonzero ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7392270Z test test_custom_working_directory ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7392640Z test test_process_runner_basic ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7393120Z test test_process_runner_is_finished ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7393690Z test test_process_runner_result ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7394080Z test test_process_runner_with_capture ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7394580Z test test_simple_echo ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7395110Z test test_stderr_capture ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7395440Z test test_stdin_content ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7395920Z test test_true_command_returns_zero ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7396430Z test test_virtual_echo ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7396980Z test test_virtual_false ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7397720Z test test_virtual_pwd ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7444210Z test test_custom_environment_variable ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7444660Z test test_virtual_true ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:24.7982370Z test test_virtual_sleep ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7453620Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/shell_parser-05c50bf1851579ee`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7454150Z test test_kill_process ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7519180Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/state-4c3d804b1a1db235`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7519980Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7578530Z test result: ok. 23 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 10.01s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7597470Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/stream-ff7f3a894d248d20`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7597920Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7606770Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7607010Z running 30 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7607320Z test test_needs_real_shell_combined_redirect ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7607670Z test test_needs_real_shell_command_substitution ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7608030Z test test_needs_real_shell_glob_patterns ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7608440Z test test_needs_real_shell_here_document ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7608840Z test test_needs_real_shell_simple_commands ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7609260Z test test_needs_real_shell_stderr_redirect ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7609610Z test test_needs_real_shell_variable_expansion ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7609940Z test test_parse_command_with_quoted_args ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7610320Z test test_parse_complex_pipeline_and_sequence ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7610620Z test test_parse_pipeline ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7610870Z test test_parse_sequence_mixed ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7611150Z test test_parse_sequence_with_and ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7611450Z test test_parse_sequence_with_or ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7611800Z test test_parse_subshell ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7612100Z test test_parse_simple_command ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7612400Z test test_parse_subshell_with_sequence ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7612730Z test test_parse_with_redirect_append ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7614640Z test test_parse_with_redirect_out ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7614990Z test test_tokenize_double_quoted_string ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7615310Z test test_tokenize_mixed_operators ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7615600Z test test_tokenize_simple_command ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7616420Z test test_tokenize_single_quoted_string ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7616830Z test test_tokenize_with_and_operator ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7617160Z test test_tokenize_with_append_redirect ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7617560Z test test_tokenize_with_input_redirect ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7772330Z test test_tokenize_with_or_operator ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7868260Z test test_tokenize_with_parentheses ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7881170Z test test_tokenize_with_pipe ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7890010Z test test_tokenize_with_redirect ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7906470Z test test_tokenize_with_semicolon ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7913730Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7922760Z test result: ok. 30 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7923310Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7923370Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7923490Z running 13 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7923730Z test test_global_state_default ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7924010Z test test_global_state_reset ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7924560Z test test_global_state_runner_registration ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7928890Z test test_global_state_initial_cwd ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7929210Z test test_global_state_shell_settings ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7929520Z test test_global_state_signal_handlers ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7929840Z test test_global_state_virtual_commands ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7930150Z test test_shell_settings_default ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7930450Z test test_shell_settings_enable_disable ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7937550Z test test_global_state_with_shell_settings ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7937900Z test test_shell_settings_reset ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7938220Z test test_shell_settings_set_long_names ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7938540Z test test_shell_settings_set_short_flags ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7938770Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7939030Z test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7940240Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7940360Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7940490Z running 8 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7940710Z test test_output_stream_chunks ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7941000Z test test_streaming_exit_code ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7941330Z test test_streaming_collect_stdout ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7941610Z test test_streaming_runner_basic ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7941880Z test test_streaming_runner_cwd ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7942150Z test test_streaming_runner_env ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7955170Z test test_streaming_stderr ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7984050Z test test_streaming_runner_with_stdin ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7984320Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7984580Z test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7985130Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.7987000Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/utils-129d82f690348e14`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8038980Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8062460Z running 35 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8063780Z ^[[1m^[[92m     Running^[[0m `/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/virtual_commands-a9acb435784019ca`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8065460Z test test_ansi_config_default ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8065770Z test test_ansi_config_process_preserve_all ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8066180Z test test_ansi_config_process_strip_control_only ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8066580Z test test_ansi_config_process_strip_all ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8066910Z test test_ansi_config_process_strip_ansi_only ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8068450Z test test_command_result_error ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8068760Z test test_command_result_error_with_code ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8069080Z test test_command_result_success ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8069390Z test test_command_result_success_empty ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8069690Z test test_invalid_argument_error ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8070030Z test test_missing_operand_error ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8070330Z test test_quote_already_double_quoted ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8072660Z test test_quote_already_single_quoted ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8072970Z test test_quote_empty_string ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8073260Z test test_quote_newline ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8073510Z test test_quote_path ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8074050Z test test_quote_simple_string ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8074330Z test test_quote_safe_characters ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8074610Z test test_quote_special_characters ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8074900Z test test_quote_with_single_quote ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8075240Z test test_resolve_path_absolute ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8075520Z test test_quote_with_spaces ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8075810Z test test_resolve_path_relative_with_cwd ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8076140Z test test_resolve_path_relative_without_cwd ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8076450Z test test_strip_all ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8076700Z test test_strip_ansi_basic ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8076960Z test test_strip_ansi_color_codes ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8077250Z test test_strip_ansi_multiple ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8077530Z test test_strip_control_chars_basic ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8077870Z test test_strip_control_chars_preserve_carriage_return ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8078260Z test test_strip_ansi_no_sequences ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8078580Z test test_strip_control_chars_preserve_newline ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8078930Z test test_strip_control_chars_preserve_tab ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8079250Z test test_validate_args_insufficient ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8079580Z test test_validate_args_sufficient ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8079790Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8080050Z test result: ok. 35 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8080390Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8107500Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8114630Z running 20 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8118870Z test test_command_context_is_cancelled_default ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8120480Z test test_command_context_get_cwd ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8121010Z test test_command_context_is_cancelled_with_fn ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8121370Z test test_command_context_new ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8121630Z test test_command_context_with_cwd ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8121860Z test test_disable_virtual_commands ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8122120Z test test_execute_echo_with_n_flag ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8122350Z test test_enable_virtual_commands ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8122580Z test test_execute_virtual_echo ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8122790Z test test_execute_virtual_exit ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8123010Z test test_execute_virtual_false ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.8123230Z test test_execute_virtual_pwd ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9221020Z test test_execute_virtual_sleep ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9223340Z test test_execute_virtual_true ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9224010Z test test_execute_virtual_which ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9224340Z test test_registry_contains ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9224650Z test test_registry_new ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9225130Z test test_process_runner_virtual_pwd ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9225490Z test test_process_runner_virtual_echo ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9225860Z test test_virtual_commands_default_enabled ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9226100Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9226400Z test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.11s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9226790Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9227580Z ^[[1m^[[92m   Doc-tests^[[0m command_stream
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:34.9240050Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustdoc --edition=2021 --crate-type lib --color always --crate-name command_stream --test src/lib.rs --test-run-directory /Users/runner/work/command-stream/command-stream/rust --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps -C embed-bitcode=no --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' --error-format human`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.0045460Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.0046420Z running 13 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.0046810Z test src/events.rs - events::StreamEmitter::on (line 93) ... ignored
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.0549150Z test src/lib.rs - (line 38) - compile ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.1342500Z test src/macros.rs - macros (line 17) - compile ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.1908500Z test src/ansi.rs - ansi::AnsiUtils::strip_control_chars (line 37) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.1967060Z test src/ansi.rs - ansi::AnsiUtils::strip_ansi (line 17) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.1979590Z test src/macros.rs - macros::cmd (line 84) - compile ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.2363820Z test src/pipeline.rs - pipeline (line 9) - compile ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.3715750Z test src/quote.rs - quote::needs_quoting (line 88) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.3825220Z test src/quote.rs - quote::quote (line 13) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.4023360Z test src/stream.rs - stream (line 8) - compile ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5400750Z test src/quote.rs - quote::quote_all (line 67) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5624800Z test src/trace.rs - trace::trace (line 33) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5639930Z test src/trace.rs - trace::trace_lazy (line 55) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5640480Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5640890Z test result: ok. 12 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.56s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5641230Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5691570Z ##[group]Run cargo test --doc --all-features --verbose
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5691900Z ^[[36;1mcargo test --doc --all-features --verbose^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5722880Z shell: /bin/bash -e {0}
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5723050Z env:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5723190Z   CARGO_TERM_COLOR: always
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5723490Z   CARGO_REGISTRY_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5723710Z   CARGO_TOKEN: ***
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5723870Z   CARGO_HOME: /Users/runner/.cargo
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5724060Z   CARGO_INCREMENTAL: 0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.5724210Z ##[endgroup]
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6404470Z ^[[1m^[[92m       Fresh^[[0m unicode-ident v1.0.22
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6405030Z ^[[1m^[[92m       Fresh^[[0m libc v0.2.178
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6405350Z ^[[1m^[[92m       Fresh^[[0m proc-macro2 v1.0.104
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6406020Z ^[[1m^[[92m       Fresh^[[0m cfg-if v1.0.4
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6406280Z ^[[1m^[[92m       Fresh^[[0m quote v1.0.42
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6406550Z ^[[1m^[[92m       Fresh^[[0m errno v0.3.14
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6407390Z ^[[1m^[[92m       Fresh^[[0m syn v2.0.111
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6407740Z ^[[1m^[[92m       Fresh^[[0m memchr v2.7.6
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6408080Z ^[[1m^[[92m       Fresh^[[0m scopeguard v1.2.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6408350Z ^[[1m^[[92m       Fresh^[[0m smallvec v1.15.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6408660Z ^[[1m^[[92m       Fresh^[[0m aho-corasick v1.1.4
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6408960Z ^[[1m^[[92m       Fresh^[[0m lock_api v0.4.14
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6409260Z ^[[1m^[[92m       Fresh^[[0m parking_lot_core v0.9.12
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6410700Z ^[[1m^[[92m       Fresh^[[0m regex-syntax v0.8.8
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6411100Z ^[[1m^[[92m       Fresh^[[0m autocfg v1.5.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6412620Z ^[[1m^[[92m       Fresh^[[0m bitflags v2.10.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6412940Z ^[[1m^[[92m       Fresh^[[0m pin-project-lite v0.2.16
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6413250Z ^[[1m^[[92m       Fresh^[[0m regex-automata v0.4.13
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6414860Z ^[[1m^[[92m       Fresh^[[0m parking_lot v0.12.5
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6415180Z ^[[1m^[[92m       Fresh^[[0m tokio-macros v2.6.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6415500Z ^[[1m^[[92m       Fresh^[[0m signal-hook-registry v1.4.8
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6415820Z ^[[1m^[[92m       Fresh^[[0m mio v1.1.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6416080Z ^[[1m^[[92m       Fresh^[[0m socket2 v0.6.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6417690Z ^[[1m^[[92m       Fresh^[[0m bytes v1.11.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6422560Z ^[[1m^[[92m       Fresh^[[0m cfg_aliases v0.2.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6423060Z ^[[1m^[[92m       Fresh^[[0m tokio v1.48.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6423450Z ^[[1m^[[92m       Fresh^[[0m serde_core v1.0.228
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6426320Z ^[[1m^[[92m       Fresh^[[0m rustix v1.1.3
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6426750Z ^[[1m^[[92m       Fresh^[[0m predicates-core v1.0.9
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6427310Z ^[[1m^[[92m       Fresh^[[0m core-foundation-sys v0.8.7
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6427730Z ^[[1m^[[92m       Fresh^[[0m futures-core v0.3.31
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6428200Z ^[[1m^[[92m       Fresh^[[0m iana-time-zone v0.1.64
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6441480Z ^[[1m^[[92m       Fresh^[[0m num-traits v0.2.19
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6504330Z ^[[1m^[[92m       Fresh^[[0m zmij v1.0.2
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6505030Z ^[[1m^[[92m       Fresh^[[0m async-stream-impl v0.3.6
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6505450Z ^[[1m^[[92m       Fresh^[[0m thiserror-impl v2.0.17
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6505840Z ^[[1m^[[92m       Fresh^[[0m serde_derive v1.0.228
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6506610Z ^[[1m^[[92m       Fresh^[[0m once_cell v1.21.3
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6507010Z ^[[1m^[[92m       Fresh^[[0m itoa v1.0.17
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6507340Z ^[[1m^[[92m       Fresh^[[0m anstyle v1.0.13
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6507840Z ^[[1m^[[92m       Fresh^[[0m either v1.15.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6508430Z ^[[1m^[[92m       Fresh^[[0m env_home v0.1.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6508780Z ^[[1m^[[92m       Fresh^[[0m termtree v0.5.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6509130Z ^[[1m^[[92m       Fresh^[[0m difflib v0.4.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6509450Z ^[[1m^[[92m       Fresh^[[0m which v7.0.3
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6509810Z ^[[1m^[[92m       Fresh^[[0m predicates-tree v1.0.12
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6510190Z ^[[1m^[[92m       Fresh^[[0m predicates v3.1.3
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6510560Z ^[[1m^[[92m       Fresh^[[0m serde_json v1.0.148
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6511380Z ^[[1m^[[92m       Fresh^[[0m thiserror v2.0.17
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6511760Z ^[[1m^[[92m       Fresh^[[0m serde v1.0.228
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6512090Z ^[[1m^[[92m       Fresh^[[0m nix v0.29.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6520480Z ^[[1m^[[92m       Fresh^[[0m async-stream v0.3.6
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6521150Z ^[[1m^[[92m       Fresh^[[0m chrono v0.4.42
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6521520Z ^[[1m^[[92m       Fresh^[[0m getrandom v0.3.4
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6521900Z ^[[1m^[[92m       Fresh^[[0m tokio-stream v0.1.17
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6522260Z ^[[1m^[[92m       Fresh^[[0m bstr v1.12.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6522590Z ^[[1m^[[92m       Fresh^[[0m regex v1.12.2
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6522940Z ^[[1m^[[92m       Fresh^[[0m async-trait v0.1.89
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6523290Z ^[[1m^[[92m       Fresh^[[0m filetime v0.2.26
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6523630Z ^[[1m^[[92m       Fresh^[[0m wait-timeout v0.2.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6524230Z ^[[1m^[[92m       Fresh^[[0m glob v0.3.3
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6524540Z ^[[1m^[[92m       Fresh^[[0m fastrand v2.3.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6524880Z ^[[1m^[[92m       Fresh^[[0m assert_cmd v2.1.1
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6525390Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `std::path::Path`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6526120Z   ^[[1m^[[94m--> ^[[0msrc/commands/mod.rs:53:5
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6526440Z    ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6526780Z ^[[1m^[[94m53^[[0m ^[[1m^[[94m|^[[0m use std::path::Path;
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6527290Z    ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6527670Z    ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6528140Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6529280Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6529610Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `e`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6529970Z   ^[[1m^[[94m--> ^[[0msrc/commands/touch.rs:33:24
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6530420Z    ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6530710Z ^[[1m^[[94m33^[[0m ^[[1m^[[94m|^[[0m             if let Err(e) =
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6531240Z    ^[[1m^[[94m|^[[0m                        ^[[1m^[[33m^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_e`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6531660Z    ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6532050Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6532340Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6532490Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `file_type`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6532820Z    ^[[1m^[[94m--> ^[[0msrc/commands/ls.rs:124:9
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6533090Z     ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6533430Z ^[[1m^[[94m124^[[0m ^[[1m^[[94m|^[[0m     let file_type = if metadata.is_dir() { "d" } else { "-" };
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6534040Z     ^[[1m^[[94m|^[[0m         ^[[1m^[[33m^^^^^^^^^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_file_type`^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6534400Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6534620Z ^[[1m^[[33mwarning^[[0m^[[1m: field `output_rx` is never read^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6534940Z    ^[[1m^[[94m--> ^[[0msrc/lib.rs:184:5
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6535240Z     ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6535540Z ^[[1m^[[94m175^[[0m ^[[1m^[[94m|^[[0m pub struct ProcessRunner {
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6535980Z     ^[[1m^[[94m|^[[0m            ^[[1m^[[94m-------------^[[0m ^[[1m^[[94mfield in this struct^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6536300Z ^[[1m^[[94m...^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6536700Z ^[[1m^[[94m184^[[0m ^[[1m^[[94m|^[[0m     output_rx: Option<mpsc::Receiver<StreamChunk>>,
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6537070Z     ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6537320Z     ^[[1m^[[94m|^[[0m
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6537650Z     ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6537920Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6538030Z ^[[1m^[[92m       Fresh^[[0m tempfile v3.24.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6538380Z ^[[1m^[[92m       Fresh^[[0m tokio-test v0.4.4
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6538920Z ^[[1m^[[33mwarning^[[0m: `command-stream` (lib) generated 4 warnings (run `cargo fix --lib -p command-stream` to apply 3 suggestions)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6540010Z ^[[1m^[[92m       Fresh^[[0m command-stream v0.9.5 (/Users/runner/work/command-stream/command-stream/rust)
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6540580Z ^[[1m^[[92m    Finished^[[0m `test` profile [unoptimized + debuginfo] target(s) in 0.03s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6540960Z ^[[1m^[[92m   Doc-tests^[[0m command_stream
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6549740Z ^[[1m^[[92m     Running^[[0m `/Users/runner/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustdoc --edition=2021 --crate-type lib --color always --crate-name command_stream --test src/lib.rs --test-run-directory /Users/runner/work/command-stream/command-stream/rust --extern assert_cmd=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libassert_cmd-8171de51fa1871e3.rlib --extern async_trait=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libasync_trait-684a92d4af82f92a.dylib --extern chrono=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libchrono-5b62cb8548271d91.rlib --extern command_stream=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libcommand_stream-f141f708f55db615.rlib --extern filetime=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libfiletime-cc7202e39228be22.rlib --extern glob=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libglob-5e781dd9fe0d8419.rlib --extern libc=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/liblibc-adf0e97a72c9f357.rlib --extern nix=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libnix-1d7829e4fbf9c59a.rlib --extern once_cell=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libonce_cell-77cf045a0689ce84.rlib --extern regex=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libregex-f7a498c56b02aa67.rlib --extern serde=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde-526a305eddb32bca.rlib --extern serde_json=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libserde_json-b8e1f50cd96cfc26.rlib --extern tempfile=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtempfile-5227d10a42ec4c80.rlib --extern thiserror=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libthiserror-2190f405d921106c.rlib --extern tokio=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio-c16ca638aad13137.rlib --extern tokio_test=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libtokio_test-10c8a04ec10b0bf4.rlib --extern which=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps/libwhich-116700e1643d6de1.rlib -L dependency=/Users/runner/work/command-stream/command-stream/rust/target/debug/deps -C embed-bitcode=no --cfg 'feature="default"' --cfg 'feature="json"' --cfg 'feature="serde"' --cfg 'feature="serde_json"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' --error-format human`
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6967340Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6967890Z running 13 tests
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.6969280Z test src/events.rs - events::StreamEmitter::on (line 93) ... ignored
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.7435560Z test src/lib.rs - (line 38) - compile ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.8371180Z test src/macros.rs - macros (line 17) - compile ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.8901370Z test src/ansi.rs - ansi::AnsiUtils::strip_control_chars (line 37) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.9142150Z test src/ansi.rs - ansi::AnsiUtils::strip_ansi (line 17) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.9289690Z test src/macros.rs - macros::cmd (line 84) - compile ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:35.9404010Z test src/pipeline.rs - pipeline (line 9) - compile ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.1283900Z test src/quote.rs - quote::needs_quoting (line 88) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.1485580Z test src/quote.rs - quote::quote (line 13) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.1652030Z test src/stream.rs - stream (line 8) - compile ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.1652640Z test src/quote.rs - quote::quote_all (line 67) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.2728340Z test src/trace.rs - trace::trace (line 33) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.3446440Z test src/trace.rs - trace::trace_lazy (line 55) ... ok
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.3502500Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.3503040Z test result: ok. 12 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.65s
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.3503470Z 
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.4120210Z Post job cleanup.
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.5130180Z Cache hit occurred on the primary key macOS-cargo-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5, not saving cache.
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.5211340Z Post job cleanup.
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.5988210Z [command]/opt/homebrew/bin/git version
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6077670Z git version 2.54.0
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6097170Z Copying '/Users/runner/.gitconfig' to '/Users/runner/work/_temp/59d6e3f8-df28-4333-a205-4f271f299849/.gitconfig'
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6103820Z Temporarily overriding HOME='/Users/runner/work/_temp/59d6e3f8-df28-4333-a205-4f271f299849' before making global git config changes
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6104710Z Adding repository directory to the temporary git global config as a safe directory
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6111830Z [command]/opt/homebrew/bin/git config --global --add safe.directory /Users/runner/work/command-stream/command-stream
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6172430Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp core\.sshCommand
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6219910Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.6954970Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7003650Z http.https://github.com/.extraheader
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7015970Z [command]/opt/homebrew/bin/git config --local --unset-all http.https://github.com/.extraheader
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7066740Z [command]/opt/homebrew/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7642080Z [command]/opt/homebrew/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.7692840Z [command]/opt/homebrew/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:36.8357040Z Cleaning up orphan processes
+Test Rust (macos-latest)	UNKNOWN STEP	2026-06-08T20:22:37.0949540Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Build Rust package	UNKNOWN STEP	﻿2026-06-08T20:23:22.9696705Z Current runner version: '2.334.0'
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9732691Z ##[group]Runner Image Provisioner
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9733972Z Hosted Compute Agent
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9734806Z Version: 20260520.533
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9736438Z Commit: 189110e25284a9812c124fd27b339e2fb4f2f9db
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9737576Z Build Date: 2026-05-20T17:44:04Z
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9738708Z Worker ID: {97d319b0-2a38-474e-90ae-958035214444}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9740020Z Azure Region: eastus2
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9741003Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9743227Z ##[group]Operating System
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9744189Z Ubuntu
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9745129Z 24.04.4
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9745900Z LTS
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9746660Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9747615Z ##[group]Runner Image
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9748539Z Image: ubuntu-24.04
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9749811Z Version: 20260525.161.1
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9751772Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260525.161/images/ubuntu/Ubuntu2404-Readme.md
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9754326Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260525.161
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9755875Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9761397Z ##[group]GITHUB_TOKEN Permissions
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9764980Z Actions: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9765903Z ArtifactMetadata: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9766890Z Attestations: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9767924Z Checks: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9768761Z CodeQuality: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9769928Z Contents: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9770828Z Deployments: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9771740Z Discussions: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9772658Z Issues: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9773480Z Metadata: read
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9774350Z Models: read
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9775181Z Packages: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9776386Z Pages: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9777274Z PullRequests: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9778133Z RepositoryProjects: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9779182Z SecurityEvents: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9780406Z Statuses: write
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9781338Z VulnerabilityAlerts: read
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9782338Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9785446Z Secret source: Actions
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:22.9787054Z Prepare workflow directory
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:23.0537481Z Prepare all required actions
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:23.0591270Z Getting action download info
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:23.4016990Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:23.5079205Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:23.9753944Z Download action repository 'actions/cache@v4' (SHA:0057852bfaa89a56745cba8c7296529d2fc39830)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.2437895Z Complete job name: Build Rust package
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3360614Z ##[group]Run actions/checkout@v4
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3362098Z with:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3363027Z   repository: link-foundation/command-stream
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3373731Z   token: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3374581Z   ssh-strict: true
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3375620Z   ssh-user: git
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3376495Z   persist-credentials: true
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3377445Z   clean: true
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3378329Z   sparse-checkout-cone-mode: true
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3379360Z   fetch-depth: 1
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3380477Z   fetch-tags: false
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3381371Z   show-progress: true
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3382266Z   lfs: false
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3383082Z   submodules: false
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3383965Z   set-safe-directory: true
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3385214Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3386012Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3387241Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3388367Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.3389215Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.4656313Z Syncing repository: link-foundation/command-stream
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.4659183Z ##[group]Getting Git version info
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.4660988Z Working directory is '/home/runner/work/command-stream/command-stream'
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.4663073Z [command]/usr/bin/git version
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.4870041Z git version 2.54.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.4898327Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.4913579Z Temporarily overriding HOME='/home/runner/work/_temp/f70cf6a8-90f5-4484-8fb3-ac503e007a82' before making global git config changes
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.4916235Z Adding repository directory to the temporary git global config as a safe directory
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.4927880Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5261600Z Deleting the contents of '/home/runner/work/command-stream/command-stream'
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5265451Z ##[group]Initializing the repository
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5272503Z [command]/usr/bin/git init /home/runner/work/command-stream/command-stream
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5379154Z hint: Using 'master' as the name for the initial branch. This default branch name
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5381817Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5383729Z hint: to use in all of your new repositories, which will suppress this warning,
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5385200Z hint: call:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5386009Z hint:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5387006Z hint: 	git config --global init.defaultBranch <name>
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5388224Z hint:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5389352Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5391393Z hint: 'development'. The just-created branch can be renamed via this command:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5392868Z hint:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5393699Z hint: 	git branch -m <name>
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5394639Z hint:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5395854Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5884385Z Initialized empty Git repository in /home/runner/work/command-stream/command-stream/.git/
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5896578Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/command-stream
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5936753Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5938960Z ##[group]Disabling automatic garbage collection
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5941196Z [command]/usr/bin/git config --local gc.auto 0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5978704Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5981536Z ##[group]Setting up auth
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.5986415Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.6026705Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.9162307Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.9198057Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.9453750Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.9490999Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.9738035Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.9777784Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.9780227Z ##[group]Fetching the repository
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:24.9789107Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +89d47cf62671f8e1c4813af51128b0b9e47b6fa6:refs/remotes/origin/main
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.4312091Z From https://github.com/link-foundation/command-stream
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.4313560Z  * [new ref]         89d47cf62671f8e1c4813af51128b0b9e47b6fa6 -> origin/main
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.4347519Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.4348069Z ##[group]Determining the checkout info
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.4350175Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.4355766Z [command]/usr/bin/git sparse-checkout disable
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.4402804Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.4431653Z ##[group]Checking out the ref
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.4436065Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5182602Z Switched to a new branch 'main'
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5183417Z branch 'main' set up to track 'origin/main'.
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5195096Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5237580Z [command]/usr/bin/git log -1 --format=%H
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5262993Z 89d47cf62671f8e1c4813af51128b0b9e47b6fa6
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5650848Z ##[group]Run dtolnay/rust-toolchain@stable
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5651308Z with:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5651593Z   toolchain: stable
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5651889Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5652171Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5652814Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5653232Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5653521Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5776202Z ##[group]Run : parse toolchain version
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5776751Z ^[[36;1m: parse toolchain version^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5777139Z ^[[36;1mif [[ -z $toolchain ]]; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5777808Z ^[[36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5778505Z ^[[36;1m  echo "'toolchain' is a required input" >&2^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5778901Z ^[[36;1m  exit 1^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5779342Z ^[[36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5780087Z ^[[36;1m  if [[ Linux == macOS ]]; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5780728Z ^[[36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5781339Z ^[[36;1m  else^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5781846Z ^[[36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5782418Z ^[[36;1m  fi^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5782824Z ^[[36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5783465Z ^[[36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5784031Z ^[[36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5784652Z ^[[36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5785240Z ^[[36;1melse^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5785602Z ^[[36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5786031Z ^[[36;1mfi^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5820068Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5820550Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5820870Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5821511Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5821944Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5822307Z   toolchain: stable
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5822644Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5967997Z ##[group]Run : construct rustup command line
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5968503Z ^[[36;1m: construct rustup command line^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5969117Z ^[[36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5970405Z ^[[36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5971059Z ^[[36;1mecho "downgrade=" >> $GITHUB_OUTPUT^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.5999907Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6000392Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6000723Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6001323Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6001767Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6002099Z   targets: 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6002425Z   components: 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6002746Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6095921Z ##[group]Run : set $CARGO_HOME
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6096507Z ^[[36;1m: set $CARGO_HOME^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6096979Z ^[[36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6125489Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6125977Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6126312Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6126928Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6127366Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6127697Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6222677Z ##[group]Run : install rustup if needed
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6223483Z ^[[36;1m: install rustup if needed^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6223936Z ^[[36;1mif ! command -v rustup &>/dev/null; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6224883Z ^[[36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6225784Z ^[[36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6226213Z ^[[36;1mfi^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6254930Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6255407Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6255737Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6256332Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6256763Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6257121Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6257502Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6349815Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6350572Z ^[[36;1mrustup toolchain install stable --profile minimal --no-self-update^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6380012Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6380477Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6380795Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6381383Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6381810Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6382154Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6382545Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.6382925Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:25.8124791Z info: syncing channel updates for stable-x86_64-unknown-linux-gnu
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:26.0732817Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:26.0909843Z info: removing previous version of component clippy
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:26.0976738Z info: removing previous version of component rustfmt
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:26.0985344Z info: removing previous version of component cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:26.1023913Z info: removing previous version of component rust-std
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:26.1108179Z info: removing previous version of component rustc
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:26.1153024Z info: downloading 5 components
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9338941Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9423712Z   stable-x86_64-unknown-linux-gnu updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.95.0 (59807616e 2026-04-14))
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9424713Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9522018Z ##[group]Run rustup default stable
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9522370Z ^[[36;1mrustup default stable^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9549801Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9550180Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9550418Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9550995Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9551328Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9551577Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9551861Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9657776Z info: using existing install for stable-x86_64-unknown-linux-gnu
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9665218Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9665568Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9735833Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9736391Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9776640Z ##[group]Run : create cachekey
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9777004Z ^[[36;1m: create cachekey^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9777550Z ^[[36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9778414Z ^[[36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9778942Z ^[[36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9806243Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9806612Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9806833Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9807263Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9807571Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9807809Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:34.9808269Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0181368Z ##[group]Run : disable incremental compilation
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0181789Z ^[[36;1m: disable incremental compilation^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0182140Z ^[[36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0182500Z ^[[36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0182800Z ^[[36;1mfi^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0210342Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0210715Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0210941Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0211374Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0211697Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0211950Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0212225Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0308629Z ##[group]Run : enable colors in Cargo output
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0308998Z ^[[36;1m: enable colors in Cargo output^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0309343Z ^[[36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0309961Z ^[[36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0310277Z ^[[36;1mfi^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0336634Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0337008Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0337241Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0337667Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0337978Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0338231Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0338505Z   CARGO_INCREMENTAL: 0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0338744Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0411922Z ##[group]Run : enable Cargo sparse registry
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0412297Z ^[[36;1m: enable Cargo sparse registry^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0412688Z ^[[36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0413419Z ^[[36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0414162Z ^[[36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0414746Z ^[[36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0415298Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0415815Z ^[[36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0416392Z ^[[36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0416916Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0417281Z ^[[36;1m  fi^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0417503Z ^[[36;1mfi^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0442412Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0442773Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0442998Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0443408Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0443742Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0443991Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0444266Z   CARGO_INCREMENTAL: 0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0444507Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0782850Z ##[group]Run : work around spurious network errors in curl 8.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0783342Z ^[[36;1m: work around spurious network errors in curl 8.0^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0783968Z ^[[36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0784807Z ^[[36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0785297Z ^[[36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0785637Z ^[[36;1mfi^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0813122Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0813471Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0813707Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0814139Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0814620Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0814861Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0815139Z   CARGO_INCREMENTAL: 0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.0815376Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1023364Z ##[group]Run rustc +stable --version --verbose
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1023775Z ^[[36;1mrustc +stable --version --verbose^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1050825Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1051227Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1051455Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1051881Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1052204Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1052449Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1052728Z   CARGO_INCREMENTAL: 0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1052987Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1220681Z rustc 1.96.0 (ac68faa20 2026-05-25)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1221266Z binary: rustc
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1221608Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1222088Z commit-date: 2026-05-25
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1222616Z host: x86_64-unknown-linux-gnu
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1223107Z release: 1.96.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1223556Z LLVM version: 22.1.2
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1877033Z ##[group]Run actions/cache@v4
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1877351Z with:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1877634Z   path: ~/.cargo/registry
+Build Rust package	UNKNOWN STEP	~/.cargo/git
+Build Rust package	UNKNOWN STEP	rust/target
+Build Rust package	UNKNOWN STEP	
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1878185Z   key: Linux-cargo-build-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1878724Z   restore-keys: Linux-cargo-build-
+Build Rust package	UNKNOWN STEP	
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1879033Z   enableCrossOsArchive: false
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1879313Z   fail-on-cache-miss: false
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1879823Z   lookup-only: false
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1880064Z   save-always: false
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1880291Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1880513Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1880987Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1881319Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1881562Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1881840Z   CARGO_INCREMENTAL: 0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.1882085Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:35.4160332Z Cache hit for: Linux-cargo-build-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:36.0612035Z Received 125908729 of 125908729 (100.0%), 207.0 MBs/sec
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:36.0613043Z Cache Size: ~120 MB (125908729 B)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:36.0643199Z [command]/usr/bin/tar -xf /home/runner/work/_temp/4671a923-813a-40c1-a488-9612eb4f329e/cache.tzst -P -C /home/runner/work/command-stream/command-stream --use-compress-program unzstd
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1582422Z Cache restored successfully
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1734949Z Cache restored from key: Linux-cargo-build-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1850507Z ##[group]Run cargo build --release --verbose
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1850899Z ^[[36;1mcargo build --release --verbose^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1881873Z shell: /usr/bin/bash -e {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1882162Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1882383Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1882815Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1883147Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1883390Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1883672Z   CARGO_INCREMENTAL: 0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.1883936Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2766133Z ^[[1m^[[92m       Fresh^[[0m libc v0.2.178
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2766806Z ^[[1m^[[92m       Fresh^[[0m unicode-ident v1.0.22
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2767397Z ^[[1m^[[92m       Fresh^[[0m proc-macro2 v1.0.104
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2768269Z ^[[1m^[[92m       Fresh^[[0m cfg-if v1.0.4
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2768750Z ^[[1m^[[92m       Fresh^[[0m quote v1.0.42
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2769250Z ^[[1m^[[92m       Fresh^[[0m autocfg v1.5.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2769972Z ^[[1m^[[92m       Fresh^[[0m cfg_aliases v0.2.1
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2770476Z ^[[1m^[[92m       Fresh^[[0m syn v2.0.111
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2770970Z ^[[1m^[[92m       Fresh^[[0m scopeguard v1.2.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2771499Z ^[[1m^[[92m       Fresh^[[0m bitflags v2.10.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2771994Z ^[[1m^[[92m       Fresh^[[0m memchr v2.7.6
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2772473Z ^[[1m^[[92m       Fresh^[[0m smallvec v1.15.1
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2773022Z ^[[1m^[[92m       Fresh^[[0m parking_lot_core v0.9.12
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2773591Z ^[[1m^[[92m       Fresh^[[0m aho-corasick v1.1.4
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2774115Z ^[[1m^[[92m       Fresh^[[0m lock_api v0.4.14
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2774604Z ^[[1m^[[92m       Fresh^[[0m errno v0.3.14
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2775122Z ^[[1m^[[92m       Fresh^[[0m linux-raw-sys v0.11.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2775667Z ^[[1m^[[92m       Fresh^[[0m regex-syntax v0.8.8
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2776237Z ^[[1m^[[92m       Fresh^[[0m signal-hook-registry v1.4.8
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2776808Z ^[[1m^[[92m       Fresh^[[0m regex-automata v0.4.13
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2777330Z ^[[1m^[[92m       Fresh^[[0m rustix v1.1.3
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2777827Z ^[[1m^[[92m       Fresh^[[0m parking_lot v0.12.5
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2778343Z ^[[1m^[[92m       Fresh^[[0m num-traits v0.2.19
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2778863Z ^[[1m^[[92m       Fresh^[[0m tokio-macros v2.6.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2779406Z ^[[1m^[[92m       Fresh^[[0m thiserror-impl v2.0.17
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2779990Z ^[[1m^[[92m       Fresh^[[0m mio v1.1.1
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2780484Z ^[[1m^[[92m       Fresh^[[0m socket2 v0.6.1
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2781113Z ^[[1m^[[92m       Fresh^[[0m pin-project-lite v0.2.16
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2781742Z ^[[1m^[[92m       Fresh^[[0m bytes v1.11.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2782259Z ^[[1m^[[92m       Fresh^[[0m either v1.15.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2782743Z ^[[1m^[[92m       Fresh^[[0m env_home v0.1.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2783193Z ^[[1m^[[92m       Fresh^[[0m iana-time-zone v0.1.64
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2783646Z ^[[1m^[[92m       Fresh^[[0m which v7.0.3
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2783962Z ^[[1m^[[92m       Fresh^[[0m tokio v1.48.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2784294Z ^[[1m^[[92m       Fresh^[[0m thiserror v2.0.17
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2784622Z ^[[1m^[[92m       Fresh^[[0m chrono v0.4.42
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2784928Z ^[[1m^[[92m       Fresh^[[0m regex v1.12.2
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2785231Z ^[[1m^[[92m       Fresh^[[0m nix v0.29.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2785562Z ^[[1m^[[92m       Fresh^[[0m async-trait v0.1.89
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2785893Z ^[[1m^[[92m       Fresh^[[0m filetime v0.2.26
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2786217Z ^[[1m^[[92m       Fresh^[[0m once_cell v1.21.3
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2786531Z ^[[1m^[[92m       Fresh^[[0m glob v0.3.3
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2787521Z ^[[1m^[[92m       Dirty^[[0m command-stream v0.9.5 (/home/runner/work/command-stream/command-stream/rust): the file `src/commands/env.rs` has changed (1780950205.513693372s, 5h 54m 48s after last build at 1780928917.769706543s)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2788743Z ^[[1m^[[92m   Compiling^[[0m command-stream v0.9.5 (/home/runner/work/command-stream/command-stream/rust)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.2797530Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name command_stream --edition=2021 src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C linker-plugin-lto --cfg 'feature="default"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=597775dcf4632afc -C extra-filename=-fe9520a653a2bca2 --out-dir /home/runner/work/command-stream/command-stream/rust/target/release/deps -C strip=debuginfo -L dependency=/home/runner/work/command-stream/command-stream/rust/target/release/deps --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libasync_trait-c0245a43abfa5c4f.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libchrono-ef1f0e507a22c93d.rmeta --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libfiletime-ebea693976d5eb0a.rmeta --extern glob=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libglob-a89f9a8dc04672aa.rmeta --extern libc=/home/runner/work/command-stream/command-stream/rust/target/release/deps/liblibc-a9815fab408829ab.rmeta --extern nix=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libnix-84d85dec2538d073.rmeta --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libonce_cell-b36b517adc61825f.rmeta --extern regex=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libregex-4852f50ae0bfff27.rmeta --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libthiserror-7ef89ed650235c47.rmeta --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libtokio-5cebc317e66f182d.rmeta --extern which=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libwhich-7659c5c463050ff4.rmeta`
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.3182262Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `std::path::Path`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.3182785Z   ^[[1m^[[94m--> ^[[0msrc/commands/mod.rs:53:5
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.3183122Z    ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.3183512Z ^[[1m^[[94m53^[[0m ^[[1m^[[94m|^[[0m use std::path::Path;
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.3183938Z    ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.3184264Z    ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.3184713Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.3185060Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.5684733Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `e`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.5685426Z   ^[[1m^[[94m--> ^[[0msrc/commands/touch.rs:33:24
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.5685915Z    ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.5686406Z ^[[1m^[[94m33^[[0m ^[[1m^[[94m|^[[0m             if let Err(e) =
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.5687417Z    ^[[1m^[[94m|^[[0m                        ^[[1m^[[33m^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_e`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.5687998Z    ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.5688492Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.5688840Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6232614Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `file_type`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6233129Z    ^[[1m^[[94m--> ^[[0msrc/commands/ls.rs:124:9
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6233462Z     ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6233910Z ^[[1m^[[94m124^[[0m ^[[1m^[[94m|^[[0m     let file_type = if metadata.is_dir() { "d" } else { "-" };
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6234662Z     ^[[1m^[[94m|^[[0m         ^[[1m^[[33m^^^^^^^^^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_file_type`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6235059Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6525461Z ^[[1m^[[33mwarning^[[0m^[[1m: field `output_rx` is never read^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6526126Z    ^[[1m^[[94m--> ^[[0msrc/lib.rs:184:5
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6526564Z     ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6527075Z ^[[1m^[[94m175^[[0m ^[[1m^[[94m|^[[0m pub struct ProcessRunner {
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6528158Z     ^[[1m^[[94m|^[[0m            ^[[1m^[[94m-------------^[[0m ^[[1m^[[94mfield in this struct^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6528726Z ^[[1m^[[94m...^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6529747Z ^[[1m^[[94m184^[[0m ^[[1m^[[94m|^[[0m     output_rx: Option<mpsc::Receiver<StreamChunk>>,
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6530401Z     ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6530847Z     ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6531449Z     ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:37.6531917Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:38.4475532Z ^[[1m^[[33mwarning^[[0m: `command-stream` (lib) generated 4 warnings (run `cargo fix --lib -p command-stream` to apply 3 suggestions)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:38.4487710Z ^[[1m^[[92m     Running^[[0m `/home/runner/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/bin/rustc --crate-name command_stream --edition=2021 src/main.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type bin --emit=dep-info,link -C opt-level=3 -C lto --cfg 'feature="default"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("default", "json", "serde", "serde_json"))' -C metadata=610f51783ec31905 -C extra-filename=-fff53d791b4e675b --out-dir /home/runner/work/command-stream/command-stream/rust/target/release/deps -C strip=debuginfo -L dependency=/home/runner/work/command-stream/command-stream/rust/target/release/deps --extern async_trait=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libasync_trait-c0245a43abfa5c4f.so --extern chrono=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libchrono-ef1f0e507a22c93d.rlib --extern command_stream=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libcommand_stream-fe9520a653a2bca2.rlib --extern filetime=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libfiletime-ebea693976d5eb0a.rlib --extern glob=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libglob-a89f9a8dc04672aa.rlib --extern libc=/home/runner/work/command-stream/command-stream/rust/target/release/deps/liblibc-a9815fab408829ab.rlib --extern nix=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libnix-84d85dec2538d073.rlib --extern once_cell=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libonce_cell-b36b517adc61825f.rlib --extern regex=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libregex-4852f50ae0bfff27.rlib --extern thiserror=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libthiserror-7ef89ed650235c47.rlib --extern tokio=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libtokio-5cebc317e66f182d.rlib --extern which=/home/runner/work/command-stream/command-stream/rust/target/release/deps/libwhich-7659c5c463050ff4.rlib`
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:38.4672832Z ^[[1m^[[33mwarning^[[0m^[[1m: unused imports: `ProcessRunner` and `RunOptions`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:38.4673781Z  ^[[1m^[[94m--> ^[[0msrc/main.rs:5:27
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:38.4674313Z   ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:38.4675232Z ^[[1m^[[94m5^[[0m ^[[1m^[[94m|^[[0m use command_stream::{run, ProcessRunner, RunOptions};
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:38.4676144Z   ^[[1m^[[94m|^[[0m                           ^[[1m^[[33m^^^^^^^^^^^^^^[[0m  ^[[1m^[[33m^^^^^^^^^^^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:38.4676787Z   ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:38.4677482Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:38.4678027Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2464799Z ^[[1m^[[33mwarning^[[0m: `command-stream` (bin "command-stream") generated 1 warning (run `cargo fix --bin "command-stream" -p command-stream` to apply 1 suggestion)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2466072Z ^[[1m^[[92m    Finished^[[0m `release` profile [optimized] target(s) in 11.04s
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2621462Z ##[group]Run cargo package --allow-dirty
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2621857Z ^[[36;1mcargo package --allow-dirty^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2648399Z shell: /usr/bin/bash -e {0}
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2648671Z env:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2648887Z   CARGO_TERM_COLOR: always
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2649299Z   CARGO_REGISTRY_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2649884Z   CARGO_TOKEN: ***
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2650125Z   CARGO_HOME: /home/runner/.cargo
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2650407Z   CARGO_INCREMENTAL: 0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.2650658Z ##[endgroup]
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.3121450Z ^[[1m^[[92m   Packaging^[[0m command-stream v0.9.5 (/home/runner/work/command-stream/command-stream/rust)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.3230579Z ^[[1m^[[92m    Updating^[[0m crates.io index
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.4985045Z ^[[1m^[[92m    Packaged^[[0m 71 files, 416.2KiB (87.6KiB compressed)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.4986083Z ^[[1m^[[92m   Verifying^[[0m command-stream v0.9.5 (/home/runner/work/command-stream/command-stream/rust)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.5341897Z ^[[1m^[[92m   Compiling^[[0m command-stream v0.9.5 (/home/runner/work/command-stream/command-stream/rust/target/package/command-stream-0.9.5)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.5744841Z ^[[1m^[[33mwarning^[[0m^[[1m: unused import: `std::path::Path`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.5745587Z   ^[[1m^[[94m--> ^[[0msrc/commands/mod.rs:53:5
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.5746117Z    ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.5746657Z ^[[1m^[[94m53^[[0m ^[[1m^[[94m|^[[0m use std::path::Path;
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.5747274Z    ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^^^^^^^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.5747826Z    ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.5748526Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.5749083Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8230853Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `e`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8231591Z   ^[[1m^[[94m--> ^[[0msrc/commands/touch.rs:33:24
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8232141Z    ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8232662Z ^[[1m^[[94m33^[[0m ^[[1m^[[94m|^[[0m             if let Err(e) =
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8233739Z    ^[[1m^[[94m|^[[0m                        ^[[1m^[[33m^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_e`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8234590Z    ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8235287Z    ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8235866Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8685136Z ^[[1m^[[33mwarning^[[0m^[[1m: unused variable: `file_type`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8685884Z    ^[[1m^[[94m--> ^[[0msrc/commands/ls.rs:124:9
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8686386Z     ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8687078Z ^[[1m^[[94m124^[[0m ^[[1m^[[94m|^[[0m     let file_type = if metadata.is_dir() { "d" } else { "-" };
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8688302Z     ^[[1m^[[94m|^[[0m         ^[[1m^[[33m^^^^^^^^^^[[0m ^[[1m^[[33mhelp: if this is intentional, prefix it with an underscore: `_file_type`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8689006Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8980289Z ^[[1m^[[33mwarning^[[0m^[[1m: field `output_rx` is never read^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8980955Z    ^[[1m^[[94m--> ^[[0msrc/lib.rs:184:5
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8981441Z     ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8981931Z ^[[1m^[[94m175^[[0m ^[[1m^[[94m|^[[0m pub struct ProcessRunner {
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8982634Z     ^[[1m^[[94m|^[[0m            ^[[1m^[[94m-------------^[[0m ^[[1m^[[94mfield in this struct^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8983201Z ^[[1m^[[94m...^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8984017Z ^[[1m^[[94m184^[[0m ^[[1m^[[94m|^[[0m     output_rx: Option<mpsc::Receiver<StreamChunk>>,
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8984649Z     ^[[1m^[[94m|^[[0m     ^[[1m^[[33m^^^^^^^^^^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8985097Z     ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8985710Z     ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:48.8986184Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.5160907Z ^[[1m^[[33mwarning^[[0m: `command-stream` (lib) generated 4 warnings (run `cargo fix --lib -p command-stream` to apply 3 suggestions)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.5362678Z ^[[1m^[[33mwarning^[[0m^[[1m: unused imports: `ProcessRunner` and `RunOptions`^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.5363648Z  ^[[1m^[[94m--> ^[[0msrc/main.rs:5:27
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.5363985Z   ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.5364656Z ^[[1m^[[94m5^[[0m ^[[1m^[[94m|^[[0m use command_stream::{run, ProcessRunner, RunOptions};
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.5365234Z   ^[[1m^[[94m|^[[0m                           ^[[1m^[[33m^^^^^^^^^^^^^^[[0m  ^[[1m^[[33m^^^^^^^^^^^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.5365624Z   ^[[1m^[[94m|^[[0m
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.5366074Z   ^[[1m^[[94m= ^[[0m^[[1mnote^[[0m: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.5366404Z 
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.8720047Z ^[[1m^[[33mwarning^[[0m: `command-stream` (bin "command-stream") generated 1 warning (run `cargo fix --bin "command-stream" -p command-stream` to apply 1 suggestion)
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.8721503Z ^[[1m^[[92m    Finished^[[0m `dev` profile [unoptimized + debuginfo] target(s) in 1.59s
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:49.9460717Z Post job cleanup.
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.0771691Z Cache hit occurred on the primary key Linux-cargo-build-8be5e933b326cc4b5f3b22442b66b23ac0172a3ca5d8122edc75b2dcfb59e9e5, not saving cache.
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.0881546Z Post job cleanup.
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.1874390Z [command]/usr/bin/git version
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.1911153Z git version 2.54.0
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.1953320Z Temporarily overriding HOME='/home/runner/work/_temp/648fb09c-9261-4b36-b1d4-8e5dc46d5709' before making global git config changes
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.1954617Z Adding repository directory to the temporary git global config as a safe directory
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.1959963Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.1996680Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.2030079Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.2271674Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.2296325Z http.https://github.com/.extraheader
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.2308472Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.2341266Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.2575623Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.2607502Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.2953628Z Cleaning up orphan processes
+Build Rust package	UNKNOWN STEP	2026-06-08T20:23:50.3298546Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+Release Rust crate	UNKNOWN STEP	﻿2026-06-08T20:23:54.4405378Z Current runner version: '2.334.0'
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4444536Z ##[group]Runner Image Provisioner
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4446014Z Hosted Compute Agent
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4447025Z Version: 20260520.533
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4448290Z Commit: 189110e25284a9812c124fd27b339e2fb4f2f9db
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4449706Z Build Date: 2026-05-20T17:44:04Z
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4451083Z Worker ID: {7283fe08-cc80-4ca7-bc7b-382d71ea581e}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4452514Z Azure Region: northcentralus
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4453566Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4456373Z ##[group]Operating System
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4457584Z Ubuntu
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4458674Z 24.04.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4459673Z LTS
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4460608Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4461701Z ##[group]Runner Image
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4462866Z Image: ubuntu-24.04
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4463970Z Version: 20260525.161.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4466570Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20260525.161/images/ubuntu/Ubuntu2404-Readme.md
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4469586Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20260525.161
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4471423Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4473489Z ##[group]GITHUB_TOKEN Permissions
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4476852Z Contents: write
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4478083Z Metadata: read
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4479214Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4482068Z Secret source: Actions
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.4483924Z Prepare workflow directory
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.5277375Z Prepare all required actions
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.5335035Z Getting action download info
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:54.9078990Z Download action repository 'actions/checkout@v4' (SHA:34e114876b0b11c390a56381ad16ebd13914f8d5)
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.0301247Z Download action repository 'dtolnay/rust-toolchain@stable' (SHA:29eef336d9b2848a0b548edc03f92a220660cdb8)
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.3529121Z Complete job name: Release Rust crate
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4306194Z ##[group]Run actions/checkout@v4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4307216Z with:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4307728Z   fetch-depth: 0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4308290Z   repository: link-foundation/command-stream
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4313321Z   token: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4313815Z   ssh-strict: true
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4314510Z   ssh-user: git
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4315049Z   persist-credentials: true
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4315608Z   clean: true
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4316110Z   sparse-checkout-cone-mode: true
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4316714Z   fetch-tags: false
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4317226Z   show-progress: true
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4317754Z   lfs: false
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4318220Z   submodules: false
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4318727Z   set-safe-directory: true
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4319531Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4320019Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4320772Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4321419Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.4321906Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5503685Z Syncing repository: link-foundation/command-stream
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5506465Z ##[group]Getting Git version info
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5507443Z Working directory is '/home/runner/work/command-stream/command-stream'
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5508671Z [command]/usr/bin/git version
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5581680Z git version 2.54.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5609902Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5633825Z Temporarily overriding HOME='/home/runner/work/_temp/cc60aa35-9b34-4c61-92a7-d312abf037c9' before making global git config changes
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5635796Z Adding repository directory to the temporary git global config as a safe directory
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5640524Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5689419Z Deleting the contents of '/home/runner/work/command-stream/command-stream'
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5693252Z ##[group]Initializing the repository
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5698191Z [command]/usr/bin/git init /home/runner/work/command-stream/command-stream
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5796539Z hint: Using 'master' as the name for the initial branch. This default branch name
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5798659Z hint: will change to "main" in Git 3.0. To configure the initial branch name
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5800589Z hint: to use in all of your new repositories, which will suppress this warning,
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5802085Z hint: call:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5802797Z hint:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5803414Z hint: 	git config --global init.defaultBranch <name>
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5804097Z hint:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5805283Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5806367Z hint: 'development'. The just-created branch can be renamed via this command:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5807183Z hint:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5807836Z hint: 	git branch -m <name>
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5808715Z hint:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5809465Z hint: Disable this message with "git config set advice.defaultBranchName false"
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5810755Z Initialized empty Git repository in /home/runner/work/command-stream/command-stream/.git/
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5815378Z [command]/usr/bin/git remote add origin https://github.com/link-foundation/command-stream
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5860360Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5861283Z ##[group]Disabling automatic garbage collection
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5864957Z [command]/usr/bin/git config --local gc.auto 0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5896210Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5897052Z ##[group]Setting up auth
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5903349Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.5939833Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.6309412Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.6343427Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.6575125Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.6612821Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.6850400Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.6887528Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.6889207Z ##[group]Fetching the repository
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:55.6898716Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5920811Z From https://github.com/link-foundation/command-stream
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5922986Z  * [new branch]      issue-1-03052bff       -> origin/issue-1-03052bff
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5923593Z  * [new branch]      issue-1-7de9505b       -> origin/issue-1-7de9505b
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5924198Z  * [new branch]      issue-135-5b3a55f7db0e -> origin/issue-135-5b3a55f7db0e
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5925562Z  * [new branch]      issue-136-c2c75f0016c4 -> origin/issue-136-c2c75f0016c4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5926592Z  * [new branch]      issue-139-34f447966ab4 -> origin/issue-139-34f447966ab4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5927419Z  * [new branch]      issue-14-427a6e27      -> origin/issue-14-427a6e27
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5928010Z  * [new branch]      issue-14-47a807dc      -> origin/issue-14-47a807dc
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5928569Z  * [new branch]      issue-141-392e7fb32761 -> origin/issue-141-392e7fb32761
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5929150Z  * [new branch]      issue-142-d79c313dc0de -> origin/issue-142-d79c313dc0de
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5929743Z  * [new branch]      issue-144-4375266b4889 -> origin/issue-144-4375266b4889
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5930351Z  * [new branch]      issue-146-f111406088b3 -> origin/issue-146-f111406088b3
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5930908Z  * [new branch]      issue-149-feab21d6ff91 -> origin/issue-149-feab21d6ff91
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5931828Z  * [new branch]      issue-15-9fc0cb72      -> origin/issue-15-9fc0cb72
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5932418Z  * [new branch]      issue-15-b280a47e      -> origin/issue-15-b280a47e
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5933078Z  * [new branch]      issue-151-3da6bb3ea5e3 -> origin/issue-151-3da6bb3ea5e3
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5933642Z  * [new branch]      issue-153-58c6ab4753ab -> origin/issue-153-58c6ab4753ab
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5934195Z  * [new branch]      issue-156-eb63a328307e -> origin/issue-156-eb63a328307e
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5935374Z  * [new branch]      issue-158-7e95ada294ce -> origin/issue-158-7e95ada294ce
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5935972Z  * [new branch]      issue-160-a2a2313cf693 -> origin/issue-160-a2a2313cf693
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5936527Z  * [new branch]      issue-162-0c186d5158ec -> origin/issue-162-0c186d5158ec
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5937133Z  * [new branch]      issue-18-16ce2f52      -> origin/issue-18-16ce2f52
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5937694Z  * [new branch]      issue-18-51ece309      -> origin/issue-18-51ece309
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5938260Z  * [new branch]      issue-19-99f29373      -> origin/issue-19-99f29373
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5938814Z  * [new branch]      issue-19-ee86110f      -> origin/issue-19-ee86110f
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5939361Z  * [new branch]      issue-20-12ad6602      -> origin/issue-20-12ad6602
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5939920Z  * [new branch]      issue-20-171029a1      -> origin/issue-20-171029a1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5940518Z  * [new branch]      issue-21-4d44bbc7      -> origin/issue-21-4d44bbc7
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5941094Z  * [new branch]      issue-21-621d3004      -> origin/issue-21-621d3004
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5941745Z  * [new branch]      issue-22-51ab60ad      -> origin/issue-22-51ab60ad
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5942649Z  * [new branch]      issue-22-57b75318      -> origin/issue-22-57b75318
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5943419Z  * [new branch]      issue-23-acb80d89      -> origin/issue-23-acb80d89
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5944051Z  * [new branch]      issue-23-cfe40154      -> origin/issue-23-cfe40154
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5945059Z  * [new branch]      issue-24-0a217d8d      -> origin/issue-24-0a217d8d
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5945636Z  * [new branch]      issue-24-2ec0e8fa      -> origin/issue-24-2ec0e8fa
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5946189Z  * [new branch]      issue-25-8431dd64      -> origin/issue-25-8431dd64
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5946730Z  * [new branch]      issue-25-8ff13a2c      -> origin/issue-25-8ff13a2c
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5947284Z  * [new branch]      issue-26-2cc88ea0      -> origin/issue-26-2cc88ea0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5947832Z  * [new branch]      issue-26-9bec6ea5      -> origin/issue-26-9bec6ea5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5948386Z  * [new branch]      issue-27-01ac7c56      -> origin/issue-27-01ac7c56
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5948930Z  * [new branch]      issue-27-1d58c6b2      -> origin/issue-27-1d58c6b2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5949490Z  * [new branch]      issue-28-1c9c13c6      -> origin/issue-28-1c9c13c6
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5950039Z  * [new branch]      issue-28-e256afcb      -> origin/issue-28-e256afcb
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5950591Z  * [new branch]      issue-29-55357638      -> origin/issue-29-55357638
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5951116Z  * [new branch]      issue-29-987b8dd4      -> origin/issue-29-987b8dd4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5951640Z  * [new branch]      issue-30-a0052265      -> origin/issue-30-a0052265
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5952170Z  * [new branch]      issue-30-f1b7d27d      -> origin/issue-30-f1b7d27d
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5952701Z  * [new branch]      issue-31-bfcb9a80      -> origin/issue-31-bfcb9a80
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5953231Z  * [new branch]      issue-31-dc3e9249      -> origin/issue-31-dc3e9249
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5953771Z  * [new branch]      issue-32-3dccbfab      -> origin/issue-32-3dccbfab
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5954543Z  * [new branch]      issue-32-7a506d69      -> origin/issue-32-7a506d69
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5955286Z  * [new branch]      issue-34-389ba67e      -> origin/issue-34-389ba67e
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5955832Z  * [new branch]      issue-34-7cfa0880      -> origin/issue-34-7cfa0880
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5956577Z  * [new branch]      issue-36-042fe722      -> origin/issue-36-042fe722
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5957109Z  * [new branch]      issue-36-52b7c0a5      -> origin/issue-36-52b7c0a5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5957632Z  * [new branch]      issue-37-20720488      -> origin/issue-37-20720488
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5958164Z  * [new branch]      issue-37-e875842b      -> origin/issue-37-e875842b
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5958696Z  * [new branch]      issue-38-8ff5f784      -> origin/issue-38-8ff5f784
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5959251Z  * [new branch]      issue-38-d399116a      -> origin/issue-38-d399116a
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5959821Z  * [new branch]      issue-39-607bfb8e      -> origin/issue-39-607bfb8e
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5960380Z  * [new branch]      issue-39-b4116e88      -> origin/issue-39-b4116e88
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5960952Z  * [new branch]      issue-4-9c65943d       -> origin/issue-4-9c65943d
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5961518Z  * [new branch]      issue-4-e24f5412       -> origin/issue-4-e24f5412
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5962097Z  * [new branch]      issue-40-b1e760e6      -> origin/issue-40-b1e760e6
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5962671Z  * [new branch]      issue-40-ef18d92c      -> origin/issue-40-ef18d92c
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5963300Z  * [new branch]      issue-41-49cfed34      -> origin/issue-41-49cfed34
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5963937Z  * [new branch]      issue-41-fed22157      -> origin/issue-41-fed22157
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5964900Z  * [new branch]      issue-42-77ee242c      -> origin/issue-42-77ee242c
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5965511Z  * [new branch]      issue-42-908eb7f7      -> origin/issue-42-908eb7f7
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5966086Z  * [new branch]      issue-43-7298cd5c      -> origin/issue-43-7298cd5c
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5966649Z  * [new branch]      issue-43-85b3ddfd      -> origin/issue-43-85b3ddfd
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5967221Z  * [new branch]      issue-43-af132027      -> origin/issue-43-af132027
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5968013Z  * [new branch]      issue-44-75df50dd      -> origin/issue-44-75df50dd
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5968626Z  * [new branch]      issue-44-796ff0a8      -> origin/issue-44-796ff0a8
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5969203Z  * [new branch]      issue-45-0325c0f5      -> origin/issue-45-0325c0f5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5969915Z  * [new branch]      issue-45-1ed9a563      -> origin/issue-45-1ed9a563
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5970510Z  * [new branch]      issue-45-ce5f1e15      -> origin/issue-45-ce5f1e15
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5971087Z  * [new branch]      issue-46-52edd2db      -> origin/issue-46-52edd2db
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5971663Z  * [new branch]      issue-46-d4eec70e      -> origin/issue-46-d4eec70e
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5972230Z  * [new branch]      issue-46-f237aa54      -> origin/issue-46-f237aa54
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5972823Z  * [new branch]      issue-47-7a71c96e      -> origin/issue-47-7a71c96e
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5973394Z  * [new branch]      issue-47-b31e0547      -> origin/issue-47-b31e0547
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5973989Z  * [new branch]      issue-47-e7830e99      -> origin/issue-47-e7830e99
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5975007Z  * [new branch]      issue-48-aaa5df6f      -> origin/issue-48-aaa5df6f
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5975649Z  * [new branch]      issue-48-ad9abe01      -> origin/issue-48-ad9abe01
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5976242Z  * [new branch]      issue-48-ead273fb      -> origin/issue-48-ead273fb
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5976826Z  * [new branch]      issue-49-08e57741      -> origin/issue-49-08e57741
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5977392Z  * [new branch]      issue-49-54f19e82      -> origin/issue-49-54f19e82
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5977948Z  * [new branch]      issue-49-e74051ab      -> origin/issue-49-e74051ab
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5978504Z  * [new branch]      issue-50-02f42ae4      -> origin/issue-50-02f42ae4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5979068Z  * [new branch]      issue-50-0b915412      -> origin/issue-50-0b915412
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5979627Z  * [new branch]      issue-50-5de8b754      -> origin/issue-50-5de8b754
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5980211Z  * [new branch]      issue-6-156225d2       -> origin/issue-6-156225d2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5980792Z  * [new branch]      issue-6-52fa1fa4       -> origin/issue-6-52fa1fa4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5981563Z  * [new branch]      issue-9-55d6d25e       -> origin/issue-9-55d6d25e
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5982135Z  * [new branch]      issue-9-c5ab4ea2       -> origin/issue-9-c5ab4ea2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5982705Z  * [new branch]      issue-96-a24e1d66      -> origin/issue-96-a24e1d66
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5983291Z  * [new branch]      issue-96-eb9bb8d1      -> origin/issue-96-eb9bb8d1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5983822Z  * [new branch]      main                   -> origin/main
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5984782Z  * [new tag]         js-v0.9.6              -> js-v0.9.6
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5985353Z  * [new tag]         v0.0.1                 -> v0.0.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5985808Z  * [new tag]         v0.0.2                 -> v0.0.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5986274Z  * [new tag]         v0.0.3                 -> v0.0.3
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.5986781Z  * [new tag]         v0.0.4                 -> v0.0.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6057484Z  * [new tag]         v0.0.5                 -> v0.0.5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6058190Z  * [new tag]         v0.1.0                 -> v0.1.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6058698Z  * [new tag]         v0.2.0                 -> v0.2.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6059182Z  * [new tag]         v0.3.0                 -> v0.3.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6059637Z  * [new tag]         v0.3.1                 -> v0.3.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6060082Z  * [new tag]         v0.3.2                 -> v0.3.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6060545Z  * [new tag]         v0.4.0                 -> v0.4.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6060998Z  * [new tag]         v0.5.0                 -> v0.5.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6061439Z  * [new tag]         v0.6.0                 -> v0.6.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6061870Z  * [new tag]         v0.7.0                 -> v0.7.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6062297Z  * [new tag]         v0.7.1                 -> v0.7.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6063013Z  * [new tag]         v0.8.0                 -> v0.8.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6063487Z  * [new tag]         v0.8.1                 -> v0.8.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6063929Z  * [new tag]         v0.8.2                 -> v0.8.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6064683Z  * [new tag]         v0.8.3                 -> v0.8.3
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6065139Z  * [new tag]         v0.9.0                 -> v0.9.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6065566Z  * [new tag]         v0.9.1                 -> v0.9.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6065992Z  * [new tag]         v0.9.2                 -> v0.9.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6066436Z  * [new tag]         v0.9.4                 -> v0.9.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6066875Z  * [new tag]         v0.9.5                 -> v0.9.5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6131227Z [command]/usr/bin/git branch --list --remote origin/main
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6161130Z   origin/main
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6170334Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6193288Z 971eab54771ce20ecc02038a1c9ec6cd378eee0a
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6203867Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules origin +89d47cf62671f8e1c4813af51128b0b9e47b6fa6:refs/remotes/origin/main
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6260440Z From https://github.com/link-foundation/command-stream
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6261736Z  + 971eab5...89d47cf 89d47cf62671f8e1c4813af51128b0b9e47b6fa6 -> origin/main  (forced update)
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6286416Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6287325Z ##[group]Determining the checkout info
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6288038Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6293231Z [command]/usr/bin/git sparse-checkout disable
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6336449Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6362591Z ##[group]Checking out the ref
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.6366532Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7133102Z Switched to a new branch 'main'
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7136346Z branch 'main' set up to track 'origin/main'.
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7147763Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7195467Z [command]/usr/bin/git log -1 --format=%H
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7220494Z 89d47cf62671f8e1c4813af51128b0b9e47b6fa6
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7560833Z ##[group]Run dtolnay/rust-toolchain@stable
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7561316Z with:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7561630Z   toolchain: stable
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7561956Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7562268Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7563014Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7563461Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7563786Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7696177Z ##[group]Run : parse toolchain version
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7696717Z ^[[36;1m: parse toolchain version^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7697144Z ^[[36;1mif [[ -z $toolchain ]]; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7697851Z ^[[36;1m  # GitHub does not enforce `required: true` inputs itself. https://github.com/actions/runner/issues/1070^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7698587Z ^[[36;1m  echo "'toolchain' is a required input" >&2^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7699025Z ^[[36;1m  exit 1^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7699505Z ^[[36;1melif [[ $toolchain =~ ^stable' '[0-9]+' '(year|month|week|day)s?' 'ago$ ]]; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7700144Z ^[[36;1m  if [[ Linux == macOS ]]; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7700827Z ^[[36;1m    echo "toolchain=1.$((($(date -v-$(sed 's/stable \([0-9]*\) \(.\).*/\1\2/' <<< $toolchain) +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7701486Z ^[[36;1m  else^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7702033Z ^[[36;1m    echo "toolchain=1.$((($(date --date "${toolchain#stable }" +%s)/60/60/24-16569)/7/6))" >> $GITHUB_OUTPUT^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7702657Z ^[[36;1m  fi^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7703119Z ^[[36;1melif [[ $toolchain =~ ^stable' 'minus' '[0-9]+' 'releases?$ ]]; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7703827Z ^[[36;1m  echo "toolchain=1.$((($(date +%s)/60/60/24-16569)/7/6-${toolchain//[^0-9]/}))" >> $GITHUB_OUTPUT^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7704638Z ^[[36;1melif [[ $toolchain =~ ^1\.[0-9]+$ ]]; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7705335Z ^[[36;1m  echo "toolchain=1.$((i=${toolchain#1.}, c=($(date +%s)/60/60/24-16569)/7/6, i+9*i*(10*i<=c)+90*i*(100*i<=c)))" >> $GITHUB_OUTPUT^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7705981Z ^[[36;1melse^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7706374Z ^[[36;1m  echo "toolchain=$toolchain" >> $GITHUB_OUTPUT^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7706805Z ^[[36;1mfi^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7739409Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7739912Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7740232Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7740856Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7741330Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7741673Z   toolchain: stable
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7741998Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7896031Z ##[group]Run : construct rustup command line
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7896551Z ^[[36;1m: construct rustup command line^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7897182Z ^[[36;1mecho "targets=$(for t in ${targets//,/ }; do echo -n ' --target' $t; done)" >> $GITHUB_OUTPUT^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7898011Z ^[[36;1mecho "components=$(for c in ${components//,/ }; do echo -n ' --component' $c; done)" >> $GITHUB_OUTPUT^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7898681Z ^[[36;1mecho "downgrade=" >> $GITHUB_OUTPUT^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7927583Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7928085Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7928408Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7929022Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7929516Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7929849Z   targets: 
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7930147Z   components: 
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.7930458Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8026329Z ##[group]Run : set $CARGO_HOME
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8026749Z ^[[36;1m: set $CARGO_HOME^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8027213Z ^[[36;1mecho CARGO_HOME=${CARGO_HOME:-"$HOME/.cargo"} >> $GITHUB_ENV^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8055250Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8055726Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8056033Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8056593Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8057024Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8057340Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8148148Z ##[group]Run : install rustup if needed
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8148945Z ^[[36;1m: install rustup if needed^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8149400Z ^[[36;1mif ! command -v rustup &>/dev/null; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8150346Z ^[[36;1m  curl --proto '=https' --tlsv1.2 --retry 10 --retry-connrefused --location --silent --show-error --fail https://sh.rustup.rs | sh -s -- --default-toolchain none -y^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8151273Z ^[[36;1m  echo "$CARGO_HOME/bin" >> $GITHUB_PATH^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8151676Z ^[[36;1mfi^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8178002Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8178470Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8178786Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8179343Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8179786Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8180127Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8180494Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8272036Z ##[group]Run rustup toolchain install stable --profile minimal --no-self-update
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8272805Z ^[[36;1mrustup toolchain install stable --profile minimal --no-self-update^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8301187Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8301663Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8301978Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8302548Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8302977Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8303318Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8303710Z   RUSTUP_PERMIT_COPY_RENAME: 1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.8304073Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:57.9947657Z info: syncing channel updates for stable-x86_64-unknown-linux-gnu
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:58.1505991Z info: latest update on 2026-05-28 for version 1.96.0 (ac68faa20 2026-05-25)
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:58.1650327Z info: removing previous version of component clippy
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:58.1667794Z info: removing previous version of component rustfmt
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:58.1679150Z info: removing previous version of component cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:58.1726692Z info: removing previous version of component rust-std
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:58.1775184Z info: removing previous version of component rustc
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:23:58.1827801Z info: downloading 5 components
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5670205Z 
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5743878Z   stable-x86_64-unknown-linux-gnu updated - rustc 1.96.0 (ac68faa20 2026-05-25) (from rustc 1.95.0 (59807616e 2026-04-14))
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5744889Z 
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5831403Z ##[group]Run rustup default stable
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5831718Z ^[[36;1mrustup default stable^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5858575Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5858935Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5859192Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5859806Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5860133Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5860358Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5860615Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5962165Z info: using existing install for stable-x86_64-unknown-linux-gnu
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5969908Z info: default toolchain set to stable-x86_64-unknown-linux-gnu
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.5970254Z 
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6038960Z   stable-x86_64-unknown-linux-gnu unchanged - rustc 1.96.0 (ac68faa20 2026-05-25)
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6039343Z 
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6096849Z ##[group]Run : create cachekey
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6097147Z ^[[36;1m: create cachekey^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6097662Z ^[[36;1mDATE=$(rustc +stable --version --verbose | sed -ne 's/^commit-date: \(20[0-9][0-9]\)-\([01][0-9]\)-\([0-3][0-9]\)$/\1\2\3/p')^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6098324Z ^[[36;1mHASH=$(rustc +stable --version --verbose | sed -ne 's/^commit-hash: //p')^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6098839Z ^[[36;1mecho "cachekey=$(echo $DATE$HASH | head -c12)" >> $GITHUB_OUTPUT^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6124204Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6124860Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6125066Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6125497Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6125810Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6126031Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6126613Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6483625Z ##[group]Run : disable incremental compilation
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6484007Z ^[[36;1m: disable incremental compilation^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6484688Z ^[[36;1mif [ -z "${CARGO_INCREMENTAL+set}" ]; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6485058Z ^[[36;1m  echo CARGO_INCREMENTAL=0 >> $GITHUB_ENV^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6485351Z ^[[36;1mfi^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6511192Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6511536Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6511734Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6512143Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6512461Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6512688Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6512940Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6581171Z ##[group]Run : enable colors in Cargo output
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6581520Z ^[[36;1m: enable colors in Cargo output^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6581851Z ^[[36;1mif [ -z "${CARGO_TERM_COLOR+set}" ]; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6582225Z ^[[36;1m  echo CARGO_TERM_COLOR=always >> $GITHUB_ENV^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6582526Z ^[[36;1mfi^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6606990Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6607342Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6607546Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6607935Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6608231Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6608446Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6608699Z   CARGO_INCREMENTAL: 0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6608915Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6677936Z ##[group]Run : enable Cargo sparse registry
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6678295Z ^[[36;1m: enable Cargo sparse registry^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6678670Z ^[[36;1m# implemented in 1.66, stabilized in 1.68, made default in 1.70^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6679389Z ^[[36;1mif [ -z "${CARGO_REGISTRIES_CRATES_IO_PROTOCOL+set}" -o -f "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol ]; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6680190Z ^[[36;1m  if rustc +stable --version --verbose | grep -q '^release: 1\.6[89]\.'; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6680773Z ^[[36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6681316Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse >> $GITHUB_ENV^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6681826Z ^[[36;1m  elif rustc +stable --version --verbose | grep -q '^release: 1\.6[67]\.'; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6682400Z ^[[36;1m    touch "/home/runner/work/_temp"/.implicit_cargo_registries_crates_io_protocol || true^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6682920Z ^[[36;1m    echo CARGO_REGISTRIES_CRATES_IO_PROTOCOL=git >> $GITHUB_ENV^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6683277Z ^[[36;1m  fi^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6683477Z ^[[36;1mfi^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6708201Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6708538Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6708739Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6709142Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6709467Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6709684Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6709939Z   CARGO_INCREMENTAL: 0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.6710157Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7040756Z ##[group]Run : work around spurious network errors in curl 8.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7041219Z ^[[36;1m: work around spurious network errors in curl 8.0^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7041827Z ^[[36;1m# https://rust-lang.zulipchat.com/#narrow/stream/246057-t-cargo/topic/timeout.20investigation^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7042446Z ^[[36;1mif rustc +stable --version --verbose | grep -q '^release: 1\.7[01]\.'; then^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7042919Z ^[[36;1m  echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7043236Z ^[[36;1mfi^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7068899Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7069244Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7069448Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7069860Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7070506Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7070737Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7071057Z   CARGO_INCREMENTAL: 0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7071277Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7271145Z ##[group]Run rustc +stable --version --verbose
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7271543Z ^[[36;1mrustc +stable --version --verbose^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7297404Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7297764Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7297973Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7298393Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7298695Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7298923Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7299182Z   CARGO_INCREMENTAL: 0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7299399Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7467155Z rustc 1.96.0 (ac68faa20 2026-05-25)
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7467871Z binary: rustc
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7468238Z commit-hash: ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7468676Z commit-date: 2026-05-25
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7469284Z host: x86_64-unknown-linux-gnu
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7469884Z release: 1.96.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7470329Z LLVM version: 22.1.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7538702Z ##[group]Run cargo install rust-script
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7539071Z ^[[36;1mcargo install rust-script^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7565399Z shell: /usr/bin/bash -e {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7565662Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7565865Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7566283Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7566590Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7566821Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7567078Z   CARGO_INCREMENTAL: 0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7567297Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:06.7863996Z ^[[1m^[[92m    Updating^[[0m crates.io index
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.0103308Z ^[[1m^[[92m Downloading^[[0m crates ...
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.0422652Z ^[[1m^[[92m  Downloaded^[[0m rust-script v0.36.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.0610264Z ^[[1m^[[92m  Installing^[[0m rust-script v0.36.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.0766341Z ^[[1m^[[92m    Updating^[[0m crates.io index
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.2845353Z ^[[1m^[[92m     Locking^[[0m 113 packages to latest compatible versions
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.2901177Z ^[[1m^[[92m      Adding^[[0m generic-array v0.14.7 ^[[1m^[[33m(available: v0.14.9)^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3033097Z ^[[1m^[[92m      Adding^[[0m sha1 v0.10.6 ^[[1m^[[33m(available: v0.11.0)^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3052950Z ^[[1m^[[92m      Adding^[[0m toml v0.9.12+spec-1.1.0 ^[[1m^[[33m(available: v1.1.2+spec-1.1.0)^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3083436Z ^[[1m^[[92m      Adding^[[0m winreg v0.55.0 ^[[1m^[[33m(available: v0.56.0)^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3106368Z ^[[1m^[[92m Downloading^[[0m crates ...
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3377306Z ^[[1m^[[92m  Downloaded^[[0m anstyle-query v1.1.5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3393439Z ^[[1m^[[92m  Downloaded^[[0m env_filter v1.0.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3409297Z ^[[1m^[[92m  Downloaded^[[0m anstyle v1.0.14
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3427742Z ^[[1m^[[92m  Downloaded^[[0m digest v0.10.7
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3449776Z ^[[1m^[[92m  Downloaded^[[0m anstyle-parse v1.0.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3471035Z ^[[1m^[[92m  Downloaded^[[0m generic-array v0.14.7
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3488214Z ^[[1m^[[92m  Downloaded^[[0m block-buffer v0.10.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3502913Z ^[[1m^[[92m  Downloaded^[[0m fastrand v2.4.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3519703Z ^[[1m^[[92m  Downloaded^[[0m errno v0.3.14
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3538865Z ^[[1m^[[92m  Downloaded^[[0m dirs-sys v0.5.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3552189Z ^[[1m^[[92m  Downloaded^[[0m clap_lex v1.1.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3564852Z ^[[1m^[[92m  Downloaded^[[0m clap_builder v4.6.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3636670Z ^[[1m^[[92m  Downloaded^[[0m shell-words v1.1.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3653375Z ^[[1m^[[92m  Downloaded^[[0m utf8parse v0.2.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3665796Z ^[[1m^[[92m  Downloaded^[[0m cpufeatures v0.2.17
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3682784Z ^[[1m^[[92m  Downloaded^[[0m sha1 v0.10.6
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3703685Z ^[[1m^[[92m  Downloaded^[[0m version_check v0.9.5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3720401Z ^[[1m^[[92m  Downloaded^[[0m getopts v0.2.24
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3742206Z ^[[1m^[[92m  Downloaded^[[0m unicase v2.9.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3763275Z ^[[1m^[[92m  Downloaded^[[0m toml_parser v1.1.2+spec-1.1.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3793732Z ^[[1m^[[92m  Downloaded^[[0m log v0.4.32
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3824492Z ^[[1m^[[92m  Downloaded^[[0m typenum v1.20.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3867433Z ^[[1m^[[92m  Downloaded^[[0m memchr v2.8.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3928412Z ^[[1m^[[92m  Downloaded^[[0m indexmap v2.14.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.3975391Z ^[[1m^[[92m  Downloaded^[[0m bitflags v2.13.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4025369Z ^[[1m^[[92m  Downloaded^[[0m regex v1.12.3
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4085651Z ^[[1m^[[92m  Downloaded^[[0m winnow v1.0.3
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4186759Z ^[[1m^[[92m  Downloaded^[[0m winnow v0.7.15
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4286913Z ^[[1m^[[92m  Downloaded^[[0m pulldown-cmark v0.13.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4341837Z ^[[1m^[[92m  Downloaded^[[0m toml v0.9.12+spec-1.1.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4387584Z ^[[1m^[[92m  Downloaded^[[0m unicode-width v0.2.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4447707Z ^[[1m^[[92m  Downloaded^[[0m tempfile v3.27.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4476161Z ^[[1m^[[92m  Downloaded^[[0m serde_core v1.0.228
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4506934Z ^[[1m^[[92m  Downloaded^[[0m hashbrown v0.17.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4567209Z ^[[1m^[[92m  Downloaded^[[0m clap v4.6.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4667401Z ^[[1m^[[92m  Downloaded^[[0m regex-syntax v0.8.10
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4737937Z ^[[1m^[[92m  Downloaded^[[0m once_cell v1.21.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4765952Z ^[[1m^[[92m  Downloaded^[[0m dirs v6.0.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4780286Z ^[[1m^[[92m  Downloaded^[[0m toml_writer v1.1.1+spec-1.1.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.4796666Z ^[[1m^[[92m  Downloaded^[[0m rustix v1.1.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5072777Z ^[[1m^[[92m  Downloaded^[[0m toml_datetime v0.7.5+spec-1.1.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5086629Z ^[[1m^[[92m  Downloaded^[[0m strsim v0.11.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5101535Z ^[[1m^[[92m  Downloaded^[[0m equivalent v1.0.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5113283Z ^[[1m^[[92m  Downloaded^[[0m env_logger v0.11.10
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5137647Z ^[[1m^[[92m  Downloaded^[[0m cfg-if v1.0.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5155115Z ^[[1m^[[92m  Downloaded^[[0m serde_spanned v1.1.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5167943Z ^[[1m^[[92m  Downloaded^[[0m pulldown-cmark-escape v0.11.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5177595Z ^[[1m^[[92m  Downloaded^[[0m crypto-common v0.1.7
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5189074Z ^[[1m^[[92m  Downloaded^[[0m colorchoice v1.0.5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5200812Z ^[[1m^[[92m  Downloaded^[[0m option-ext v0.2.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5211212Z ^[[1m^[[92m  Downloaded^[[0m is_terminal_polyfill v1.70.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5223005Z ^[[1m^[[92m  Downloaded^[[0m regex-automata v0.4.14
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5365617Z ^[[1m^[[92m  Downloaded^[[0m getrandom v0.4.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5404865Z ^[[1m^[[92m  Downloaded^[[0m aho-corasick v1.1.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5459818Z ^[[1m^[[92m  Downloaded^[[0m anstream v1.0.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5482961Z ^[[1m^[[92m  Downloaded^[[0m libc v0.2.186
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.5877308Z ^[[1m^[[92m  Downloaded^[[0m jiff v0.2.28
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.6123932Z ^[[1m^[[92m  Downloaded^[[0m linux-raw-sys v0.12.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.6895711Z ^[[1m^[[92m   Compiling^[[0m version_check v0.9.5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.6896626Z ^[[1m^[[92m   Compiling^[[0m memchr v2.8.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.6897346Z ^[[1m^[[92m   Compiling^[[0m libc v0.2.186
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.6897901Z ^[[1m^[[92m   Compiling^[[0m utf8parse v0.2.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.7371401Z ^[[1m^[[92m   Compiling^[[0m typenum v1.20.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.8995963Z ^[[1m^[[92m   Compiling^[[0m generic-array v0.14.7
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:07.9426315Z ^[[1m^[[92m   Compiling^[[0m serde_core v1.0.228
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:08.1193799Z ^[[1m^[[92m   Compiling^[[0m anstyle-parse v1.0.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:08.2512852Z ^[[1m^[[92m   Compiling^[[0m aho-corasick v1.1.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:08.5809389Z ^[[1m^[[92m   Compiling^[[0m anstyle v1.0.14
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:08.7716892Z ^[[1m^[[92m   Compiling^[[0m is_terminal_polyfill v1.70.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:08.8085754Z ^[[1m^[[92m   Compiling^[[0m regex-syntax v0.8.10
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:09.0127472Z ^[[1m^[[92m   Compiling^[[0m colorchoice v1.0.5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:09.0575883Z ^[[1m^[[92m   Compiling^[[0m anstyle-query v1.1.5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:09.0941399Z ^[[1m^[[92m   Compiling^[[0m anstream v1.0.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:09.4225757Z ^[[1m^[[92m   Compiling^[[0m getrandom v0.4.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:09.5205776Z ^[[1m^[[92m   Compiling^[[0m bitflags v2.13.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:09.7575838Z ^[[1m^[[92m   Compiling^[[0m cfg-if v1.0.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:09.7855709Z ^[[1m^[[92m   Compiling^[[0m rustix v1.1.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:10.0625861Z ^[[1m^[[92m   Compiling^[[0m block-buffer v0.10.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:10.1425991Z ^[[1m^[[92m   Compiling^[[0m crypto-common v0.1.7
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:10.1983135Z ^[[1m^[[92m   Compiling^[[0m option-ext v0.2.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:10.2376284Z ^[[1m^[[92m   Compiling^[[0m pulldown-cmark v0.13.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:10.3146699Z ^[[1m^[[92m   Compiling^[[0m clap_lex v1.1.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:10.5315761Z ^[[1m^[[92m   Compiling^[[0m linux-raw-sys v0.12.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:10.8773462Z ^[[1m^[[92m   Compiling^[[0m regex-automata v0.4.14
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:11.6277823Z ^[[1m^[[92m   Compiling^[[0m log v0.4.32
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:11.8146348Z ^[[1m^[[92m   Compiling^[[0m strsim v0.11.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:11.9166177Z ^[[1m^[[92m   Compiling^[[0m winnow v1.0.3
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:12.3185960Z ^[[1m^[[92m   Compiling^[[0m unicode-width v0.2.2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:12.3482166Z ^[[1m^[[92m   Compiling^[[0m toml_parser v1.1.2+spec-1.1.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:12.5195946Z ^[[1m^[[92m   Compiling^[[0m getopts v0.2.24
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:13.1666698Z ^[[1m^[[92m   Compiling^[[0m clap_builder v4.6.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:13.2928998Z ^[[1m^[[92m   Compiling^[[0m toml_datetime v0.7.5+spec-1.1.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:13.3309125Z ^[[1m^[[92m   Compiling^[[0m serde_spanned v1.1.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:13.6256201Z ^[[1m^[[92m   Compiling^[[0m dirs-sys v0.5.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:13.9496153Z ^[[1m^[[92m   Compiling^[[0m regex v1.12.3
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:14.8436250Z ^[[1m^[[92m   Compiling^[[0m env_filter v1.0.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:15.3726261Z ^[[1m^[[92m   Compiling^[[0m digest v0.10.7
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:15.6446117Z ^[[1m^[[92m   Compiling^[[0m toml_writer v1.1.1+spec-1.1.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:15.8071611Z ^[[1m^[[92m   Compiling^[[0m once_cell v1.21.4
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:15.8220401Z ^[[1m^[[92m   Compiling^[[0m cpufeatures v0.2.17
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:15.8535890Z ^[[1m^[[92m   Compiling^[[0m fastrand v2.4.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:15.9755956Z ^[[1m^[[92m   Compiling^[[0m unicase v2.9.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:16.0515788Z ^[[1m^[[92m   Compiling^[[0m jiff v0.2.28
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:16.1305792Z ^[[1m^[[92m   Compiling^[[0m winnow v0.7.15
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:17.9316230Z ^[[1m^[[92m   Compiling^[[0m pulldown-cmark-escape v0.11.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:18.0686432Z ^[[1m^[[92m   Compiling^[[0m toml v0.9.12+spec-1.1.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:19.6283498Z ^[[1m^[[92m   Compiling^[[0m tempfile v3.27.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:20.1846320Z ^[[1m^[[92m   Compiling^[[0m env_logger v0.11.10
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:20.4691990Z ^[[1m^[[92m   Compiling^[[0m sha1 v0.10.6
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:20.6606422Z ^[[1m^[[92m   Compiling^[[0m clap v4.6.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:20.6906023Z ^[[1m^[[92m   Compiling^[[0m dirs v6.0.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:20.7686285Z ^[[1m^[[92m   Compiling^[[0m shell-words v1.1.1
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:21.3622967Z ^[[1m^[[92m   Compiling^[[0m rust-script v0.36.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.1369206Z ^[[1m^[[92m    Finished^[[0m `release` profile [optimized] target(s) in 35.36s
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.1632120Z ^[[1m^[[92m  Installing^[[0m /home/runner/.cargo/bin/rust-script
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.1688051Z ^[[1m^[[92m   Installed^[[0m package `rust-script v0.36.0` (executable `rust-script`)
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.1982491Z ##[group]Run rust-script rust/scripts/get-bump-type.rs
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.1982930Z ^[[36;1mrust-script rust/scripts/get-bump-type.rs^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.2008424Z shell: /usr/bin/bash -e {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.2008690Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.2008893Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.2009284Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.2009615Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.2009843Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.2010101Z   CARGO_INCREMENTAL: 0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:42.2010328Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9760794Z Detected multi-language repository (Cargo.toml in rust/)
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9766350Z Fragment 20260608_issue_160_separate_language_releases.md: bump=patch
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9769169Z Fragment 20260608_issue_162_release_job_skip.md: bump=patch
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9769582Z 
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9769809Z Determined bump type: patch (from 2 fragment(s))
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9771049Z Output: bump_type=patch
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9771880Z Output: fragment_count=2
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9772192Z Output: has_fragments=true
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9805464Z ##[group]Run rust-script rust/scripts/check-release-needed.rs --tag-prefix rust-v
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9806154Z ^[[36;1mrust-script rust/scripts/check-release-needed.rs --tag-prefix rust-v^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9831752Z shell: /usr/bin/bash -e {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9832012Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9832215Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9832611Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9832931Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9833168Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9833442Z   CARGO_INCREMENTAL: 0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9833670Z   HAS_FRAGMENTS: true
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9837299Z   GITHUB_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9837595Z   GITHUB_REPOSITORY: link-foundation/command-stream
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:24:50.9837922Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.8145343Z Detected multi-language repository (Cargo.toml in rust/)
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9128922Z Max published version on crates.io: 0.9.5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9130336Z Output: max_published_version=0.9.5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9131244Z Found changelog fragments, proceeding with release
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9131748Z Output: should_release=true
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9132108Z Output: skip_bump=false
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9168983Z ##[group]Run rust-script rust/scripts/version-and-commit.rs --bump-type "patch" --tag-prefix rust-v --release-label Rust
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9169881Z ^[[36;1mrust-script rust/scripts/version-and-commit.rs --bump-type "patch" --tag-prefix rust-v --release-label Rust^[[0m
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9195758Z shell: /usr/bin/bash -e {0}
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9196014Z env:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9196211Z   CARGO_TERM_COLOR: always
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9196590Z   CARGO_REGISTRY_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9196900Z   CARGO_TOKEN: ***
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9197124Z   CARGO_HOME: /home/runner/.cargo
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9197385Z   CARGO_INCREMENTAL: 0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:16.9197612Z ##[endgroup]
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.2906155Z Detected multi-language repository (Cargo.toml in rust/)
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.3522664Z Max published version on crates.io: 0.9.5
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.3523408Z Initial bump (patch) from 0.9.5: 0.9.6
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.4398758Z Final release version: 0.9.6
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.4401445Z Updated rust/Cargo.toml to version 0.9.6
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.4404470Z Updated rust/Cargo.lock to version 0.9.6
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.4408593Z Collected 2 changelog fragment(s)
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.7163126Z Local branch is behind remote, rebasing...
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.7217274Z Error rebasing onto origin/main: Command failed: error: cannot rebase: Your index contains uncommitted changes.
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.7218289Z error: Please commit or stash them.
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.7218639Z 
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.7245572Z ##[error]Process completed with exit code 1.
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.7363861Z Post job cleanup.
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.8350775Z [command]/usr/bin/git version
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.8387532Z git version 2.54.0
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.8431001Z Temporarily overriding HOME='/home/runner/work/_temp/93b579b8-f405-438b-afcd-13dc4a65e395' before making global git config changes
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.8431809Z Adding repository directory to the temporary git global config as a safe directory
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.8436841Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/command-stream/command-stream
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.8473817Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.8506694Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.8740333Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.8766238Z http.https://github.com/.extraheader
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.8778431Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.8808910Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.9033460Z [command]/usr/bin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.9064169Z [command]/usr/bin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.9407294Z Cleaning up orphan processes
+Release Rust crate	UNKNOWN STEP	2026-06-08T20:25:21.9710847Z ##[warning]Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

--- a/experiments/issue-164/reproduce-rebase-bug.sh
+++ b/experiments/issue-164/reproduce-rebase-bug.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Reproduces "cannot rebase: Your index contains uncommitted changes" from the
+# Rust release workflow (rust/scripts/version-and-commit.rs).
+#
+# The failure is purely local: the script modifies + `git add`s the version
+# files (dirty index) and only THEN runs `git rebase origin/main`. git refuses
+# to rebase with a dirty index. Pass "fixed" to run the corrected order
+# (rebase while the tree is still clean, before staging).
+set -eu
+mode="${1:-buggy}"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+cd "$tmp"
+git init -q .
+git config user.email a@b.c; git config user.name a
+git checkout -q -b main
+
+printf 'version = "0.9.5"\n' > Cargo.toml
+git add Cargo.toml; git commit -qm "A: initial"
+
+# Simulate origin/main advancing on a parallel ref (commit B)
+git checkout -q -b origin-main
+echo remote-change > other.txt
+git add other.txt; git commit -qm "B: remote advanced"
+git checkout -q main   # release copy stays at commit A, behind origin-main
+
+rebase_if_behind() {
+  if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin-main)" ]; then
+    echo "Local branch is behind remote, rebasing..."
+    git rebase origin-main
+  fi
+}
+
+if [ "$mode" = fixed ]; then
+  rebase_if_behind                       # rebase first, clean tree
+  printf 'version = "0.9.6"\n' > Cargo.toml
+  git add Cargo.toml
+else
+  printf 'version = "0.9.6"\n' > Cargo.toml
+  git add Cargo.toml                     # stage -> dirty index
+  rebase_if_behind                       # then rebase -> FAILS
+fi
+
+git commit -qm "release 0.9.6"
+echo "RESULT[$mode]: success, version=$(grep version Cargo.toml)"

--- a/js/.changeset/issue-164-ci-action-versions.md
+++ b/js/.changeset/issue-164-ci-action-versions.md
@@ -1,0 +1,8 @@
+---
+'command-stream': patch
+---
+
+Update the JavaScript release workflow to the action versions used by the
+pipeline templates (`actions/checkout@v6`, `actions/setup-node@v6`,
+`peter-evans/create-pull-request@v8`), clearing the Node.js 20 deprecation
+warnings emitted by GitHub Actions.

--- a/js/tests/repository-layout.test.mjs
+++ b/js/tests/repository-layout.test.mjs
@@ -108,12 +108,13 @@ describe('repository language layout', () => {
       expect(jsReleaseJob).toContain("needs.lint.result == 'success'");
       expect(jsReleaseJob).toContain("needs.test.result == 'success'");
 
-      expect(rustReleaseJob).toContain('needs: [lint, test, build]');
+      expect(rustReleaseJob).toContain('needs: [lint, test, scripts, build]');
       expect(rustReleaseJob).toContain('always() && !cancelled()');
       expect(rustReleaseJob).toContain("github.ref == 'refs/heads/main'");
       expect(rustReleaseJob).toContain("github.event_name == 'push'");
       expect(rustReleaseJob).toContain("needs.lint.result == 'success'");
       expect(rustReleaseJob).toContain("needs.test.result == 'success'");
+      expect(rustReleaseJob).toContain("needs.scripts.result == 'success'");
       expect(rustReleaseJob).toContain("needs.build.result == 'success'");
     }
   });

--- a/rust/changelog.d/20260609_issue_164_rebase_before_staging.md
+++ b/rust/changelog.d/20260609_issue_164_rebase_before_staging.md
@@ -1,0 +1,10 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Rebase onto the latest `origin/<branch>` **before** staging the version bump
+  in the Rust release script, so concurrent releases no longer abort with
+  "cannot rebase: Your index contains uncommitted changes". The release now
+  syncs on a clean working tree, matching the JavaScript release script.

--- a/rust/scripts/version-and-commit.rs
+++ b/rust/scripts/version-and-commit.rs
@@ -433,6 +433,7 @@ mod tests {
     use super::update_cargo_lock;
     use std::fs;
     use std::path::PathBuf;
+    use std::process::Command;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     fn temp_dir(name: &str) -> PathBuf {
@@ -513,6 +514,86 @@ version = "1.12.3"
         assert!(!update_cargo_lock(&cargo_lock, "example-sum-package-name", "0.14.0").unwrap());
         assert_eq!(fs::read_to_string(&cargo_lock).unwrap(), content);
     }
+
+    /// Regression test for issue #164: the Rust release job failed with
+    /// "cannot rebase: Your index contains uncommitted changes." because the
+    /// script staged the version bump (`git add`) and only afterwards ran
+    /// `git rebase origin/main`. `git rebase` refuses to run with a dirty
+    /// index, so the release must rebase onto the remote BEFORE staging.
+    ///
+    /// This test reproduces both orderings against a real temporary repository
+    /// and asserts the buggy order fails while the fixed order succeeds.
+    #[test]
+    fn rebase_must_run_before_staging_the_version_bump() {
+        let repo = temp_dir("rebase-order");
+        let git = |args: &[&str]| -> std::process::Output {
+            Command::new("git")
+                .args(args)
+                .current_dir(&repo)
+                .output()
+                .expect("failed to run git")
+        };
+
+        // Some CI images default to `master`; force the initial branch to main.
+        git(&["init", "-q", "."]);
+        git(&["checkout", "-q", "-b", "main"]);
+        git(&["config", "user.email", "ci@example.com"]);
+        git(&["config", "user.name", "ci"]);
+
+        // Commit A: the state the release job checks out.
+        fs::write(repo.join("Cargo.toml"), "version = \"0.1.0\"\n").unwrap();
+        git(&["add", "Cargo.toml"]);
+        git(&["commit", "-qm", "A: initial"]);
+
+        // Commit B on a parallel ref simulates origin/main advancing while the
+        // release job was running (e.g. a concurrent release pushed to main).
+        git(&["checkout", "-q", "-b", "upstream"]);
+        fs::write(repo.join("remote.txt"), "remote change\n").unwrap();
+        git(&["add", "remote.txt"]);
+        git(&["commit", "-qm", "B: remote advanced"]);
+        git(&["checkout", "-q", "main"]);
+
+        // BUGGY ORDER: stage the bump first, then rebase -> git rejects the
+        // dirty index. This is exactly what broke the release job.
+        fs::write(repo.join("Cargo.toml"), "version = \"0.1.1\"\n").unwrap();
+        git(&["add", "Cargo.toml"]);
+        let buggy = git(&["rebase", "upstream"]);
+        assert!(
+            !buggy.status.success(),
+            "rebase unexpectedly succeeded with a dirty index"
+        );
+        let buggy_err = String::from_utf8_lossy(&buggy.stderr);
+        assert!(
+            buggy_err.contains("cannot rebase") || buggy_err.contains("uncommitted changes"),
+            "unexpected rebase error: {buggy_err}"
+        );
+
+        // Reset back to a clean tree at commit A.
+        let _ = git(&["rebase", "--abort"]);
+        git(&["reset", "-q", "--hard", "HEAD"]);
+
+        // FIXED ORDER: rebase while the tree is clean, THEN stage and commit.
+        let fixed = git(&["rebase", "upstream"]);
+        assert!(
+            fixed.status.success(),
+            "rebase with a clean tree failed: {}",
+            String::from_utf8_lossy(&fixed.stderr)
+        );
+        fs::write(repo.join("Cargo.toml"), "version = \"0.1.1\"\n").unwrap();
+        git(&["add", "Cargo.toml"]);
+        let commit = git(&["commit", "-qm", "chore: release 0.1.1"]);
+        assert!(
+            commit.status.success(),
+            "commit after clean rebase failed: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
+
+        // The bump rides on top of the upstream commit, proving no work was lost.
+        let log = git(&["log", "--oneline"]);
+        let log_out = String::from_utf8_lossy(&log.stdout);
+        assert!(log_out.contains("release 0.1.1"));
+        assert!(log_out.contains("B: remote advanced"));
+    }
 }
 
 #[cfg(not(test))]
@@ -564,6 +645,32 @@ fn main() {
             "github-actions[bot]@users.noreply.github.com",
         ],
     );
+
+    // Sync with the latest remote state BEFORE touching any files.
+    //
+    // This must happen while the working tree is clean: `git rebase` refuses to
+    // run with a dirty index ("cannot rebase: Your index contains uncommitted
+    // changes"). Rebasing after staging the version bump is what previously
+    // broke the release job. Rebasing first also means the version bump is
+    // computed from the most recent state of the branch (matches the JS
+    // version-and-commit.mjs ordering).
+    let current_branch =
+        exec("git", &["rev-parse", "--abbrev-ref", "HEAD"]).unwrap_or_else(|_| "main".to_string());
+    if let Err(e) = exec("git", &["fetch", "origin", &current_branch]) {
+        eprintln!("Warning: Could not fetch origin/{}: {}", current_branch, e);
+    } else {
+        let local = exec("git", &["rev-parse", "HEAD"]).unwrap_or_default();
+        let remote =
+            exec("git", &["rev-parse", &format!("origin/{}", current_branch)]).unwrap_or_default();
+        if !local.is_empty() && !remote.is_empty() && local != remote {
+            println!("Local branch is behind remote, rebasing...");
+            if let Err(e) = exec("git", &["rebase", &format!("origin/{}", current_branch)]) {
+                eprintln!("Error rebasing onto origin/{}: {}", current_branch, e);
+                let _ = exec("git", &["rebase", "--abort"]);
+                exit(1);
+            }
+        }
+    }
 
     // Get current version
     let content = match fs::read_to_string(&package_manifest) {
@@ -653,25 +760,6 @@ fn main() {
         set_output("version_committed", "false");
         set_output("new_version", &new_version);
         return;
-    }
-
-    // Fetch latest remote state before committing (supports concurrent release workflows)
-    let current_branch =
-        exec("git", &["rev-parse", "--abbrev-ref", "HEAD"]).unwrap_or_else(|_| "main".to_string());
-    if let Err(e) = exec("git", &["fetch", "origin", &current_branch]) {
-        eprintln!("Warning: Could not fetch origin/{}: {}", current_branch, e);
-    } else {
-        let local = exec("git", &["rev-parse", "HEAD"]).unwrap_or_default();
-        let remote =
-            exec("git", &["rev-parse", &format!("origin/{}", current_branch)]).unwrap_or_default();
-        if !local.is_empty() && !remote.is_empty() && local != remote {
-            println!("Local branch is behind remote, rebasing...");
-            if let Err(e) = exec("git", &["rebase", &format!("origin/{}", current_branch)]) {
-                eprintln!("Error rebasing onto origin/{}: {}", current_branch, e);
-                let _ = exec("git", &["rebase", "--abort"]);
-                exit(1);
-            }
-        }
     }
 
     // Commit changes


### PR DESCRIPTION
## Summary

Fixes the broken release pipeline reported in #164. The **Rust** release job
failed on every concurrent release because `rust/scripts/version-and-commit.rs`
staged the version bump with `git add` **before** running `git rebase origin/main`.
`git rebase` refuses to run with a dirty index, so the job aborted with:

```
Local branch is behind remote, rebasing...
Error rebasing onto origin/main: Command failed: error: cannot rebase: Your index contains uncommitted changes.
error: Please commit or stash them.
##[error]Process completed with exit code 1.
```

The **JavaScript** script (`js/scripts/version-and-commit.mjs`) already does
these in the correct order (rebase first, then stage) — which is exactly why the
JS run succeeded while the Rust run failed on the very same commit.

### Root cause

Both workflows fire on a push to `main`. The JS release finished first, bumped
to `0.9.6`, and pushed — advancing `origin/main` under the Rust job. The Rust
job then correctly detected it was behind and tried to rebase, but it had
already dirtied its index, so the rebase failed. Full timeline and evidence:
[`docs/case-studies/issue-164/README.md`](docs/case-studies/issue-164/README.md).

## Changes

- **Fix:** move the fetch + rebase sync in `rust/scripts/version-and-commit.rs`
  to run **before any file modification**, while the working tree is clean —
  matching the JS script.
- **Regression test:** `rebase_must_run_before_staging_the_version_bump()`
  builds a temp git repo, reproduces the dirty-index failure for the buggy
  order, and proves the fixed order succeeds.
- **New CI job (`scripts`)** in `rust.yml` runs the inline `rust-script --test`
  suites for every `rust/scripts/*.rs` (35 tests across 6 scripts) and **gates
  the `release` job** on it. These release-script tests never ran in CI before —
  `cargo test` only covers the library crate.
- **Action version bumps** to match the pipeline templates and clear the
  `Node.js 20 actions are deprecated` warnings: `actions/checkout@v6`,
  `actions/setup-node@v6`, `actions/cache@v5`, `peter-evans/create-pull-request@v8`.
- **Case study** under `docs/case-studies/issue-164/` with downloaded CI logs,
  timeline, requirements matrix, root-cause analysis, template comparison, and
  an existing-components / online-facts survey.
- **Changelog fragment** documenting the fix so the next Rust release records it.

## Codebase-wide audit (issue requirement)

Every version-bump-then-rebase/push site was checked. Only the Rust script
shared the bug; `js/scripts/version-and-commit.mjs` already rebases first, and
no other script has the pattern. Details in the case study §4.4.

## Templates compared (issue requirement)

All four `*-ai-driven-development-pipeline-template` repos were compared. The
**rust** template has the identical bug — reported upstream:
[rust-…-template#67](https://github.com/link-foundation/rust-ai-driven-development-pipeline-template/issues/67)
(with a reproducible example, workaround, and code-fix suggestion). The js,
python, and csharp templates do not share it. Action versions now match the
templates exactly.

## How to reproduce / verify

- Local repro: `experiments/issue-164/reproduce-rebase-bug.sh buggy` fails with
  the exact CI error; `… fixed` succeeds.
- Tests: `rust-script --test rust/scripts/version-and-commit.rs` → 5 passed
  (including the new regression test). The new `scripts` CI job runs all 6
  suites on every PR and push.

Closes #164
