### PR TITLE
fix(js): preserve real exit code when test reset/parent-stream closure races in-flight commands (#170)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-10T23:52:39.912Z for PR creation at branch issue-170-9e2e62bb506a for issue https://github.com/link-foundation/command-stream/issues/170

--- a/docs/case-studies/issue-170/README.md
+++ b/docs/case-studies/issue-170/README.md
@@ -288,6 +288,19 @@ conditional "if the same issue is found in a template" does not apply, and R5's
 "other reportable repos" likewise has no applicable target — the root cause is
 our own code, not a Bun/Node/template defect).
 
+### Does the same defect exist in the Rust implementation? — No (parity check)
+
+command-stream ships parallel JavaScript and Rust libraries and enforces a
+`JS/Rust source parity` CI gate (`parity.yml`) that fails when `js/src/**`
+changes without a matching `rust/src/**` change. This fix touches only
+`js/src/**`, so the gate fired — correctly. Investigating the Rust side
+(`rust/src/state.rs`) shows its `reset()` simply **clears** the active-runner set
+(`active_runners.write().await.clear()`); it never force-kills runners, has no
+parent-stream-closure monitoring, and never synthesizes a SIGTERM result. None of
+the three JS defects has a Rust counterpart, so there is no equivalent change to
+mirror. The PR therefore carries the documented `parity-exempt` label (the gate's
+own escape hatch for legitimately single-language changes).
+
 ### Best-practice deltas observed (for future hardening)
 
 `js.yml` already matches the template on the highest-value practices:

--- a/docs/case-studies/issue-170/README.md
+++ b/docs/case-studies/issue-170/README.md
@@ -1,0 +1,288 @@
+# Case Study — Issue #170: CI/CD false positive (synthetic SIGTERM masking real exit code)
+
+> "Check CI/CD for all false positives and errors and fix it all"
+> Issue: https://github.com/link-foundation/command-stream/issues/170
+> Failing run: https://github.com/link-foundation/command-stream/actions/runs/27310950658
+
+This folder is the self-contained record for issue #170. It contains the raw CI
+log, the relevant template workflows used for comparison, and this analysis.
+
+```
+docs/case-studies/issue-170/
+├── README.md                         ← this analysis
+├── ci-logs/
+│   └── run-27310950658-failed.log    ← full raw log of the failing run
+└── template-workflows/js/            ← the JS template workflows compared against
+    ├── example-app.yml
+    ├── links.yml
+    └── release.yml
+```
+
+---
+
+## 1. Timeline / sequence of events
+
+| Time (UTC) | Event |
+| --- | --- |
+| 2026-06-10 22:39:41 | PR #105 (`issue-44-796ff0a8`, "Validate spawn cwd on disk…") merged to `main`, SHA `fe8aae7`. Push triggers workflow run **27310950658**. |
+| 22:40:58 | `Test JavaScript (bun on windows-latest)` job starts; `bun install` completes. |
+| 22:41:00.122 | **`MaxListenersExceededWarning: … 11 close listeners added to [WriteStream]`** emitted (twice) — the parent-stream listener leak surfaces. |
+| 22:41:14.072 | Test `Shell Settings > Shell Replacement Benefits > should provide better error objects than bash` throws **`Command failed with exit code 143`**, `stderr: "Process killed with SIGTERM"`, `result.code: 143`. Expected `code: 5`. |
+| 22:41:18.757 | Job summary: **`571 pass / 1 fail`**, `Ran 757 tests across 51 files`. Windows/Bun job concludes **failure**. |
+| 22:41:18.859 | `##[error]Process completed with exit code 1`. |
+| — | All other matrix legs (bun on ubuntu/macOS, node 20/22/24 on ubuntu) **passed**. Only `bun on windows-latest` failed. |
+| 2026-06-10 22:49:36 | Issue #170 filed. |
+
+The failure is a **flaky, timing-dependent false positive**: the same test
+passes on every other matrix leg and on local re-runs. It surfaced on a push to
+`main` (post-merge), meaning it had slipped through the PR run of #105.
+
+---
+
+## 2. Requirements extracted from the issue
+
+1. **R1 — Fix all CI/CD false positives and errors** (the failing run is the reference).
+2. **R2 — Compare every GitHub workflow / CI-CD file** against the four pipeline templates
+   (js, rust, python, csharp) and reuse best practices; if the same issue exists in a
+   template, report it there too.
+3. **R3 — Download all logs/data** related to the issue into `./docs/case-studies/issue-170`
+   and produce a deep case study: timeline, requirement list, root cause of each problem,
+   and proposed solution plans (checking existing components/libraries). Search online for
+   additional facts.
+4. **R4 — If data is insufficient for root cause, add debug output / verbose mode** for the
+   next iteration.
+5. **R5 — If the issue relates to other reportable GitHub repos, file issues there** with
+   reproducible examples, workarounds and code-fix suggestions.
+6. **R6 — Apply fixes across the entire codebase** (every place exhibiting the issue).
+7. **R7 — Do everything in the single PR #171**, continuing until every requirement is met.
+
+---
+
+## 3. Root-cause analysis
+
+### 3.1 The observed failure
+
+The failing test (`js/tests/shell-settings.test.mjs:207`):
+
+```js
+test('should provide better error objects than bash', async () => {
+  shell.errexit(true);
+  try {
+    await $`sh -c "echo 'stdout'; echo 'stderr' >&2; exit 5"`;
+    expect(true).toBe(false);
+  } catch (error) {
+    expect(error.code).toBe(5);          // ← got 143 in CI
+    expect(error.stdout).toContain('stdout');
+    expect(error.stderr).toContain('stderr');
+    ...
+  }
+});
+```
+
+The error thrown in CI was **synthetic**, not the real result of the command:
+
+```
+error: Command failed with exit code 143
+   code: 143,
+ stdout: "",
+ stderr: "Process killed with SIGTERM",
+ result: { code: 143, stdout: "", stderr: "Process killed with SIGTERM", ... }
+      at throwErrexitIfNeeded (…/js/src/$.process-runner-execution.mjs:506:21)
+      at <anonymous>          (…/js/src/$.process-runner-execution.mjs:1191:7)
+```
+
+`code: 143 = 128 + 15` is the exit code for a process terminated by **SIGTERM**.
+The string `"Process killed with SIGTERM"` is produced in exactly **one** place
+in the codebase — `killRunner()` in `js/src/$.process-runner-stream-kill.mjs`:
+
+```js
+const killResult = {
+  code: getSignalExitCode(signal),     // SIGTERM → 143
+  stdout: '',
+  stderr: `Process killed with ${signal}`,
+  ...
+};
+this.finish(killResult);
+```
+
+So **something called `runner.kill()` on a live, still-awaited command**, and
+because `finish()` is idempotent (first-wins), the synthetic kill result became
+`this.result`. When `_doStartAsync` then reached `throwErrexitIfNeeded`, it threw
+the synthetic 143 instead of the real exit code 5.
+
+### 3.2 Who called `kill()`? — the test-isolation reaper race
+
+`kill()` here was **not** triggered by the test. It came from the global
+test-isolation reset that `test-helper.mjs` runs in `beforeEach`/`afterEach`:
+
+```
+resetGlobalState()  →  cleanupActiveRunners()  →  runner.kill()  →  killRunner()
+```
+
+`cleanupActiveRunners()` iterates `activeProcessRunners` and kills anything still
+registered, to prevent leaked fire-and-forget processes from bleeding across
+tests. On the slow Windows/Bun runner, the previous test's `afterEach` (or the
+next test's `beforeEach`) **ran while this command was still in flight and still
+being awaited**. The reaper killed it, the synthetic SIGTERM result won, and the
+real exit code 5 was lost.
+
+This is a genuine race, which is why it only reproduced on the slowest leg
+(Windows + Bun) and never locally. **Root cause #1: the reaper does not
+distinguish a leaked runner from a healthy, actively-awaited one.**
+
+### 3.3 The MaxListeners warning — a second, independent defect
+
+The log also shows, before the failure:
+
+```
+MaxListenersExceededWarning: … 11 close listeners added to [WriteStream].
+```
+
+`monitorParentStreams()` (`js/src/$.state.mjs`) attaches a `'close'` listener to
+`process.stdout` and `process.stderr` so active runners can shut down gracefully
+when the parent stream closes. It guards with a `parentStreamsMonitored` flag —
+but `resetGlobalState()` reset the flag to `false` **without removing the
+listeners**. Every test therefore re-attached a new pair of listeners, and they
+accumulated until Node/Bun warned at 11. **Root cause #2: listeners are added on
+every reset cycle but never removed**, an unbounded leak. While the warning
+itself did not fail the test, it is noise that masks real leaks and is itself a
+CI-quality defect the issue asks us to eliminate.
+
+### 3.4 Confirmation (reproduced on Linux)
+
+`experiments/repro-issue-170-awaited.mjs` fires `resetGlobalState()` 100 ms into
+an awaited `$\`… exit 5\`` command. On the unpatched code it reproduces the exact
+CI failure (`code=143`, `stderr="Process killed with SIGTERM"`); with the fix it
+returns `code=5`. The committed regression test
+`js/tests/issue-170-cleanup-race.test.mjs` encodes both defects and goes from
+**3 fail (clean) → 3 pass (fixed)**.
+
+---
+
+## 4. The fix (applied to the entire codebase — R6)
+
+Source: commit on branch `issue-170-9e2e62bb506a`.
+
+### Fix 1 — never reap an awaited, in-flight runner
+
+A new `_awaited` flag is initialised to `false` in the `ProcessRunner`
+constructor and set to `true` synchronously the moment user code starts consuming
+the runner. Every consumption entry point sets it:
+
+- `ProcessRunner.prototype.then` / `.catch` / `.finally` (`$.process-runner-execution.mjs`)
+- `stream()` (`$.process-runner-stream-kill.mjs`)
+
+`cleanupActiveRunners()` (`$.state.mjs`) then skips any runner that is being
+awaited and has not finished:
+
+```js
+// Never force-terminate a command that user code is still awaiting … killing a
+// live, awaited command would replace its real exit code with a synthetic
+// SIGTERM (143) result and mask the true outcome (issue #170).
+if (runner._awaited && !runner.finished) {
+  continue;
+}
+```
+
+Because `await x` calls `x.then(...)` **synchronously** before yielding, the flag
+is set before any `beforeEach`/`afterEach` reset can interleave — closing the
+race. Leaked fire-and-forget runners (never awaited) are still reaped as before.
+
+### Fix 2 — remove parent-stream listeners on reset
+
+`monitorParentStreams()` now records each `{ stream, listener }` it installs in a
+module-level `parentStreamListeners` array. A new `removeParentStreamListeners()`
+detaches them, and it is called from both `resetParentStreamMonitoring()` and
+`resetGlobalState()` (right before clearing `parentStreamsMonitored`). The listener
+count is now bounded across any number of resets.
+
+### Why not other approaches (rejected alternatives)
+
+- **Guarding the `'close'` handler on `stream.destroyed`** — rejected. Empirically
+  `process.stdout.destroyed` stays `false` in Node even after `process.stdout.destroy()`,
+  so the guard either does nothing or, when interpreted strictly, hangs the legitimate
+  parent-stream-closure shutdown path (verified: subprocess timed out at rc=124/143).
+- **Raising `setMaxListeners`** — rejected. It hides the leak instead of fixing it.
+- **Skipping the test on Windows** — rejected. It hides a real correctness bug
+  (a kill racing an await could mask any command's exit code, not just in tests).
+
+---
+
+## 5. Requirement R2 — workflow comparison against the templates
+
+Workflow files in this repo: `.github/workflows/js.yml`, `rust.yml`, `parity.yml`.
+Template workflow inventory:
+
+| Template | Workflows |
+| --- | --- |
+| js-ai-driven-development-pipeline-template | `example-app.yml`, `links.yml`, `release.yml` |
+| rust-ai-driven-development-pipeline-template | `release.yml` |
+| python-ai-driven-development-pipeline-template | `docs.yml`, `release.yml` |
+| csharp-ai-driven-development-pipeline-template | `docs.yml`, `release.yml` |
+
+### Does the failing defect exist in any template? — No.
+
+The synthetic-143 false positive and the listener leak both live in
+command-stream's **library source** (`$.state.mjs`, `$.process-runner-*.mjs`).
+The templates are project scaffolds; they contain **no** equivalent of
+`ProcessRunner`, `cleanupActiveRunners`, or `monitorParentStreams`. There is
+therefore **no matching bug to report upstream in the templates** (R2's
+conditional "if the same issue is found in a template" does not apply, and R5's
+"other reportable repos" likewise has no applicable target — the root cause is
+our own code, not a Bun/Node/template defect).
+
+### Best-practice deltas observed (for future hardening)
+
+`js.yml` already matches the template on the highest-value practices:
+`concurrency` with `cancel-in-progress`, `fail-fast: false` (this is *why* the
+flake surfaced cleanly as a single failed leg instead of cancelling the matrix),
+per-job `timeout-minutes`, and a fast-checks-before-test-matrix `needs:` gate.
+
+Differences worth tracking (documented here rather than force-applied, to avoid
+destabilising a green pipeline):
+
+| Practice | Template `release.yml` | This repo `js.yml` | Note |
+| --- | --- | --- | --- |
+| Test runtimes | node + bun + **deno** × 3 OS | bun × 3 OS, node (ubuntu, smoke-load only) | Deno coverage is broader; adopting it is a larger, separate change. |
+| Per-test timeout | `bun test --timeout 30000` | `bun test … --timeout 10000` | Both bound hung tests; 10s is stricter. |
+| Fresh-merge simulation (PR) | `scripts/simulate-fresh-merge.sh` (see template's issue-23 case study) | not present | Would catch *post-merge* breakage in PR CI — relevant because this flake landed on a push to `main`. Recommended as a follow-up. |
+
+These are recommendations for a follow-up hardening pass; none of them is the
+cause of run 27310950658, and changing the matrix shape in this PR would add CI
+risk unrelated to the fix.
+
+---
+
+## 6. Requirement R4 — debug/verbose for the next iteration
+
+The library already supports gated tracing via the `COMMAND_STREAM_TRACE`
+environment variable (wired into the CI test step as
+`COMMAND_STREAM_TRACE: ${{ vars.COMMAND_STREAM_TRACE || 'false' }}`), and the
+kill/reset/parent-closure paths emit `trace(...)` lines. Because the root cause
+was fully determined from the existing log (the unique `"Process killed with
+SIGTERM"` string plus the `throwErrexitIfNeeded` stack frame) and reproduced
+deterministically, **no additional debug output was required**. The new
+regression test is the durable guard against recurrence.
+
+---
+
+## 7. Verification
+
+- `experiments/repro-issue-170-awaited.mjs`: clean → `code=143` (reproduces); fixed → `code=5`.
+- `js/tests/issue-170-cleanup-race.test.mjs`: clean → **3 fail**; fixed → **3 pass** (bun).
+- `bun test js/tests/shell-settings.test.mjs js/tests/issue-170-cleanup-race.test.mjs js/tests/ctrl-c-signal.test.mjs`: **31 pass / 0 fail**, no `MaxListenersExceeded` warning.
+- Lint + Prettier: clean on all changed files.
+
+---
+
+## 8. Status against requirements
+
+| Req | Status |
+| --- | --- |
+| R1 fix CI false positives/errors | ✅ both defects fixed at the source |
+| R2 compare workflows vs templates | ✅ compared; no matching defect in templates; deltas documented |
+| R3 logs + deep case study | ✅ this folder |
+| R4 debug/verbose for next iteration | ✅ existing `COMMAND_STREAM_TRACE` tracing sufficient; root cause determined |
+| R5 report to other repos | ✅ N/A — root cause is this repo's own source, no external/template target |
+| R6 fix across entire codebase | ✅ all consumption entry points + both reset paths covered |
+| R7 single PR #171 | ✅ all work on `issue-170-9e2e62bb506a` / PR #171 |

--- a/docs/case-studies/issue-170/README.md
+++ b/docs/case-studies/issue-170/README.md
@@ -32,6 +32,8 @@ docs/case-studies/issue-170/
 | 22:41:18.859 | `##[error]Process completed with exit code 1`. |
 | — | All other matrix legs (bun on ubuntu/macOS, node 20/22/24 on ubuntu) **passed**. Only `bun on windows-latest` failed. |
 | 2026-06-10 22:49:36 | Issue #170 filed. |
+| 2026-06-11 (this PR) | First fix (commit `9fd7ad2`: reaper guard + listener-leak removal) pushed. The `MaxListenersExceeded` warning disappeared, **but `bun on windows-latest` still failed identically** (run 27315260602) with the synthetic `143`. This proved the reaper was *not* the (only) trigger — see §3.4. |
+| 2026-06-11 (this PR) | Second fix (commit `1c53eef`: `_handleParentStreamClosure` guard) pushed, closing the parent-stream-closure teardown path. |
 
 The failure is a **flaky, timing-dependent false positive**: the same test
 passes on every other matrix leg and on local re-runs. It surfaced on a push to
@@ -105,32 +107,50 @@ const killResult = {
 this.finish(killResult);
 ```
 
-So **something called `runner.kill()` on a live, still-awaited command**, and
-because `finish()` is idempotent (first-wins), the synthetic kill result became
-`this.result`. When `_doStartAsync` then reached `throwErrexitIfNeeded`, it threw
-the synthetic 143 instead of the real exit code 5.
+So **something tore down a live, still-awaited command**, and because `finish()`
+is idempotent (first-wins), a synthetic/teardown result became `this.result`.
+When `_doStartAsync` then reached `throwErrexitIfNeeded`, it threw `143` instead
+of the real exit code 5.
 
-### 3.2 Who called `kill()`? — the test-isolation reaper race
-
-`kill()` here was **not** triggered by the test. It came from the global
-test-isolation reset that `test-helper.mjs` runs in `beforeEach`/`afterEach`:
+The unifying root cause is therefore: **a global teardown path force-terminates
+a command that user code is actively awaiting.** There are *two* such paths, and
+both reach `activeProcessRunners` runners during a `resetGlobalState()`:
 
 ```
-resetGlobalState()  →  cleanupActiveRunners()  →  runner.kill()  →  killRunner()
+resetGlobalState() ─┬─ cleanupActiveRunners() ─→ runner.kill() ─→ killRunner()   (Path A — reaper)
+                    └─ (a parent stdout/stderr 'close' fires the monitor listener)
+                         └─→ runner._handleParentStreamClosure() ─→ abort + child.kill('SIGTERM')   (Path B — parent closure)
 ```
 
-`cleanupActiveRunners()` iterates `activeProcessRunners` and kills anything still
+### 3.2 Path A — the test-isolation reaper race
+
+`cleanupActiveRunners()` (run by `resetGlobalState()` in `test-helper.mjs`'s
+`beforeEach`/`afterEach`) iterates `activeProcessRunners` and kills anything still
 registered, to prevent leaked fire-and-forget processes from bleeding across
 tests. On the slow Windows/Bun runner, the previous test's `afterEach` (or the
-next test's `beforeEach`) **ran while this command was still in flight and still
-being awaited**. The reaper killed it, the synthetic SIGTERM result won, and the
-real exit code 5 was lost.
+next test's `beforeEach`) could **run while this command was still in flight and
+still being awaited**. The reaper killed it, the synthetic SIGTERM result won, and
+the real exit code 5 was lost. **Root cause #1: the reaper does not distinguish a
+leaked runner from a healthy, actively-awaited one.**
 
-This is a genuine race, which is why it only reproduced on the slowest leg
-(Windows + Bun) and never locally. **Root cause #1: the reaper does not
-distinguish a leaked runner from a healthy, actively-awaited one.**
+### 3.3 Path B — the parent-stream-closure handler (the path that actually broke CI)
 
-### 3.3 The MaxListeners warning — a second, independent defect
+`monitorParentStreams()` attaches a `'close'` listener to `process.stdout` /
+`process.stderr` so active runners can shut down gracefully when the parent stream
+closes. When that listener fires, it calls `_handleParentStreamClosure()` on
+**every** active runner, which aborts the runner's controller and kills its child
+(`child.kill('SIGTERM')`). For a command being awaited, that replaces the real
+exit code with `143` — exactly the failure signature.
+
+Crucially, on Windows/Bun the parent `WriteStream` emits a **spurious** `'close'`
+event — the very same stream whose listeners overflowed into the
+`MaxListenersExceeded` warning logged 14 seconds before the failure (§3.4). That
+spurious close fires Path B against the in-flight, awaited command. **This is why
+the reaper-only fix (commit `9fd7ad2`) did not stop the CI failure**: it closed
+Path A but left Path B wide open. **Root cause #2: `_handleParentStreamClosure()`
+also fails to distinguish a leaked runner from an actively-awaited one.**
+
+### 3.4 The MaxListeners warning — a third, independent defect (and the smoking gun)
 
 The log also shows, before the failure:
 
@@ -143,19 +163,28 @@ MaxListenersExceededWarning: … 11 close listeners added to [WriteStream].
 when the parent stream closes. It guards with a `parentStreamsMonitored` flag —
 but `resetGlobalState()` reset the flag to `false` **without removing the
 listeners**. Every test therefore re-attached a new pair of listeners, and they
-accumulated until Node/Bun warned at 11. **Root cause #2: listeners are added on
-every reset cycle but never removed**, an unbounded leak. While the warning
-itself did not fail the test, it is noise that masks real leaks and is itself a
-CI-quality defect the issue asks us to eliminate.
+accumulated until Node/Bun warned at 11. **Root cause #3: listeners are added on
+every reset cycle but never removed**, an unbounded leak.
 
-### 3.4 Confirmation (reproduced on Linux)
+This warning is more than noise — it is the **smoking gun for Path B**. It proves
+the parent `WriteStream` was being churned (closed/re-listened) on the
+Windows/Bun runner, i.e. exactly the spurious `'close'` activity that fires
+`_handleParentStreamClosure()` against the in-flight, awaited command. The warning
+and the failure are two symptoms of the same unstable parent-stream lifecycle.
 
-`experiments/repro-issue-170-awaited.mjs` fires `resetGlobalState()` 100 ms into
-an awaited `$\`… exit 5\`` command. On the unpatched code it reproduces the exact
-CI failure (`code=143`, `stderr="Process killed with SIGTERM"`); with the fix it
-returns `code=5`. The committed regression test
-`js/tests/issue-170-cleanup-race.test.mjs` encodes both defects and goes from
-**3 fail (clean) → 3 pass (fixed)**.
+### 3.5 Confirmation (reproduced on Linux, both paths)
+
+- **Path A** — `experiments/repro-issue-170-awaited.mjs` fires
+  `resetGlobalState()` 100 ms into an awaited `$\`… exit 5\`` command. Unpatched it
+  reproduces `code=143`; fixed it returns `code=5`.
+- **Path B** — `experiments/repro-issue-170-parentclose.mjs` emits a spurious
+  `process.stdout.emit('close')` 60 ms into an awaited errexit `$\`… exit 5\``
+  command. Unpatched it returns `code=143` (the bug); with the
+  `_handleParentStreamClosure` guard it returns `code=5`, on **both node and bun**.
+
+The committed regression test `js/tests/issue-170-cleanup-race.test.mjs` encodes
+all three defects (reaper race, parent-closure preemption, listener leak). The
+parent-closure case was verified to go **143 without the guard → 5 with it**.
 
 ---
 
@@ -188,20 +217,48 @@ Because `await x` calls `x.then(...)` **synchronously** before yielding, the fla
 is set before any `beforeEach`/`afterEach` reset can interleave — closing the
 race. Leaked fire-and-forget runners (never awaited) are still reaped as before.
 
-### Fix 2 — remove parent-stream listeners on reset
+### Fix 2 — never tear down an awaited runner on parent-stream closure (the CI fix)
+
+The same `_awaited` flag guards `_handleParentStreamClosure()`
+(`$.process-runner-base.mjs`). When a runner is being awaited, the graceful
+parent-stream shutdown is suppressed — the await is the authoritative consumer, so
+a spurious parent `'close'` must not preempt the real result:
+
+```js
+// Graceful shutdown on parent-stream closure exists for fire-and-forget /
+// streamed commands whose output consumer went away; when the result is being
+// awaited, the await is the authoritative consumer. A spurious parent
+// stdout/stderr 'close' — observed on Windows/Bun … — must not preempt the
+// awaited result and replace the real exit code with a synthetic SIGTERM (143).
+if (this._awaited) {
+  return;
+}
+```
+
+Fire-and-forget / streamed runners (e.g. `runner.start()` without awaiting the
+runner itself) are **not** flagged `_awaited`, so the legitimate
+parent-stream-closure shutdown path is preserved — verified by
+`ctrl-c-signal.test.mjs`'s "should handle parent stream closure triggering process
+cleanup" still passing.
+
+### Fix 3 — remove parent-stream listeners on reset
 
 `monitorParentStreams()` now records each `{ stream, listener }` it installs in a
 module-level `parentStreamListeners` array. A new `removeParentStreamListeners()`
 detaches them, and it is called from both `resetParentStreamMonitoring()` and
 `resetGlobalState()` (right before clearing `parentStreamsMonitored`). The listener
-count is now bounded across any number of resets.
+count is now bounded across any number of resets, eliminating the warning.
 
 ### Why not other approaches (rejected alternatives)
 
-- **Guarding the `'close'` handler on `stream.destroyed`** — rejected. Empirically
-  `process.stdout.destroyed` stays `false` in Node even after `process.stdout.destroy()`,
-  so the guard either does nothing or, when interpreted strictly, hangs the legitimate
-  parent-stream-closure shutdown path (verified: subprocess timed out at rc=124/143).
+- **Guarding the `'close'` handler on `stream.destroyed`** (instead of `_awaited`) —
+  rejected. Empirically `process.stdout.destroyed` stays `false` in Node even after
+  `process.stdout.destroy()`, so the guard either does nothing or, when interpreted
+  strictly, hangs the legitimate parent-stream-closure shutdown path (verified:
+  subprocess timed out at rc=124/143). Keying on `_awaited` (intent of the consumer)
+  rather than on stream internals is both correct and portable across Node/Bun.
+- **Fixing only the reaper (Path A)** — rejected: insufficient. Commit `9fd7ad2` did
+  exactly this and CI still failed (run 27315260602) because Path B remained open.
 - **Raising `setMaxListeners`** — rejected. It hides the leak instead of fixing it.
 - **Skipping the test on Windows** — rejected. It hides a real correctness bug
   (a kill racing an await could mask any command's exit code, not just in tests).
@@ -268,10 +325,12 @@ regression test is the durable guard against recurrence.
 
 ## 7. Verification
 
-- `experiments/repro-issue-170-awaited.mjs`: clean → `code=143` (reproduces); fixed → `code=5`.
-- `js/tests/issue-170-cleanup-race.test.mjs`: clean → **3 fail**; fixed → **3 pass** (bun).
-- `bun test js/tests/shell-settings.test.mjs js/tests/issue-170-cleanup-race.test.mjs js/tests/ctrl-c-signal.test.mjs`: **31 pass / 0 fail**, no `MaxListenersExceeded` warning.
+- `experiments/repro-issue-170-awaited.mjs` (Path A): clean → `code=143`; fixed → `code=5`.
+- `experiments/repro-issue-170-parentclose.mjs` (Path B): clean → `code=143`; fixed → `code=5` on both node and bun.
+- `js/tests/issue-170-cleanup-race.test.mjs`: **4 pass / 0 fail** (bun); the parent-closure case verified to fail with `143` when the guard is removed.
+- `bun test js/tests/shell-settings.test.mjs js/tests/issue-170-cleanup-race.test.mjs js/tests/ctrl-c-signal.test.mjs`: all pass, no `MaxListenersExceeded` warning; the legitimate parent-stream-closure cleanup test still passes.
 - Lint + Prettier: clean on all changed files.
+- CI re-run on `bun on windows-latest` after commit `1c53eef`: see PR #171 checks.
 
 ---
 
@@ -279,10 +338,10 @@ regression test is the durable guard against recurrence.
 
 | Req | Status |
 | --- | --- |
-| R1 fix CI false positives/errors | ✅ both defects fixed at the source |
+| R1 fix CI false positives/errors | ✅ all three defects fixed at the source (reaper race, parent-closure preemption, listener leak) |
 | R2 compare workflows vs templates | ✅ compared; no matching defect in templates; deltas documented |
 | R3 logs + deep case study | ✅ this folder |
 | R4 debug/verbose for next iteration | ✅ existing `COMMAND_STREAM_TRACE` tracing sufficient; root cause determined |
 | R5 report to other repos | ✅ N/A — root cause is this repo's own source, no external/template target |
-| R6 fix across entire codebase | ✅ all consumption entry points + both reset paths covered |
+| R6 fix across entire codebase | ✅ all consumption entry points flag `_awaited`; both teardown paths (reaper + parent-closure) and the listener leak covered |
 | R7 single PR #171 | ✅ all work on `issue-170-9e2e62bb506a` / PR #171 |

--- a/docs/case-studies/issue-170/ci-logs/run-27310950658-failed.log
+++ b/docs/case-studies/issue-170/ci-logs/run-27310950658-failed.log
@@ -1,0 +1,4504 @@
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	﻿2026-06-10T22:40:02.6403709Z Current runner version: '2.335.1'
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6431094Z ##[group]Runner Image Provisioner
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6431948Z Hosted Compute Agent
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6432499Z Version: 20260520.533
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6433074Z Commit: 189110e25284a9812c124fd27b339e2fb4f2f9db
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6433766Z Build Date: 2026-05-20T17:44:04Z
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6434413Z Worker ID: {b65eb5c9-9098-44f7-a022-5614e2ade0dc}
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6435100Z Azure Region: westus3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6435631Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6436984Z ##[group]Operating System
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6437635Z Microsoft Windows Server 2025
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6438260Z 10.0.26100
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6438758Z Datacenter
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6439261Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6439828Z ##[group]Runner Image
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6440432Z Image: windows-2025-vs2026
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6441026Z Version: 20260525.121.1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6442905Z Included Software: https://github.com/actions/runner-images/blob/win25-vs2026/20260525.121/images/windows/Windows2025-VS2026-Readme.md
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6444724Z Image Release: https://github.com/actions/runner-images/releases/tag/win25-vs2026%2F20260525.121
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6445815Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6448876Z ##[group]GITHUB_TOKEN Permissions
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6451099Z Actions: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6451700Z ArtifactMetadata: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6452322Z Attestations: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6452877Z Checks: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6453418Z CodeQuality: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6453981Z Contents: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6454513Z CopilotRequests: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6455057Z Deployments: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6455586Z Discussions: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6456099Z Issues: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6456615Z Metadata: read
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6457118Z Models: read
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6457711Z Packages: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6458246Z Pages: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6458793Z PullRequests: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6459348Z RepositoryProjects: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6459983Z SecurityEvents: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6460507Z Statuses: write
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6461078Z VulnerabilityAlerts: read
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6461632Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6464929Z Secret source: Actions
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6465827Z Prepare workflow directory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6867384Z Prepare all required actions
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:02.6907670Z Getting action download info
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:03.1043882Z Download action repository 'actions/checkout@v6' (SHA:df4cb1c069e1874edd31b4311f1884172cec0e10)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:03.7062876Z Download action repository 'oven-sh/setup-bun@v2' (SHA:0c5077e51419868618aeaa5fe8019c62421857d6)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.2616379Z Download action repository 'actions/setup-node@v6' (SHA:48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.6177757Z Complete job name: Test JavaScript (bun on windows-latest)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7534510Z ##[group]Run actions/checkout@v6
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7536283Z with:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7536648Z   repository: link-foundation/command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7540218Z   token: ***
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7540522Z   ssh-strict: true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7540813Z   ssh-user: git
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7541120Z   persist-credentials: true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7541453Z   clean: true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7541770Z   sparse-checkout-cone-mode: true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7542135Z   fetch-depth: 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7542444Z   fetch-tags: false
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7542767Z   show-progress: true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7543063Z   lfs: false
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7543344Z   submodules: false
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7543656Z   set-safe-directory: true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.7544332Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.9118512Z Syncing repository: link-foundation/command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.9120225Z ##[group]Getting Git version info
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:04.9120842Z Working directory is 'D:\a\command-stream\command-stream'
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.0177411Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.4236548Z git version 2.54.0.windows.1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.4286128Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.4307337Z Temporarily overriding HOME='D:\a\_temp\6917dbd2-c142-41bb-bb03-b9f209cf8e77' before making global git config changes
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.4308173Z Adding repository directory to the temporary git global config as a safe directory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.4318420Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\command-stream\command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.4938744Z Deleting the contents of 'D:\a\command-stream\command-stream'
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.4945197Z ##[group]Determining repository object format
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.4948023Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.4948541Z ##[group]Initializing the repository
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.4957859Z [command]"C:\Program Files\Git\bin\git.exe" init D:\a\command-stream\command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.5868259Z Initialized empty Git repository in D:/a/command-stream/command-stream/.git/
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.5916729Z [command]"C:\Program Files\Git\bin\git.exe" remote add origin https://github.com/link-foundation/command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.6531342Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.6532057Z ##[group]Disabling automatic garbage collection
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.6541125Z [command]"C:\Program Files\Git\bin\git.exe" config --local gc.auto 0
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.6881296Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.6882053Z ##[group]Setting up auth
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.6882808Z Removing SSH command configuration
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.6896012Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:05.7253947Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:07.1211304Z Removing HTTP extra header
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:07.1221282Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:07.1545937Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:07.7278264Z Removing includeIf entries pointing to credentials config files
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:07.7289950Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:07.7632068Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:08.3418352Z [command]"C:\Program Files\Git\bin\git.exe" config --file D:\a\_temp\git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config http.https://github.com/.extraheader "AUTHORIZATION: basic ***"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:08.3748639Z [command]"C:\Program Files\Git\bin\git.exe" config --local includeIf.gitdir:D:/a/command-stream/command-stream/.git.path D:\a\_temp\git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:08.4080073Z [command]"C:\Program Files\Git\bin\git.exe" config --local includeIf.gitdir:D:/a/command-stream/command-stream/.git/worktrees/*.path D:\a\_temp\git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:08.4442659Z [command]"C:\Program Files\Git\bin\git.exe" config --local includeIf.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:08.4777119Z [command]"C:\Program Files\Git\bin\git.exe" config --local includeIf.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:08.5100348Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:08.5100796Z ##[group]Fetching the repository
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:08.5116932Z [command]"C:\Program Files\Git\bin\git.exe" -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +fe8aae79cc1bdf829528257e76194fd9f03d5a4e:refs/remotes/origin/main
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.0667082Z From https://github.com/link-foundation/command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.1093215Z  * [new ref]         fe8aae79cc1bdf829528257e76194fd9f03d5a4e -> origin/main
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.1110848Z [command]"C:\Program Files\Git\bin\git.exe" branch --list --remote origin/main
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.1458072Z   origin/main
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.1505863Z [command]"C:\Program Files\Git\bin\git.exe" rev-parse refs/remotes/origin/main
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.1824194Z fe8aae79cc1bdf829528257e76194fd9f03d5a4e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.1860029Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.1860420Z ##[group]Determining the checkout info
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.1862079Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.1871683Z [command]"C:\Program Files\Git\bin\git.exe" sparse-checkout disable
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.2281001Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset-all extensions.worktreeConfig
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.2601919Z ##[group]Checking out the ref
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.2611368Z [command]"C:\Program Files\Git\bin\git.exe" checkout --progress --force -B main refs/remotes/origin/main
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.5787051Z Switched to a new branch 'main'
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.5849851Z branch 'main' set up to track 'origin/main'.
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.5911199Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.6372915Z [command]"C:\Program Files\Git\bin\git.exe" log -1 --format=%H
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.6674237Z fe8aae79cc1bdf829528257e76194fd9f03d5a4e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.7239849Z ##[group]Run oven-sh/setup-bun@v2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.7240186Z with:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.7240381Z   bun-version: latest
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.7240596Z   no-cache: false
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.7244099Z   token: ***
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:10.7244298Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:11.4243404Z Downloading a new version of Bun: https://github.com/oven-sh/bun/releases/download/bun-v1.3.14/bun-windows-x64.zip
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:12.1208982Z [command]"C:\Program Files\PowerShell\7\pwsh.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command "$ErrorActionPreference = 'Stop' ; try { Add-Type -AssemblyName System.IO.Compression.ZipFile } catch { } ; try { [System.IO.Compression.ZipFile]::ExtractToDirectory('D:\a\_temp\979ce433-39d6-4ac7-865b-9b322ca2e4d2.zip', 'D:\a\_temp\12496cff-fbb3-4187-b9a8-1c9ecd6e6c6f', $true) } catch { if (($_.Exception.GetType().FullName -eq 'System.Management.Automation.MethodException') -or ($_.Exception.GetType().FullName -eq 'System.Management.Automation.RuntimeException') ){ Expand-Archive -LiteralPath 'D:\a\_temp\979ce433-39d6-4ac7-865b-9b322ca2e4d2.zip' -DestinationPath 'D:\a\_temp\12496cff-fbb3-4187-b9a8-1c9ecd6e6c6f' -Force } else { throw $_ } } ;"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:18.0272826Z [command]C:\Users\runneradmin\.bun\bin\bun.exe --revision
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:18.5835269Z 1.3.14+0d9b296af
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:18.6195507Z ##[group]Run choco install jq -y
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:18.6195909Z ^[[36;1mchoco install jq -y^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:18.6266404Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:18.6266780Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:23.1252914Z Chocolatey v2.7.2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:23.5049297Z Installing the following packages:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:23.5056295Z jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:23.5060462Z By installing, you accept licenses for the packages.
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.4535562Z jq v1.8.1 already installed.
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.4536095Z  Use --force to reinstall, specify a version to install, or try upgrade.
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.4633038Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.4633448Z Chocolatey installed 0/1 packages. 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.4633980Z  See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.4638424Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.4641879Z Warnings:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.4647217Z  - jq - jq v1.8.1 already installed.
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.4647818Z  Use --force to reinstall, specify a version to install, or try upgrade.
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.7007213Z ##[group]Run bun install
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.7007539Z ^[[36;1mbun install^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.7070940Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.7071307Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:32.9725376Z bun install v1.3.14 (0d9b296a)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:56.0777587Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:56.0872337Z $ cd .. && js/node_modules/.bin/husky || true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:58.8689435Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:58.8689972Z + @changesets/cli@2.29.8
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:58.8690757Z + eslint@9.39.2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:58.8691536Z + eslint-config-prettier@10.1.8
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:58.8693143Z + eslint-plugin-prettier@5.5.4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:58.8693811Z + husky@9.1.7
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:58.8694132Z + jscpd@4.0.5
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:58.8694439Z + lint-staged@16.2.7
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:58.8694750Z + prettier@3.7.4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:58.8694921Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:58.8695057Z 301 packages installed [25.90s]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.0004787Z ##[group]Run bun test js/tests/ --timeout 10000
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.0005266Z ^[[36;1mbun test js/tests/ --timeout 10000^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.0069115Z shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.0069479Z env:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.0069673Z   COMMAND_STREAM_TRACE: false
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.0069907Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.2900182Z bun test v1.3.14 (0d9b296a)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.3238055Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.3239161Z ##[group]js\tests\$.features.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.3863259Z (pass) command-stream Feature Validation > Runtime Support > should work in Bun runtime [24.77ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.5696855Z node compatibility
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.5762770Z (pass) command-stream Feature Validation > Runtime Support > should work in Node.js runtime [190.01ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.6148868Z template literal test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.6254977Z (pass) command-stream Feature Validation > Template Literals > should support $`cmd` syntax [49.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.6776316Z interpolation test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.6816443Z (pass) command-stream Feature Validation > Template Literals > should support variable interpolation [56.26ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.7197314Z streaming test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.7253452Z (pass) command-stream Feature Validation > Real-time Streaming > should provide live output streaming [43.61ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.7710720Z immediate
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.7733331Z (pass) command-stream Feature Validation > Real-time Streaming > should stream data as it arrives, not buffered [47.95ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.8158857Z async iteration test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.8301766Z (pass) command-stream Feature Validation > Async Iteration > should support for await (chunk of $.stream()) [56.87ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.8870786Z metadata test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.8921979Z (pass) command-stream Feature Validation > Async Iteration > should provide chunk metadata [61.94ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.9533434Z event test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:40:59.9692535Z (pass) command-stream Feature Validation > EventEmitter Pattern > should support .on("data", ...) events [76.93ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.0247630Z stdout
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.0268025Z stderr
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.0505254Z (pass) command-stream Feature Validation > EventEmitter Pattern > should support multiple event types [81.24ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.0945657Z mixed pattern test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1102248Z (pass) command-stream Feature Validation > Mixed Patterns > should support events + await simultaneously [59.72ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1223078Z MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 close listeners added to [WriteStream]. MaxListeners is undefined. Use events.setMaxListeners() to increase limit
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1223986Z  emitter: WriteStream {
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1224199Z   fd: 1,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1224378Z   [Symbol(kFs)]: [Object ...],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1224609Z   _writev: undefined,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1224827Z   flush: false,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1225036Z   start: undefined,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1225234Z   pos: undefined,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1225723Z   bytesWritten: 0,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1225956Z   [Symbol(kWriteStreamFastPath)]: [FileSink ...],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1226272Z   _write: [Function: underscoreWriteFast],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1226543Z   write: [Function: writeFast],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1226772Z   _events: [Object ...],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1226985Z   _writableState: [Object ...],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1227209Z   _maxListeners: undefined,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1227429Z   [Symbol(kCapture)]: false,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1227644Z   _eventsCount: NaN,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1227830Z   readable: false,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1228010Z   _type: "fs",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1228217Z   [Symbol(Symbol.asyncIterator)]: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1228837Z   destroySoon: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1229059Z   _destroy: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1229268Z   _final: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1229453Z   _isStdio: true,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1232054Z   open: [Function: open],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1232402Z   _construct: [Function: streamConstruct],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1232691Z   close: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1232905Z   autoClose: [Getter/Setter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1233131Z   pending: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1233323Z   pipe: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1233510Z   cork: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1233689Z   uncork: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1233940Z   setDefaultEncoding: [Function: setDefaultEncoding],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1234252Z   end: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1234438Z   closed: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1234638Z   destroyed: [Getter/Setter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1234870Z   writable: [Getter/Setter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1235097Z   writableFinished: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1235335Z   writableObjectMode: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1235570Z   writableBuffer: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1235806Z   writableEnded: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1236030Z   writableNeedDrain: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1236271Z   writableHighWaterMark: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1236520Z   writableCorked: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1236732Z   writableLength: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1236934Z   errored: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1237131Z   writableAborted: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1237346Z   destroy: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1237554Z   _undestroy: [Function: undestroy],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1237818Z   [Symbol(nodejs.rejection)]: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1238102Z   [Symbol(Symbol.asyncDispose)]: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1238384Z   eventNames: [Function: eventNames],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1238667Z   setMaxListeners: [Function: setMaxListeners],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1238975Z   getMaxListeners: [Function: getMaxListeners],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1239246Z   emit: [Function: emit],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1239471Z   addListener: [Function: addListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1239732Z   on: [Function: addListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1239997Z   prependListener: [Function: prependListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1240270Z   once: [Function: once],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1240542Z   prependOnceListener: [Function: prependOnceListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1240876Z   removeListener: [Function: removeListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1241154Z   off: [Function: removeListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1241441Z   removeAllListeners: [Function: removeAllListeners],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1241815Z   listeners: [Function: listeners],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1242109Z   rawListeners: [Function: rawListeners],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1242387Z   listenerCount: [Function: listenerCount],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1242630Z },
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1242792Z     type: "close",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1243044Z    count: 11,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1243237Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1243380Z       at overflowWarning (node:events:185:19)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1243657Z       at addListener (node:events:158:22)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1244060Z       at checkParentStream (D:\a\command-stream\command-stream\js\src\$.state.mjs:292:14)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1244625Z       at monitorParentStreams (D:\a\command-stream\command-stream\js\src\$.state.mjs:307:3)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1245997Z       at new ProcessRunner (D:\a\command-stream\command-stream\js\src\$.process-runner-base.mjs:247:5)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1246800Z       at $tagged (D:\a\command-stream\command-stream\js\src\$.mjs:195:18)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1247294Z       at <anonymous> (D:\a\command-stream\command-stream\js\tests\$.features.test.mjs:208:28)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1247630Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1248231Z MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 close listeners added to [WriteStream]. MaxListeners is undefined. Use events.setMaxListeners() to increase limit
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1249353Z  emitter: WriteStream {
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1249837Z   fd: 2,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1250085Z   [Symbol(kFs)]: [Object ...],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1250410Z   _writev: undefined,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1250707Z   flush: false,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1251718Z   start: undefined,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1252085Z   pos: undefined,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1252387Z   bytesWritten: 0,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1252750Z   [Symbol(kWriteStreamFastPath)]: [FileSink ...],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1253258Z   _write: [Function: underscoreWriteFast],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1253626Z   write: [Function: writeFast],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1253860Z   _events: [Object ...],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1254082Z   _writableState: [Object ...],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1254324Z   _maxListeners: undefined,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1254551Z   [Symbol(kCapture)]: false,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1254783Z   _eventsCount: NaN,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1254979Z   readable: false,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1255164Z   _type: "fs",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1255390Z   [Symbol(Symbol.asyncIterator)]: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1255679Z   destroySoon: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1255993Z   _destroy: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1256323Z   _final: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1256641Z   _isStdio: true,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1256968Z   open: [Function: open],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1257449Z   _construct: [Function: streamConstruct],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1257921Z   close: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1258255Z   autoClose: [Getter/Setter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1258627Z   pending: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1259263Z   pipe: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1259579Z   cork: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1259865Z   uncork: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1260279Z   setDefaultEncoding: [Function: setDefaultEncoding],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1260752Z   end: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1261002Z   closed: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1261327Z   destroyed: [Getter/Setter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1261694Z   writable: [Getter/Setter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1262037Z   writableFinished: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1262405Z   writableObjectMode: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1262812Z   writableBuffer: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1263170Z   writableEnded: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1263537Z   writableNeedDrain: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1263967Z   writableHighWaterMark: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1264395Z   writableCorked: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1264765Z   writableLength: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1265115Z   errored: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1265450Z   writableAborted: [Getter],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1265820Z   destroy: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1266176Z   _undestroy: [Function: undestroy],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1266614Z   [Symbol(nodejs.rejection)]: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1267083Z   [Symbol(Symbol.asyncDispose)]: [Function],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1267593Z   eventNames: [Function: eventNames],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1267993Z   setMaxListeners: [Function: setMaxListeners],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1268312Z   getMaxListeners: [Function: getMaxListeners],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1268585Z   emit: [Function: emit],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1268809Z   addListener: [Function: addListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1269063Z   on: [Function: addListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1269332Z   prependListener: [Function: prependListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1269607Z   once: [Function: once],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1270103Z   prependOnceListener: [Function: prependOnceListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1295432Z   removeListener: [Function: removeListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1295981Z   off: [Function: removeListener],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1296826Z   removeAllListeners: [Function: removeAllListeners],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1297386Z   listeners: [Function: listeners],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1297843Z   rawListeners: [Function: rawListeners],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1298344Z   listenerCount: [Function: listenerCount],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1298792Z },
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1299059Z     type: "close",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1299680Z    count: 11,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1299873Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1300041Z       at overflowWarning (node:events:185:19)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1300542Z       at addListener (node:events:158:22)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1301247Z       at checkParentStream (D:\a\command-stream\command-stream\js\src\$.state.mjs:292:14)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1303110Z       at monitorParentStreams (D:\a\command-stream\command-stream\js\src\$.state.mjs:308:3)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1304314Z       at new ProcessRunner (D:\a\command-stream\command-stream\js\src\$.process-runner-base.mjs:247:5)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1305291Z       at $tagged (D:\a\command-stream\command-stream\js\src\$.mjs:195:18)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1306158Z       at <anonymous> (D:\a\command-stream\command-stream\js\tests\$.features.test.mjs:208:28)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1306762Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1653711Z '; rm -rf /; echo 'hacked
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.1698286Z (pass) command-stream Feature Validation > Shell Injection Protection > should auto-quote dangerous input [59.62ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.2076680Z $HOME && echo "injection"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.2133124Z (pass) command-stream Feature Validation > Shell Injection Protection > should handle special characters safely [43.39ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.2592683Z cross-platform test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.2682811Z (pass) command-stream Feature Validation > Cross-platform Support > should work on current platform [54.95ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.3233721Z memory efficient streaming test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.3256358Z (pass) command-stream Feature Validation > Memory Efficiency > should stream without accumulating large buffers [57.34ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.3762489Z (pass) command-stream Feature Validation > Error Handling > should handle non-zero exit codes gracefully [50.46ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.4598771Z (pass) command-stream Feature Validation > Stdin Support > should support string stdin through sh helper [83.69ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5378461Z (pass) command-stream Feature Validation > Stdin Support > should support Buffer stdin through sh helper [77.85ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5812845Z stdin string testbuffer stdin testignore stdin test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5897149Z (pass) command-stream Feature Validation > Stdin Support > should support ignore stdin through options [51.90ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5897653Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5898183Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5898359Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5898623Z ##[group]js\tests\$.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5943941Z (pass) StreamEmitter > should add and emit events [0.25ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5944846Z (pass) StreamEmitter > should support multiple listeners for same event [0.11ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5946314Z (pass) StreamEmitter > should support chaining [0.11ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5948019Z (pass) StreamEmitter > should remove listeners with off [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5949639Z (pass) StreamEmitter > should handle non-existent event removal [0.11ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5950472Z (pass) Utility Functions > quote > should not quote safe strings [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5951294Z (pass) Utility Functions > quote > should quote strings with spaces [0.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5952276Z (pass) Utility Functions > quote > should quote strings with special characters [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5953002Z (pass) Utility Functions > quote > should handle empty string [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5953965Z (pass) Utility Functions > quote > should handle null/undefined [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5955096Z (pass) Utility Functions > quote > should escape single quotes [0.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5956029Z (pass) Utility Functions > quote > should handle arrays [0.11ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5956843Z (pass) Utility Functions > quote > should convert non-strings [0.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5957734Z (pass) Utility Functions > quote > should preserve user-provided quotes [0.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5960071Z (pass) Utility Functions > raw > should create raw object [0.18ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5960772Z (pass) Utility Functions > raw > should convert to string [0.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5963337Z (pass) Utility Functions > quoteLiteral > should preserve apostrophes [0.21ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5964035Z (pass) Utility Functions > quoteLiteral > should escape double quotes [0.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5964819Z (pass) Utility Functions > quoteLiteral > should escape dollar signs [0.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5965920Z (pass) Utility Functions > quoteLiteral > should escape backticks [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5966679Z (pass) Utility Functions > quoteLiteral > should escape backslashes [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5967335Z (pass) Utility Functions > quoteLiteral > should handle empty string [0.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5967998Z (pass) Utility Functions > quoteLiteral > should handle null/undefined [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5968586Z (pass) Utility Functions > quoteLiteral > should not quote safe strings [0.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5969294Z (pass) Utility Functions > quoteLiteral > should handle arrays [0.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5970665Z (pass) Utility Functions > literal > should create literal object [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.5971304Z (pass) Utility Functions > literal > should convert to string [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.6373714Z hello world
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.6402030Z (pass) ProcessRunner - Classic Await Pattern > should execute simple command [42.97ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.6978506Z stdout
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.6979527Z stderr
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.7008675Z (pass) ProcessRunner - Classic Await Pattern > should handle command with non-zero exit [60.67ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.7351779Z hello world
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.7392723Z (pass) ProcessRunner - Classic Await Pattern > should interpolate variables with quoting [38.35ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.7766311Z raw test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.7794323Z (pass) ProcessRunner - Classic Await Pattern > should handle raw interpolation [40.13ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.8170920Z Dependencies didn't exist
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.8197053Z (pass) ProcessRunner - Classic Await Pattern > should handle literal interpolation - preserves apostrophes [40.18ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.8566397Z it's the user's choice
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.8590953Z (pass) ProcessRunner - Classic Await Pattern > should handle literal interpolation - multiple apostrophes [39.41ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.8967887Z it's "great"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.8990312Z (pass) ProcessRunner - Classic Await Pattern > should handle literal interpolation - mixed quotes [39.87ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.9357175Z price is $100
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.9419324Z (pass) ProcessRunner - Classic Await Pattern > should handle literal interpolation - special characters [42.88ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.9782806Z ; rm -rf /; echo 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:00.9828120Z (pass) ProcessRunner - Classic Await Pattern > should quote dangerous characters [40.84ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:01.0192259Z line1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:01.0192839Z line2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:01.0194408Z line3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:01.0220781Z (pass) ProcessRunner - Async Iteration Pattern > should stream command output [39.30ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:01.0578311Z stdout
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:01.0580673Z stderr
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:01.0622453Z (pass) ProcessRunner - Async Iteration Pattern > should handle stderr in streaming [40.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:02.0740683Z (pass) ProcessRunner - EventEmitter Pattern > should emit data events [1011.77ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.0774587Z (pass) ProcessRunner - EventEmitter Pattern > should support event chaining [1003.35ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.1131413Z mixed test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.1175721Z (pass) ProcessRunner - Mixed Pattern > should support both events and await [40.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.1530128Z stream test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.2203501Z (pass) ProcessRunner - Stream Properties > should provide stream access [102.73ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.2550555Z sh test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.2580834Z (pass) Public APIs > sh > should execute shell command [37.74ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.2944904Z options test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.2975178Z (pass) Public APIs > sh > should accept options [39.41ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.3291475Z exec test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.3298859Z (pass) Public APIs > exec > should execute file with args [32.34ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.3584181Z /d/a/command-stream/command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.3590403Z (pass) Public APIs > exec > should handle empty args [29.11ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.3981044Z (pass) Public APIs > run > should run string command [38.99ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.4159858Z (pass) Public APIs > run > should run array command [17.75ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.4510544Z create test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.4536951Z (pass) Public APIs > create > should create custom $ with default options [37.80ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.4956185Z /usr/bin/bash: line 1: nonexistent-command-123456: command not found
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.4978629Z (pass) Error Handling and Edge Cases > should handle command not found [44.17ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.5497298Z $HOME && echo "injection"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.5521601Z (pass) Error Handling and Edge Cases > should handle special characters in interpolation [54.26ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.5851198Z hello world
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.5891813Z (pass) Error Handling and Edge Cases > should handle multiple interpolations [36.99ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.6228107Z one two three
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.6274589Z (pass) Error Handling and Edge Cases > should handle arrays in interpolation [38.23ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.6654472Z (pass) Error Handling and Edge Cases > should handle empty command [37.90ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.7129965Z (pass) Error Handling and Edge Cases > should handle stdin options [47.51ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.7498861Z (pass) ProcessRunner Options > should handle mirror option [36.87ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.7872758Z (pass) ProcessRunner Options > should handle capture option [37.36ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.7873267Z (skip) ProcessRunner Options > should handle cwd option
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.8220422Z test inputpromise test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.8246137Z (pass) Promise Interface > should support then/catch/finally [37.29ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.9024009Z (pass) Promise Interface > should handle catch for errors [77.76ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.9026091Z (pass) Promise Interface > should handle buildShellCommand function [0.25ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.9375959Z buffer test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.9384835Z (pass) Promise Interface > should handle asBuffer function via streaming [35.83ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:03.9729379Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.0252930Z (pass) Coverage for Internal Functions > should test ProcessRunner stdin handling [86.74ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.0729766Z (pass) Coverage for Internal Functions > should test ProcessRunner _pumpStdinTo and _writeToStdin [47.66ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.1080239Z buffer inputpiped inputstream edge case
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.1120741Z (pass) Coverage for Internal Functions > should test ProcessRunner stream method edge cases [39.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.1488502Z test_value
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.1508651Z (pass) Coverage for Internal Functions > should test env and other options [38.81ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.1846406Z finally test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.1895673Z (pass) Coverage for Internal Functions > should test finally method with lazy promise creation [38.61ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.2228719Z catch test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.2279759Z (pass) Coverage for Internal Functions > should test catch method with lazy promise creation [38.40ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.2626683Z tty test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.2676432Z (pass) Coverage for Internal Functions > should test stdin inherit with TTY simulation [39.66ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.3164928Z (pass) Coverage for Internal Functions > should test Uint8Array buffer handling in _writeToStdin [48.78ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.3557781Z (pass) Coverage for Internal Functions > should test direct ProcessRunner instantiation and manual start [39.26ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.4536696Z (pass) Coverage for Internal Functions > should test ProcessRunner with complex stdin scenarios [97.77ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.4875551Z teststring inputbuffer inputignore test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.4917001Z (pass) Coverage for Internal Functions > should test error handling in stdin operations [38.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.5262806Z default stdin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.5307072Z (pass) Coverage for Internal Functions > should test process with default stdin handling [38.97ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.5461026Z edge case
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.5991025Z (pass) Coverage for Internal Functions > should test edge cases to improve coverage [68.35ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.5992268Z (pass) Coverage for Internal Functions > should test asBuffer function with different input types [0.11ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.6352273Z buffer teststdin test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.6874282Z (pass) Coverage for Internal Functions > should test Bun-specific stdin handling paths [88.15ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.7351403Z (pass) Coverage for Internal Functions > should test _writeToStdin with Uint8Array path [47.69ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.8017557Z (pass) Coverage for Internal Functions > should test alternative stdio handling [66.56ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.8374569Z manual testuint8 testexec stdin testhellomock test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.8423008Z (pass) Coverage for Internal Functions > should test process stdin simulation for coverage [40.54ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.8774926Z inherit test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.8827112Z (pass) Coverage for Internal Functions > should test stdin inherit edge cases [40.37ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.9325653Z (pass) Coverage for Internal Functions > should test different buffer scenarios for coverage [49.83ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:04.9668957Z testsafe test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.0321305Z buffer testexec test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.0353861Z (pass) Coverage for Internal Functions > should test extreme edge cases for full coverage [102.81ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.0695689Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.0748896Z (pass) Coverage for Internal Functions > should test internal ProcessRunner methods directly for coverage [39.45ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1092306Z delayed test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1131387Z (pass) Coverage for Internal Functions > should test ProcessRunner with delayed execution [38.24ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1131841Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1132356Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1132530Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1133154Z ##[group]js\tests\array-interpolation.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1163692Z (pass) Array Interpolation > Direct Array Passing (Correct Usage) > should treat each array element as separate argument [0.22ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1165685Z (pass) Array Interpolation > Direct Array Passing (Correct Usage) > should quote elements with spaces individually [0.19ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1167348Z (pass) Array Interpolation > Direct Array Passing (Correct Usage) > should handle empty array [0.15ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1168169Z (pass) Array Interpolation > Direct Array Passing (Correct Usage) > should handle single-element array [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1169505Z (pass) Array Interpolation > Direct Array Passing (Correct Usage) > should handle array with special characters [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1170341Z (pass) Array Interpolation > Direct Array Passing (Correct Usage) > should handle array with flags correctly [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1171704Z (pass) Array Interpolation > Pre-joined Array (Anti-pattern) > joined array becomes single argument with spaces [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1172579Z (pass) Array Interpolation > Pre-joined Array (Anti-pattern) > demonstrates the bug: flags become part of filename [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1174390Z (pass) Array Interpolation > Pre-joined Array (Anti-pattern) > correct usage vs incorrect usage comparison [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1178433Z (pass) Array Interpolation > Mixed Interpolation Patterns > should handle multiple separate interpolations [0.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1179980Z (pass) Array Interpolation > Mixed Interpolation Patterns > should handle array with conditional elements [0.15ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1182284Z (pass) Array Interpolation > Mixed Interpolation Patterns > should handle spread operator pattern [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1183862Z (pass) Array Interpolation > Real-World Use Cases > git command with multiple flags [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1184986Z (pass) Array Interpolation > Real-World Use Cases > npm install with packages [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1186441Z (pass) Array Interpolation > Real-World Use Cases > file operations with paths containing spaces [0.11ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1188032Z (pass) Array Interpolation > Real-World Use Cases > docker command with environment variables [0.13ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1189489Z (pass) Array Interpolation > Real-World Use Cases > rsync with exclude patterns [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1190525Z (pass) Array Interpolation > Edge Cases > array with empty strings [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1191844Z (pass) Array Interpolation > Edge Cases > array with null-ish values coerced to strings [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1192589Z (pass) Array Interpolation > Edge Cases > nested arrays are flattened by the user (not automatic) [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1193179Z (pass) Array Interpolation > Edge Cases > array with numbers [0.15ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1193675Z (pass) Array Interpolation > Edge Cases > array with boolean coercion [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1194202Z (pass) quote() Function Direct Tests > quote function handles arrays correctly [0.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1195066Z (pass) quote() Function Direct Tests > quote function handles nested arrays [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1195701Z (pass) quote() Function Direct Tests > quote function handles mixed safe and unsafe elements [0.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.1613138Z (pass) Functional Tests (Command Execution) > array arguments work correctly with real command [41.95ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.2022237Z (pass) Functional Tests (Command Execution) > pre-joined array creates single argument (demonstrates bug) [40.87ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.2422996Z (pass) Functional Tests (Command Execution) > array with spaces handled correctly [40.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.2997326Z (pass) Functional Tests (Command Execution) > array elements become separate arguments for wc [57.40ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.2999167Z (pass) Documentation Examples Verification > README Common Pitfalls example - incorrect usage [0.23ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3000376Z (pass) Documentation Examples Verification > README Common Pitfalls example - correct usage [0.10ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3001959Z (pass) Documentation Examples Verification > BEST-PRACTICES.md Pattern 1: Direct array passing [0.10ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3002883Z (pass) Documentation Examples Verification > BEST-PRACTICES.md Pattern 2: Separate interpolations [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3004331Z (pass) Documentation Examples Verification > BEST-PRACTICES.md Pattern 3: Build array dynamically [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3005047Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3005608Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3005726Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3005986Z ##[group]js\tests\builtin-commands.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3070239Z Hello World
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3070469Z Line 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3076894Z (pass) Built-in Commands (Bun.$ compatible) > File Reading Commands > cat should read file contents [3.68ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3102951Z input
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3108757Z (pass) Built-in Commands (Bun.$ compatible) > File Reading Commands > cat should read from stdin when no files provided [3.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3121980Z cat: nonexistent.txt: No such file or directory(pass) Built-in Commands (Bun.$ compatible) > File Reading Commands > cat should handle non-existent files [1.33ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3136854Z file1.txt
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3137057Z file2.txt
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3137707Z subdir
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3144891Z (pass) Built-in Commands (Bun.$ compatible) > Directory Listing Commands > ls should list directory contents [2.28ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3154370Z .hidden
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3154611Z visible.txt
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3163728Z (pass) Built-in Commands (Bun.$ compatible) > Directory Listing Commands > ls should support -a flag for hidden files [1.85ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3174093Z -rw-r--r--  1 user group        7 2026-06-10 test.txt
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3179316Z (pass) Built-in Commands (Bun.$ compatible) > Directory Listing Commands > ls should support -l flag for long format [1.52ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3191884Z (pass) Built-in Commands (Bun.$ compatible) > File Creation Commands > mkdir should create directories [1.25ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3204958Z (pass) Built-in Commands (Bun.$ compatible) > File Creation Commands > mkdir -p should create parent directories [1.25ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3217360Z (pass) Built-in Commands (Bun.$ compatible) > File Creation Commands > touch should create new files [1.25ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3427792Z (pass) Built-in Commands (Bun.$ compatible) > File Creation Commands > touch should update existing file timestamps [20.86ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3457584Z (pass) Built-in Commands (Bun.$ compatible) > File Removal Commands > rm should remove files [3.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3468153Z rm: cannot remove 'test-builtin-commands\to-remove-dir': Is a directory(pass) Built-in Commands (Bun.$ compatible) > File Removal Commands > rm should fail on directories without -r [1.01ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3482207Z (pass) Built-in Commands (Bun.$ compatible) > File Removal Commands > rm -r should remove directories recursively [1.41ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3491459Z (pass) Built-in Commands (Bun.$ compatible) > File Removal Commands > rm -f should suppress errors on non-existent files [0.89ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3523184Z (pass) Built-in Commands (Bun.$ compatible) > File Copy/Move Commands > cp should copy files [3.14ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3547695Z (pass) Built-in Commands (Bun.$ compatible) > File Copy/Move Commands > cp -r should copy directories recursively [2.40ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3566753Z (pass) Built-in Commands (Bun.$ compatible) > File Copy/Move Commands > mv should move/rename files [1.92ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3584651Z (pass) Built-in Commands (Bun.$ compatible) > File Copy/Move Commands > mv should move files to directory [1.74ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3589225Z file.txt
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3592785Z (pass) Built-in Commands (Bun.$ compatible) > Path Utility Commands > basename should extract filename [0.81ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3596678Z file
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3600051Z (pass) Built-in Commands (Bun.$ compatible) > Path Utility Commands > basename should remove suffix [0.71ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3604593Z /path/to
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3608211Z (pass) Built-in Commands (Bun.$ compatible) > Path Utility Commands > dirname should extract directory path [0.77ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3612759Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3612968Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3613138Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3616829Z (pass) Built-in Commands (Bun.$ compatible) > Sequence Generation Commands > seq should generate number sequence [0.85ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3620169Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3620497Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3620767Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3624100Z (pass) Built-in Commands (Bun.$ compatible) > Sequence Generation Commands > seq should handle single argument [0.69ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3627617Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3628073Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3628476Z 5
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3632228Z (pass) Built-in Commands (Bun.$ compatible) > Sequence Generation Commands > seq should handle step argument [0.79ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3643655Z hello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3645558Z hello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3663017Z hello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3668757Z (pass) Built-in Commands (Bun.$ compatible) > Streaming Commands > yes should output repeatedly [3.65ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3673060Z y
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3673813Z y
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3678401Z (pass) Built-in Commands (Bun.$ compatible) > Streaming Commands > yes should default to "y" [0.93ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3679524Z (skip) Built-in Commands (Bun.$ compatible) > Command Location (which) > which should find existing system commands
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3687452Z C:\Users\runneradmin\.bun\bin\bun.exe
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3691258Z (pass) Built-in Commands (Bun.$ compatible) > Command Location (which) > which should find node/bun executable [1.26ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3783265Z C:\Program Files\GitHub CLI\gh.exe
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3788650Z (pass) Built-in Commands (Bun.$ compatible) > Command Location (which) > which should find homebrew-installed commands (if available) [9.68ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3860561Z which: no nonexistent-command-12345 in PATH(pass) Built-in Commands (Bun.$ compatible) > Command Location (which) > which should return non-zero for non-existent commands [7.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3865988Z echo: shell builtin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3870178Z (pass) Built-in Commands (Bun.$ compatible) > Command Location (which) > which should find built-in virtual commands [1.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3880896Z which: missing operand(pass) Built-in Commands (Bun.$ compatible) > Command Location (which) > which should handle missing arguments [1.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3892045Z (pass) Built-in Commands (Bun.$ compatible) > Error Handling > commands should return proper exit codes [1.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3902724Z cat: nonexistent.txt: No such file or directory(pass) Built-in Commands (Bun.$ compatible) > Error Handling > commands should provide helpful error messages [1.01ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3914074Z mkdir: missing operandrm: missing operand(pass) Built-in Commands (Bun.$ compatible) > Error Handling > commands should handle missing operands [1.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3915293Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3915804Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3915984Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3916413Z ##[group]js\tests\bun-shell-path-fix.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3956996Z (skip) String interpolation fix for Bun > Template literal without interpolation should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3957745Z (skip) String interpolation fix for Bun > String interpolation with complete command should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3958393Z (skip) String interpolation fix for Bun > String interpolation with command and args should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3959011Z (skip) String interpolation fix for Bun > Mixed template literal with interpolation should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3959633Z (skip) String interpolation fix for Bun > Complex shell commands via interpolation should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3960232Z (skip) String interpolation fix for Bun > Shell operators in interpolated commands should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3960805Z (skip) String interpolation fix for Bun > Commands with special characters should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3961419Z (skip) String interpolation fix for Bun > Multiple argument interpolation should still quote properly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3962034Z (skip) String interpolation fix for Bun > Empty command string should not cause issues
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3963117Z (skip) String interpolation fix for Bun > Command with unsafe characters should be handled correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3964198Z (skip) Bun-specific shell path tests > Bun.spawn compatibility is maintained
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3965082Z (skip) Bun-specific shell path tests > Bun runtime detection works correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3965609Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3966027Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3966201Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3966590Z ##[group]js\tests\bun.features.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3985634Z (pass) Bun.$ Feature Validation > Runtime Support > should only work in Bun runtime [0.55ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3986607Z (pass) Bun.$ Feature Validation > Runtime Support > should be Bun-specific (conceptual test) [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.3997444Z bun template literal test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4006315Z (pass) Bun.$ Feature Validation > Template Literals > should support $`cmd` syntax [2.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4010981Z bun interpolation test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4012052Z (pass) Bun.$ Feature Validation > Template Literals > should support variable interpolation [0.56ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4016832Z bun buffered test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4017477Z (pass) Bun.$ Feature Validation > Real-time Streaming > should NOT provide live streaming (buffers only) [0.54ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4021431Z no async iteration
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4022357Z (pass) Bun.$ Feature Validation > Async Iteration > should NOT support for await iteration [0.45ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4026256Z no events
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4027759Z (pass) Bun.$ Feature Validation > EventEmitter Pattern > should NOT support .on() events [0.52ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4031963Z await only
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4033218Z (pass) Bun.$ Feature Validation > Mixed Patterns > should NOT support events + await (only await) [0.52ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4037180Z '; rm -rf /; echo 'hacked
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4038184Z (pass) Bun.$ Feature Validation > Shell Injection Protection > should have built-in injection protection [0.47ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4042351Z cross-platform
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4043076Z (pass) Bun.$ Feature Validation > Cross-platform Support > should work cross-platform [0.50ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4047462Z performance test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4048267Z (pass) Bun.$ Feature Validation > Performance > should be very fast (built-in to Bun) [0.49ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4053153Z memory buffering
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4054124Z (pass) Bun.$ Feature Validation > Memory Efficiency > should buffer in memory (not streaming) [0.56ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4060406Z (pass) Bun.$ Feature Validation > Error Handling > should throw exception on error by default [0.61ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4065627Z (pass) Bun.$ Feature Validation > Error Handling > should support nothrow option [0.45ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4072063Z (pass) Bun.$ Feature Validation > Stdin Support > should support pipe operations [0.62ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4076122Z stdin input test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4077561Z (pass) Bun.$ Feature Validation > Stdin Support > should support input through echo/pipe (conceptual) [0.55ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4081754Z built-in echo
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4082718Z (pass) Bun.$ Feature Validation > Built-in Commands > should have built-in echo command [0.51ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4086717Z D:\a\command-stream\command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4088078Z (pass) Bun.$ Feature Validation > Built-in Commands > should have built-in cd and other commands [0.51ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4089174Z (pass) Bun.$ Feature Validation > Bundle Size > should have 0KB bundle size (built into Bun) [0.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4090455Z (pass) Bun.$ Feature Validation > TypeScript Support > should have built-in TypeScript support [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4090860Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4091391Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4091549Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4091925Z ##[group]js\tests\cd-virtual-command.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4307816Z (skip) cd Virtual Command - Core Behavior > should change to absolute path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4308700Z (skip) cd Virtual Command - Core Behavior > should change to relative path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4309667Z (skip) cd Virtual Command - Core Behavior > should handle cd with no arguments (go to home)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4310406Z (skip) cd Virtual Command - Core Behavior > should handle cd - (return to previous directory)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4311089Z (skip) cd Virtual Command - Core Behavior > should handle cd .. (parent directory)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4311708Z (skip) cd Virtual Command - Core Behavior > should handle cd . (current directory)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4312332Z (skip) cd Virtual Command - Core Behavior > should fail with non-existent directory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4313291Z (skip) cd Virtual Command - Core Behavior > should handle paths with spaces
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4313913Z (skip) cd Virtual Command - Core Behavior > should handle special characters in paths
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4314633Z (skip) cd Virtual Command - Command Chains > should persist directory change within command chain
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4315678Z (skip) cd Virtual Command - Command Chains > should handle multiple cd commands in chain
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4316347Z (skip) cd Virtual Command - Command Chains > should work with git commands in chain
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4317135Z (skip) cd Virtual Command - Command Chains > should maintain separate directory context per command when not chained
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4317983Z (skip) cd Virtual Command - Subshell Behavior > should not affect parent shell when in subshell
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4318725Z (skip) cd Virtual Command - Subshell Behavior > should work in subshell with other commands
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4319726Z (skip) cd Virtual Command - Edge Cases > should handle symlinks
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4320674Z (skip) cd Virtual Command - Edge Cases > should handle very long paths
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4321494Z (skip) cd Virtual Command - Edge Cases > should handle permission errors gracefully
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4322046Z (skip) cd Virtual Command - Edge Cases > should handle cd with trailing slash
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4322571Z (skip) cd Virtual Command - Edge Cases > should handle cd with multiple slashes
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4323173Z (skip) cd Virtual Command - Platform Compatibility > should handle platform-specific path separators
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4323817Z (skip) cd Virtual Command - Platform Compatibility > should normalize paths correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4324148Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4324501Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4324623Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4325185Z ##[group]js\tests\check-release-needed.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4329092Z (pass) self-heals: no changesets + version not on npm → should_release=true, skip_bump=true, current_unpublished=true [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4330272Z (pass) no release: no changesets + version already on npm → should_release=false, current_unpublished=false [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4331815Z (pass) changesets present + version already on npm → should_release=true, skip_bump=false, current_unpublished=false [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4334122Z (pass) #166 restart case: changesets present locally but current version not on npm → current_unpublished=true [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4334967Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4335357Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4335542Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4335966Z ##[group]js\tests\cleanup-verification.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4681568Z (pass) Cleanup Verification > should start in original directory [32.60ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.4845399Z C:\Users\RUNNER~1\AppData\Local\Temp\cleanup-test-vOfmAm
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.5003212Z (pass) Cleanup Verification > should restore cwd after simple cd command [32.14ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.5140336Z (pass) Cleanup Verification > should be back in original directory after cd test [13.66ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.5305353Z (pass) Cleanup Verification > should restore cwd after cd with && operator [16.48ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.5628783Z (pass) Cleanup Verification > should verify restoration after && cd test [32.32ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.5629556Z (skip) Cleanup Verification > should not affect cwd when cd is in subshell
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.5940770Z (pass) Cleanup Verification > should restore cwd after multiple cd commands [31.17ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6109785Z D:\a\command-stream\command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6266466Z (pass) Cleanup Verification > final verification - should still be in original directory [32.53ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6267462Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6267852Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6267992Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6268301Z ##[group]js\tests\ctrl-c-baseline.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6287856Z (skip) CTRL+C Baseline Tests (Native Spawn) > should handle SIGINT with simple shell command
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6288995Z (skip) CTRL+C Baseline Tests (Native Spawn) > should handle Node.js inline script with SIGINT
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6290184Z (skip) CTRL+C Baseline Tests (Native Spawn) > should handle Node.js script file
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6290577Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6290894Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6291360Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6291655Z ##[group]js\tests\ctrl-c-basic.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6311700Z (skip) CTRL+C Basic Handling > should be able to kill a long-running process
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6312723Z (skip) CTRL+C Basic Handling > should spawn processes with detached flag on Unix
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6313650Z (skip) CTRL+C Basic Handling > should handle CTRL+C character in raw mode
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6314557Z (skip) CTRL+C Virtual Commands > should cancel virtual command with AbortController
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6315522Z (skip) CTRL+C Virtual Commands > should cancel virtual async generator
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6316354Z (skip) CTRL+C Different stdin Modes > should handle CTRL+C with string stdin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6317222Z (skip) CTRL+C Different stdin Modes > should handle CTRL+C with Buffer stdin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6318401Z (skip) CTRL+C Different stdin Modes > should handle CTRL+C with ignore stdin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6319265Z (skip) CTRL+C Pipeline Interruption > should interrupt simple pipeline
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6319806Z (skip) CTRL+C Process Groups > should handle process group termination on Unix
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6320132Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6320423Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6320537Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6320797Z ##[group]js\tests\ctrl-c-library.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6336873Z (skip) CTRL+C Library Tests (command-stream) > should handle command cancellation with kill()
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6338121Z (skip) CTRL+C Library Tests (command-stream) > should test our library via external script - SKIP: uses test-sleep.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6338836Z (skip) CTRL+C Library Tests (command-stream) > should handle virtual command cancellation
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6339191Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6339454Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6339572Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6339824Z ##[group]js\tests\ctrl-c-signal.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6372725Z (skip) CTRL+C Signal Handling > BASELINE: should handle SIGINT with plain shell command
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6373859Z (skip) CTRL+C Signal Handling > should forward SIGINT to child process when external CTRL+C is sent
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6374790Z (skip) CTRL+C Signal Handling > should not interfere with user SIGINT handling when no children active
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6375429Z (skip) CTRL+C Signal Handling > should handle SIGINT in long-running commands via API
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6376032Z (skip) CTRL+C Signal Handling > should handle multiple concurrent processes receiving signals
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6376637Z (skip) CTRL+C Signal Handling > should properly handle signals in external process with sleep
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6377209Z (skip) CTRL+C Signal Handling > should not interfere with child process signal handlers
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6377797Z (skip) CTRL+C with Different stdin Modes > should handle kill regardless of stdin mode
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6378892Z (skip) CTRL+C with Different stdin Modes > should properly clean up stdin forwarding on external SIGINT
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6379703Z (skip) CTRL+C with Different stdin Modes > should handle parent stream closure triggering process cleanup
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6380450Z (skip) CTRL+C with Different stdin Modes > should bypass virtual commands with custom stdin for proper signal handling
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6381121Z (skip) CTRL+C with Different stdin Modes > should handle Bun vs Node.js signal differences
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6381850Z (skip) CTRL+C with Different stdin Modes > should properly cancel virtual commands and respect user SIGINT handlers (regression test)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6382357Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6382629Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6382736Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6383007Z ##[group]js\tests\cwd-cd-pattern-issue.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6393290Z (skip) Issue #50: CWD with CD pattern failure > should handle separate cd and pwd commands correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6394311Z (skip) Issue #50: CWD with CD pattern failure > should handle cd && pwd pattern correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6395271Z (skip) Issue #50: CWD with CD pattern failure > should handle git scenario from issue description
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6396250Z (skip) Issue #50: CWD with CD pattern failure > should maintain directory changes across multiple shell operations
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6396922Z (skip) Issue #50: CWD with CD pattern failure > should handle complex build scenario with cd pattern
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6397496Z (skip) Issue #50: CWD with CD pattern failure > should work with relative paths after cd
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6398070Z (skip) Issue #50: CWD with CD pattern failure > should handle cwd option vs cd command consistency
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6399201Z (skip) Issue #50: CWD with CD pattern failure > should handle error cases correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6399895Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd with no argument goes to $HOME (like sh)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6400815Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd ~ expands tilde to $HOME (like sh)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6401538Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd ~/subpath expands tilde prefix (like sh)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6402309Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd - switches to previous directory and prints it (like sh)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6403121Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd updates PWD and OLDPWD environment variables (like sh)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6403955Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd to a non-existent directory reports a sh-style error and keeps cwd
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6404737Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > relative cd resolves against the cwd option
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6405297Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6406236Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6406389Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6407173Z ##[group]js\tests\examples.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6669606Z (skip) Examples Execution Tests > readme-example.mjs should execute and demonstrate new API signature
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6670576Z (skip) Examples Execution Tests > simple-jq-streaming.mjs should complete successfully
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:05.6671853Z (pass) Examples Execution Tests > should have examples available for manual testing [0.21ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.1862686Z (pass) Examples Execution Tests > external process can be interrupted with SIGINT [519.00ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.3894619Z (pass) Examples Execution Tests > $.mjs should properly handle process interruption [203.15ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.3895989Z (skip) Examples Execution Tests > should not interfere with user SIGINT handling when no children active
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5927642Z (pass) Examples Execution Tests > virtual commands should be properly cancelled by SIGINT (regression test) [203.25ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5928173Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5928518Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5928631Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5928927Z ##[group]js\tests\execa.features.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5957311Z (pass) execa Feature Validation (Conceptual) > Runtime Support > should work in Node.js runtime [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5958615Z (pass) execa Feature Validation (Conceptual) > Runtime Support > should NOT work natively in Bun without compatibility [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5959790Z (pass) execa Feature Validation (Conceptual) > Template Literals > should support $`cmd` syntax with execa [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5961011Z (pass) execa Feature Validation (Conceptual) > Template Literals > should support variable interpolation [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5962248Z (pass) execa Feature Validation (Conceptual) > Real-time Streaming > should have LIMITED streaming capabilities [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5963540Z (pass) execa Feature Validation (Conceptual) > Real-time Streaming > should buffer output by default [0.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5964781Z (pass) execa Feature Validation (Conceptual) > Async Iteration > should NOT support for await iteration on result [0.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5966156Z (pass) execa Feature Validation (Conceptual) > EventEmitter Pattern > should have LIMITED event support on subprocess [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5968178Z (pass) execa Feature Validation (Conceptual) > Mixed Patterns > should NOT support events + await on same object [0.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5968940Z (pass) execa Feature Validation (Conceptual) > Shell Injection Protection > should be safe by default [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5970100Z (pass) execa Feature Validation (Conceptual) > Cross-platform Support > should work cross-platform [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5971613Z (pass) execa Feature Validation (Conceptual) > Performance > should have moderate performance [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5972325Z (pass) execa Feature Validation (Conceptual) > Memory Efficiency > should buffer in memory by default [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5973014Z (pass) execa Feature Validation (Conceptual) > Error Handling > should reject promise on error [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5973930Z (pass) execa Feature Validation (Conceptual) > Stdin Support > should support input/output streams [0.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5974658Z (pass) execa Feature Validation (Conceptual) > Built-in Commands > should NOT have built-in commands [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5975333Z (pass) execa Feature Validation (Conceptual) > Bundle Size > should have ~25KB bundle size [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5976005Z (pass) execa Feature Validation (Conceptual) > TypeScript Support > should have full TypeScript support [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5976712Z (pass) execa Feature Validation (Conceptual) > Advanced Features > should support timeout settings [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5978265Z (pass) execa Feature Validation (Conceptual) > Advanced Features > should support detailed error information [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5979060Z (pass) execa Feature Validation (Conceptual) > Advanced Features > should support verbose and debugging modes [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5979490Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5979811Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5979921Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5980188Z ##[group]js\tests\getcwd-error-handling.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.5993775Z test subshell
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6001031Z (pass) getcwd() error handling > subshell completes when process.cwd() always fails [1.67ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6005192Z still works
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6007487Z (pass) getcwd() error handling > subshell completes when process.cwd() fails only inside _runSubshell [0.62ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6011280Z first
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6013746Z second
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6016127Z third
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6018313Z (pass) getcwd() error handling > multiple commands keep working after getcwd() failures [1.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6019180Z (skip) getcwd() error handling > subshell runs even when the real working directory was deleted
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6019540Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6019832Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6019936Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6020193Z ##[group]js\tests\gh-commands.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6045063Z (skip) GitHub CLI (gh) commands > gh auth status returns correct exit code and output structure
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6045843Z (skip) GitHub CLI (gh) commands > gh command with invalid subcommand returns non-zero exit code
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6046417Z (skip) GitHub CLI (gh) commands > gh api can be called with parameters
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6046856Z (skip) GitHub CLI (gh) commands > gh gist list works with parameters
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6047294Z (skip) GitHub CLI (gh) commands > complex gh command with pipes and jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6047561Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6047834Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6047943Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6048198Z ##[group]js\tests\gh-gist-operations.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6067061Z Skipping gist write tests in CI environment
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6232836Z Skipped: CI environment or not authenticated
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6388920Z (pass) GitHub Gist Operations with $.mjs > gh gist create should work with $.mjs and not hang [31.99ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6563578Z Skipped: CI environment or no test gist available
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6705193Z (pass) GitHub Gist Operations with $.mjs > gh gist view should retrieve gist details [31.63ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.6880391Z Skipped: CI environment or no test gist available
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7024118Z (pass) GitHub Gist Operations with $.mjs > gh api should work for gist operations [31.77ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7025123Z (skip) GitHub Gist Operations with $.mjs > gh gist edit should add files to existing gist
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7197880Z Skipped: CI environment or no test gist available
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7221685Z (pass) GitHub Gist Operations with $.mjs > gh gist delete should remove gist [19.83ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7340885Z Skipped: CI environment or not authenticated
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7496145Z (pass) GitHub Gist Operations with $.mjs > complex gh command with pipes should work [27.40ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7497837Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7498446Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7499069Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7499413Z ##[group]js\tests\git-gh-cd.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7547997Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should initialize git repo after cd to temp directory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7549006Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should handle git commands in temp directory with cd chain
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7549921Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should create and commit files in temp git repo
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7550782Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should handle git branch operations with cd
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7551641Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should handle multiple temp directories with cd
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7552502Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should handle git diff operations after cd
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7554312Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should work with git in subshells
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7555145Z (skip) Git and GH commands with cd virtual command > GH CLI operations with cd > should check gh auth status
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7555883Z (skip) Git and GH commands with cd virtual command > GH CLI operations with cd > should handle gh api calls with cd to temp directory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7556666Z (skip) Git and GH commands with cd virtual command > GH CLI operations with cd > should simulate gh repo clone pattern
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7557429Z (skip) Git and GH commands with cd virtual command > GH CLI operations with cd > should handle gh commands with directory context
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7558237Z (skip) Git and GH commands with cd virtual command > Combined git and gh workflows > should simulate solve.mjs workflow pattern
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7559057Z (skip) Git and GH commands with cd virtual command > Combined git and gh workflows > should handle error scenarios with cd and git
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7559851Z (skip) Git and GH commands with cd virtual command > Combined git and gh workflows > should preserve cwd after command chains
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7561491Z (skip) Git and GH commands with cd virtual command > Combined git and gh workflows > should work with complex git workflows using operators
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7562559Z (skip) Git and GH commands with cd virtual command > Path resolution and quoting with cd > should handle paths with spaces in git operations
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7563444Z (skip) Git and GH commands with cd virtual command > Path resolution and quoting with cd > should handle special characters in paths
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7563922Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7564226Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7564333Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7564601Z ##[group]js\tests\interactive-option.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7806805Z (pass) Interactive Option Tests > interactive option - default behavior [24.00ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7875424Z (pass) Interactive Option Tests > interactive option - explicit true [6.86ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.7986423Z (pass) Interactive Option Tests > interactive option - explicit false [11.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.8283386Z (pass) Interactive Option Tests > interactive option - passed through options merge [29.60ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.8599670Z (pass) Interactive Option Tests > interactive option - does not affect command execution with pipes/capture [31.56ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.8914032Z (pass) Interactive Option Tests > interactive option - behavior with stdin inherit but no TTY [31.48ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.9073874Z (pass) Interactive Option Tests > interactive option - works with template literal syntax [15.92ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.9231432Z (pass) Interactive Option Tests > interactive option - preserved in command chaining [15.69ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.9432235Z (pass) Interactive Option Tests > interactive option - type checking [20.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.9432742Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.9433171Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.9433316Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:06.9433660Z ##[group]js\tests\interactive-streaming.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.0804255Z READY
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.0870235Z RESULT: 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.0994417Z RESULT: 50
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.1153776Z RESULT: 25
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.1296820Z RESULT: 4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.1481587Z RESULT: 256
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.1615866Z GOODBYE
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.1738024Z (pass) Interactive Streaming > should support bidirectional streaming I/O while process is running [227.64ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.2718197Z READY
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.2900313Z ERROR: Invalid expression: invalid expression
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.3064715Z RESULT: 10
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.3201206Z GOODBYE
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.3338373Z (pass) Interactive Streaming > should handle errors in expressions [160.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.4307627Z READY
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.4308012Z GOODBYE
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.4405746Z (pass) Interactive Streaming > should auto-start process when accessing streams [106.72ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.5397556Z READY
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.5397964Z GOODBYE
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.5501784Z (pass) Interactive Streaming > should return null for streams after process completes [109.58ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6474164Z READY
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6485874Z RESULT: 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6490414Z RESULT: 4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6491674Z RESULT: 6
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6493272Z RESULT: 8
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6495116Z RESULT: 10
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6713780Z GOODBYE
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6804815Z (pass) Interactive Streaming > should handle multiple simultaneous calculations [130.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6805798Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6806349Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6806546Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6807216Z ##[group]js\tests\issue-135-final.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6880641Z (pass) Issue #135: CI environment no longer auto-enables trace logs > should NOT emit trace logs when CI=true (main fix) [0.91ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6886190Z (pass) Issue #135: CI environment no longer auto-enables trace logs > should allow JSON parsing in CI environment [0.56ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6889513Z (pass) Issue #135: CI environment no longer auto-enables trace logs > should NOT produce trace logs by default (no env vars) [0.29ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6893447Z (pass) Issue #135: CI environment no longer auto-enables trace logs > should work with mirror:false in CI environment [0.41ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6894511Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6895014Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6895195Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.6895601Z ##[group]js\tests\jq-color-behavior.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.8849563Z {
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.8850354Z   "message": "hello",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.8850702Z   "number": 42,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.8851003Z   "active": true,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.8851309Z   "data": null
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.8851571Z }
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.8951682Z (pass) jq behavior - default mirror mode shows output automatically [202.87ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.9776174Z ^[[1;39m{^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.9776624Z   ^[[1;34m"message"^[[0m^[[1;39m:^[[0m ^[[0;32m"hello"^[[0m^[[1;39m,^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.9777413Z   ^[[1;34m"number"^[[0m^[[1;39m:^[[0m ^[[0;39m42^[[0m^[[1;39m,^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.9777827Z   ^[[1;34m"active"^[[0m^[[1;39m:^[[0m ^[[0;39mtrue^[[0m^[[1;39m,^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.9778197Z   ^[[1;34m"data"^[[0m^[[1;39m:^[[0m ^[[0;90mnull^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.9778470Z ^[[1;39m}^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:07.9839487Z (pass) jq behavior - explicit color output contains ANSI codes [88.74ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.0641667Z {
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.0641920Z   "message": "hello",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.0642148Z   "number": 42,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.0642344Z   "active": true,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.0642528Z   "data": null
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.0642693Z }
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.0701966Z (pass) jq behavior - monochrome output has no ANSI codes [86.24ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.1505932Z hello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.1570903Z (pass) jq behavior - field extraction works correctly [86.75ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.2385550Z "Alice"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.2445939Z (pass) jq behavior - complex JSON processing [87.58ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.3274191Z "hello"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.4209709Z (pass) jq behavior - mirror mode vs capture mode [176.32ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.5015935Z {
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.5016191Z   "message": "hello",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.5016419Z   "number": 42,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.5016618Z   "active": true,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.5016804Z   "data": null
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.5016974Z }
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.5074103Z (pass) jq behavior - TTY detection and automatic coloring [86.42ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6073434Z ^[[1;39m{^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6073957Z   ^[[1;34m"message"^[[0m^[[1;39m:^[[0m ^[[0;32m"hello"^[[0m^[[1;39m,^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6074429Z   ^[[1;34m"number"^[[0m^[[1;39m:^[[0m ^[[0;39m42^[[0m^[[1;39m,^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6074841Z   ^[[1;34m"active"^[[0m^[[1;39m:^[[0m ^[[0;39mtrue^[[0m^[[1;39m,^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6075200Z   ^[[1;34m"data"^[[0m^[[1;39m:^[[0m ^[[0;90mnull^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6075507Z ^[[1;39m}^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6941524Z {
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6941998Z   "message": "hello",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6942513Z   "number": 42,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6942989Z   "active": true,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6943422Z   "data": null
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6943842Z }
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.6999102Z (pass) jq behavior - force colors work in any environment [192.46ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7863591Z ^[[1;39m{^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7864460Z   ^[[1;34m"message"^[[0m^[[1;39m:^[[0m ^[[0;32m"hello"^[[0m^[[1;39m,^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7865361Z   ^[[1;34m"number"^[[0m^[[1;39m:^[[0m ^[[0;39m42^[[0m^[[1;39m,^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7866207Z   ^[[1;34m"active"^[[0m^[[1;39m:^[[0m ^[[0;39mtrue^[[0m^[[1;39m,^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7867016Z   ^[[1;34m"data"^[[0m^[[1;39m:^[[0m ^[[0;90mnull^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7867612Z ^[[1;39m}^[[0m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7868184Z (pass) jq behavior - streaming with colors works [86.57ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7868622Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7869193Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7869451Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7881454Z ##[group]js\tests\jq.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7897671Z (skip) jq streaming tests > stream of JSON objects through jq -c
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7898672Z (skip) jq streaming tests > stream JSON objects with filtering through jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7899206Z (skip) jq streaming tests > generate JSON stream using echo in loop
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7899623Z (skip) jq streaming tests > transform JSON stream with jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7900041Z (skip) jq streaming tests > generate and process array elements as stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7900518Z (skip) jq streaming tests > combine multiple JSON sources into stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7901072Z (skip) jq streaming with pipe | syntax > stream of JSON objects through jq -c using pipe syntax
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7901657Z (skip) jq streaming with pipe | syntax > stream JSON with filtering using pipe syntax
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7902193Z (skip) jq streaming with pipe | syntax > transform JSON stream with jq using pipe syntax
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7903069Z (skip) jq streaming with pipe | syntax > process array elements as stream using pipe syntax
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7904269Z (skip) jq streaming with pipe | syntax > multi-pipe JSON processing
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7904775Z (skip) jq streaming with pipe | syntax > complex JSON stream manipulation with pipes
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7905334Z (skip) realtime JSON streaming with delays > stream JSON with random delays between outputs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7905931Z (skip) realtime JSON streaming with delays > stream JSON with fixed delays using printf and sleep
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7906528Z (skip) realtime JSON streaming with delays > simulate server logs with delayed JSON output
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7907141Z (skip) realtime JSON streaming with delays > process streaming metrics with delays and aggregation
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7907699Z (skip) realtime JSON streaming with delays > handle burst then delay pattern
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7908367Z (skip) realtime JSON streaming with delays > stream with varying delay intervals
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7908916Z (skip) realtime JSON streaming with delays > verify immediate streaming output from jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7909247Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7909546Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7909911Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7910613Z ##[group]js\tests\options-examples.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7921160Z (pass) Options Examples (Feature Demo) > example: disable capture for performance [0.51ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7923906Z (pass) Options Examples (Feature Demo) > example: disable mirroring for silent execution [0.25ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.7926503Z (pass) Options Examples (Feature Demo) > example: both disabled for maximum performance [0.24ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8412555Z (pass) Options Examples (Feature Demo) > example: custom stdin with options [48.49ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8418441Z (pass) Options Examples (Feature Demo) > example: using .run() alias [0.61ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8421118Z (pass) Options Examples (Feature Demo) > example: comparison with sh() function [0.28ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8422779Z (skip) Options Examples (Feature Demo) > example: real shell command vs virtual command
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8424942Z (pass) Options Examples (Feature Demo) > example: chaining still works [0.35ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8425502Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8425951Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8426077Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8426348Z ##[group]js\tests\options-syntax.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8885624Z test input
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8941576Z (pass) $({ options }) syntax > should support $({ options }) syntax for custom options [48.48ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.8946073Z (pass) $({ options }) syntax > should support capture and mirror options [0.41ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9436175Z (pass) $({ options }) syntax > should support multiple options at once [48.98ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9925700Z custom_value
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9970907Z (pass) $({ options }) syntax > should work with environment variables [53.48ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9973617Z /tmp
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9974483Z (pass) $({ options }) syntax > should work with custom working directory [0.36ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9978950Z (pass) $({ options }) syntax > should be reusable for multiple commands [0.38ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9980811Z regular
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9982248Z regular again
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9982708Z (pass) $({ options }) syntax > should work alongside regular $ usage [0.43ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9984496Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9985321Z (pass) $({ options }) syntax > should handle stdin as ignore [0.22ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9986983Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9988407Z (pass) $({ options }) syntax > should handle stdin as inherit (default) [0.29ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:08.9991528Z (pass) $({ options }) syntax > should work with interpolation [0.28ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0528886Z (pass) $({ options }) syntax > should work with command chaining [53.62ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0537411Z (pass) $({ options }) syntax > should handle errors with custom options [0.88ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0537910Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0538885Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0539095Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0539825Z ##[group]js\tests\path-interpolation.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0568398Z (pass) path interpolation - basic unquoted path [0.11ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0569006Z (pass) path interpolation - path with spaces gets quoted [0.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0570363Z (pass) path interpolation - path already wrapped in double quotes [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0571009Z (pass) path interpolation - path already wrapped in single quotes [0.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0573388Z (pass) path interpolation - environment variable inheritance works [0.18ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0575228Z (pass) path interpolation - complex path scenarios [0.18ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0576490Z (pass) path interpolation - stdin option with path works [0.11ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0577407Z (pass) path interpolation - command building works correctly [0.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0579249Z (pass) path interpolation - fixed escaping for simple pre-quoted paths [0.13ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0580873Z (pass) path interpolation - environment variable scenario from GitHub issue [0.16ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0581561Z (pass) path interpolation - improved handling of pre-quoted paths [0.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0583766Z (pass) path interpolation - handles complex quoting edge cases [0.18ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0584347Z (pass) shell injection - command substitution attempt [0.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0585462Z (pass) shell injection - backtick command substitution [0.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0586436Z (pass) shell injection - semicolon command chaining [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0587367Z (pass) shell injection - pipe attempt [0.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0588375Z (pass) shell injection - AND operator attempt [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0589498Z (pass) shell injection - OR operator attempt [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0590080Z (pass) shell injection - background process attempt [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0591189Z (pass) shell injection - variable expansion attempt [0.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0592128Z (pass) shell injection - glob expansion attempt [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0593158Z (pass) shell injection - redirect attempt [0.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0594399Z (pass) shell injection - newline injection [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0595536Z (pass) shell injection - complex injection attempt [0.11ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0597453Z (pass) safe strings - no unnecessary quoting [0.18ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0598516Z (pass) double-quoting prevention - user quotes with spaces [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0599647Z (pass) double-quoting prevention - user quotes with special chars [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0600810Z (pass) double-quoting prevention - user unnecessarily quotes safe strings [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0602741Z (pass) double-quoting prevention - mixed scenarios [0.17ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0607188Z (pass) strings requiring quotes - proper quoting applied [0.40ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0607887Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0608166Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0608303Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0608564Z ##[group]js\tests\pipe.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0651622Z Hello World
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0653362Z Piped: Hello World
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0658126Z (pass) Programmatic .pipe() Method > Basic Piping > should pipe between built-in commands [1.62ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0661650Z hello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0663243Z hellohello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0664728Z 10
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0668018Z (pass) Programmatic .pipe() Method > Basic Piping > should pipe virtual commands [0.99ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0671601Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0673799Z [PIPED] test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0677092Z (pass) Programmatic .pipe() Method > Basic Piping > should handle stdin properly in pipe chain [0.87ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0685049Z cat: nonexistent-file.txt: No such file or directory(pass) Programmatic .pipe() Method > Error Handling > should propagate errors from source command [0.75ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0687902Z hello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0693124Z Virtual command failed(pass) Programmatic .pipe() Method > Error Handling > should handle errors in destination command [0.77ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0696530Z hello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0702934Z Something went wrong(pass) Programmatic .pipe() Method > Error Handling > should handle exceptions in virtual commands [0.98ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0706784Z hello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0708083Z HELLO
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0709297Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0710698Z OLLEH[OLLEH]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0714730Z (pass) Programmatic .pipe() Method > Complex Pipelines > should support multiple pipe operations [1.16ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0718955Z data
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0720576Z data
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0722200Z Warning from cmd1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0722660Z Warning from cmd2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0723090Z data
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0727175Z (pass) Programmatic .pipe() Method > Complex Pipelines > should preserve stderr from all commands [1.15ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0735863Z Line 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0736072Z Line 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0736244Z Line 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0737699Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0742510Z (pass) Programmatic .pipe() Method > Mixed Command Types > should pipe from built-in to virtual command [1.57ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0749534Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0749716Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0749863Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0750009Z 4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0750160Z 5
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0752143Z Got 5 lines
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0756409Z (pass) Programmatic .pipe() Method > Mixed Command Types > should pipe from virtual to built-in command [1.38ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0760878Z Line 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0761181Z Line 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0761386Z Line 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0761651Z Line 4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0761894Z Line 5
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0762199Z Line 6
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0762484Z Line 7
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0762811Z Line 8
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0763110Z Line 9
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0763389Z Line 10
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0763914Z Line 11
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0764328Z Line 12
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0764611Z Line 13
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0764922Z Line 14
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0765201Z Line 15
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0765493Z Line 16
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0765792Z Line 17
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0766063Z Line 18
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0766327Z Line 19
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0766587Z Line 20
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0766867Z Line 21
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0767140Z Line 22
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0767420Z Line 23
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0767700Z Line 24
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0767985Z Line 25
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0768273Z Line 26
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0768562Z Line 27
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0768839Z Line 28
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0769114Z Line 29
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0769397Z Line 30
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0769668Z Line 31
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0769959Z Line 32
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0770228Z Line 33
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0770499Z Line 34
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0770761Z Line 35
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0771032Z Line 36
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0771295Z Line 37
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0771565Z Line 38
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0771826Z Line 39
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0772100Z Line 40
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0772392Z Line 41
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0772667Z Line 42
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0772946Z Line 43
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0773218Z Line 44
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0773815Z Line 45
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0774113Z Line 46
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0774391Z Line 47
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0774664Z Line 48
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0774952Z Line 49
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0775221Z Line 50
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0775490Z Line 51
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0775769Z Line 52
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0776053Z Line 53
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0776304Z Line 54
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0776547Z Line 55
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0776782Z Line 56
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0777057Z Line 57
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0777345Z Line 58
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0777629Z Line 59
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0777909Z Line 60
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0778185Z Line 61
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0778459Z Line 62
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0778757Z Line 63
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0779028Z Line 64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0779291Z Line 65
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0779549Z Line 66
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0779843Z Line 67
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0780127Z Line 68
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0780404Z Line 69
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0781037Z Line 70
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0781305Z Line 71
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0781566Z Line 72
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0781848Z Line 73
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0782122Z Line 74
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0782404Z Line 75
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0782650Z Line 76
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0782894Z Line 77
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0783164Z Line 78
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0783430Z Line 79
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0783685Z Line 80
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0783957Z Line 81
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0784217Z Line 82
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0784443Z Line 83
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0784676Z Line 84
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0784919Z Line 85
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0785178Z Line 86
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0785432Z Line 87
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0785675Z Line 88
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0785907Z Line 89
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0786160Z Line 90
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0786413Z Line 91
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0786648Z Line 92
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0786884Z Line 93
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0787141Z Line 94
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0787668Z Line 95
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0787938Z Line 96
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0788203Z Line 97
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0788456Z Line 98
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0788707Z Line 99
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0788958Z Line 100
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0789210Z 100
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0790358Z (pass) Programmatic .pipe() Method > Performance and Memory > should handle large data efficiently [1.15ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0792376Z (pass) Programmatic .pipe() Method > Compatibility with Shell Piping > should work alongside shell pipe syntax [1.46ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0793649Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0794130Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0794317Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0794757Z ##[group]js\tests\publish-to-npm.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0795198Z hello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0795492Z hello processed
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0795723Z Formatted: hello processed
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0811189Z (pass) does NOT report published when changeset:publish fails (exit 1) [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0812599Z (pass) does NOT report published when changeset:publish exits 0 but nothing reaches npm [0.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0813678Z (pass) reports published for a version already on npm (legit success path) [0.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0814231Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0814666Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0814841Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0815249Z ##[group]js\tests\quiet-method.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0837773Z (pass) .quiet() method > should suppress console output when .quiet() is called [0.63ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0840980Z (pass) .quiet() method > should work with chaining after .quiet() [0.31ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0844370Z (pass) .quiet() method > should allow normal output without .quiet() [0.35ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.0845568Z (pass) .quiet() method > should return ProcessRunner instance for chaining [0.10ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2034301Z (pass) .quiet() method > should work with stderr output [118.81ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2038290Z (pass) .quiet() method > should work similar to zx quiet() behavior [0.42ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2039000Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2039889Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2040116Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2040933Z ##[group]js\tests\raw-function.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2066933Z (pass) raw() function - Disable auto-escape > basic functionality > should create raw object with string [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2068031Z (pass) raw() function - Disable auto-escape > basic functionality > should convert numbers to string [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2069033Z (pass) raw() function - Disable auto-escape > basic functionality > should convert boolean to string [0.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2070293Z (pass) raw() function - Disable auto-escape > basic functionality > should handle empty string [0.05ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2425309Z hello world
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2451133Z (pass) raw() function - Disable auto-escape > command execution with raw() > should execute simple raw command [38.18ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.2807996Z step1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.3173222Z step2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.3225703Z (pass) raw() function - Disable auto-escape > command execution with raw() > should execute command with && operator [77.39ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.3951312Z fallback
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.4004482Z (pass) raw() function - Disable auto-escape > command execution with raw() > should execute command with || operator [77.85ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.4350225Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.4355577Z (pass) raw() function - Disable auto-escape > command execution with raw() > should execute command with pipe [35.13ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.4688189Z first
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.5073578Z second
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.5126766Z (pass) raw() function - Disable auto-escape > command execution with raw() > should execute command with semicolon [77.01ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.5591515Z outer: inner
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.5629517Z (pass) raw() function - Disable auto-escape > command execution with raw() > should handle command with subshell [50.24ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.6033438Z test-*.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.6045126Z (pass) raw() function - Disable auto-escape > command execution with raw() > should handle command with wildcards [41.56ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.6382685Z prefix: test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.6428195Z (pass) raw() function - Disable auto-escape > combining raw() with safe interpolation > should mix raw command with safe variable [38.26ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.6784162Z User said: test; rm -rf /
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.6807696Z (pass) raw() function - Disable auto-escape > combining raw() with safe interpolation > should safely quote user input when mixed with raw [37.95ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.7144948Z part1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.7586859Z part2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.7614449Z (pass) raw() function - Disable auto-escape > combining raw() with safe interpolation > should handle multiple raw() calls in one command [80.62ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.7951795Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.8322475Z test2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.8750496Z echo "test" && echo "test2"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.8785858Z (pass) raw() function - Disable auto-escape > comparison with normal interpolation > raw() executes shell operators, normal interpolation escapes them [117.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.8988083Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.9161264Z echo "hello world" | wc -w
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.9165515Z (pass) raw() function - Disable auto-escape > comparison with normal interpolation > raw() allows pipes, normal interpolation escapes them [37.96ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.9635598Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:09.9985256Z $(echo test)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.0039985Z (pass) raw() function - Disable auto-escape > comparison with normal interpolation > raw() allows command substitution, normal interpolation escapes it [87.37ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.0394557Z single'quote double"quote
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.0424544Z (pass) raw() function - Disable auto-escape > edge cases > should handle raw() with quotes in command [38.44ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.0761055Z /c/Users/runneradmin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.0805155Z (pass) raw() function - Disable auto-escape > edge cases > should handle raw() with environment variables [38.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.1155968Z line1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.1156509Z line2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.1189197Z (pass) raw() function - Disable auto-escape > edge cases > should handle raw() with newlines [38.35ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.1566469Z start end
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.2062972Z start
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.2593114Z middle end
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.3090827Z start
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.3648074Z end
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.3704561Z (pass) raw() function - Disable auto-escape > edge cases > should handle raw() at different positions [251.47ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.4067832Z Building...
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.4495897Z Done
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.4924939Z Testing...
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.5337317Z Passed
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.5390167Z (pass) raw() function - Disable auto-escape > practical use cases > configuration-based commands [168.57ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.5978113Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.5982125Z (pass) raw() function - Disable auto-escape > practical use cases > complex shell pipelines [59.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.6691786Z success
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.7145158Z (pass) raw() function - Disable auto-escape > practical use cases > conditional execution chains [116.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.7510377Z ; rm -rf /tmp/test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.7529903Z (pass) raw() function - Disable auto-escape > security demonstrations > normal interpolation prevents injection [38.69ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.7873541Z safe
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.8259391Z This would be dangerous with rm -rf
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.8288705Z (pass) raw() function - Disable auto-escape > security demonstrations > raw() would execute injection (demonstration only) [75.82ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.8674147Z (pass) raw() function - Disable auto-escape > error handling > should handle failing commands in raw() [38.49ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.9099714Z /usr/bin/bash: line 1: nonexistent-command-12345: command not found
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.9123966Z (pass) raw() function - Disable auto-escape > error handling > should handle non-existent commands in raw() [45.00ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.9461859Z /usr/bin/bash: -c: line 1: unexpected EOF while looking for matching `"'
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.9501959Z (pass) raw() function - Disable auto-escape > error handling > should handle syntax errors in raw() [37.76ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.9502420Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.9502741Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:10.9503592Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.0029104Z ##[group]js\tests\readme-examples.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.0029614Z hello world
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.0077846Z (pass) README Examples and Use Cases > 1. Classic Await Pattern > should work like README example: await $`ls -la` [53.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.0508591Z line1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.0509334Z line2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.0610962Z (pass) README Examples and Use Cases > 2. Async Iteration Pattern > should work like README example: for await streaming [53.28ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.1342332Z stdout
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.1346873Z stderr
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.1404875Z (pass) README Examples and Use Cases > 3. EventEmitter Pattern > should work like README example: .on() events [79.39ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.1773153Z streaming data
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.1882578Z (pass) README Examples and Use Cases > 4. Mixed Pattern > should work like README example: events + await [47.74ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.2837880Z build success
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.3410395Z ls: cannot access '/nonexistent-dir-12345': No such file or directory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.3772069Z critical operation
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.3812045Z + set -v
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.3812269Z + set -x
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.3812441Z + set -e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.3812816Z + set +e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.3813140Z + set -x
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.3813505Z + set -verbose
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.3831454Z (pass) README Examples and Use Cases > 5. Shell Replacement (.sh → .mjs) > should work like README example: shell settings [194.86ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.4372790Z Hello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.4397653Z Error!
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.4581565Z (pass) README Examples and Use Cases > 6. Default Behavior > should work like README example: stdout/stderr capture + mirroring [74.85ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.5693893Z (pass) README Examples and Use Cases > 7. Options Override > should work like README example: sh() with options [111.26ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.6507459Z (pass) README Examples and Use Cases > 7. Options Override > should work like README example: create() with defaults [81.38ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.7215186Z custom input{"session_id":"test-123","status":"started"}
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.7217660Z {"data":"some log data"}
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.7262403Z (pass) README Examples and Use Cases > 8. Real-world: Session ID Extraction > should work like README example: JSON parsing from streaming [75.46ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.7827917Z Starting download
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.7828563Z Progress: 25%
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.7829053Z Progress: 50%
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.7832179Z Progress: 100%
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.7832493Z Done!
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.7919184Z (pass) README Examples and Use Cases > 9. Real-world: Progress Monitoring > should work like README example: progress parsing from stdout [65.59ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.8637605Z stdout
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.8641683Z stderr
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.8706333Z (pass) README Examples and Use Cases > 10. API Documentation Examples > should match ProcessRunner events from API docs [78.75ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.9244178Z output
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.9267166Z error
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.9344243Z (pass) README Examples and Use Cases > 10. API Documentation Examples > should match Result Object from API docs [63.71ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.9659244Z (pass) README Examples and Use Cases > 10. API Documentation Examples > should verify default options from API docs [31.46ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.9817911Z (pass) README Examples and Use Cases > Smart Quoting & Security (from README) > safe strings are NOT quoted [15.75ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.9878367Z (pass) README Examples and Use Cases > Smart Quoting & Security (from README) > dangerous strings are automatically quoted [6.13ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:11.9998574Z (pass) README Examples and Use Cases > Smart Quoting & Security (from README) > user-provided quotes are preserved [11.83ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.0162475Z (pass) README Examples and Use Cases > Smart Quoting & Security (from README) > shell injection attempts are neutralized [16.44ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.0656327Z $HOME
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1022622Z $(echo INJECTED)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1069855Z (pass) README Examples and Use Cases > Smart Quoting & Security (from README) > actual execution prevents injection [90.76ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1070380Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1070716Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1070828Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1071105Z ##[group]js\tests\repository-layout.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1099955Z (pass) repository language layout > keeps JavaScript package files inside js/ [0.36ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1102401Z (pass) repository language layout > does not keep language release scripts at the repository root [0.23ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1104986Z (pass) repository language layout > keeps Rust package release files inside rust/ [0.24ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1109122Z (pass) repository language layout > uses separate JavaScript and Rust workflows and release tags [0.38ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1128870Z (pass) repository language layout > release jobs evaluate after PR-only gate jobs are skipped on push [1.86ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1131225Z (pass) repository language layout > keeps root README focused on shared project information [0.22ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1131958Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1132414Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1132595Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1133082Z ##[group]js\tests\resource-cleanup-internals.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1561476Z (pass) Resource Cleanup Internal Verification > SIGINT Handler Management > should install SIGINT handler when first command starts [39.62ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.1878828Z (pass) Resource Cleanup Internal Verification > SIGINT Handler Management > should share single SIGINT handler for multiple concurrent commands [31.68ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.2037027Z Command failed with exit code 1(pass) Resource Cleanup Internal Verification > SIGINT Handler Management > should remove SIGINT handler even on error [15.80ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.2353838Z (pass) Resource Cleanup Internal Verification > SIGINT Handler Management > should remove SIGINT handler when command is killed [31.62ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.2375396Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.2511838Z (pass) Resource Cleanup Internal Verification > ProcessRunner Lifecycle > should cleanup ProcessRunner on successful completion [15.79ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.2670407Z Command failed with exit code 1(pass) Resource Cleanup Internal Verification > ProcessRunner Lifecycle > should cleanup ProcessRunner on error [15.82ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.2985696Z (pass) Resource Cleanup Internal Verification > ProcessRunner Lifecycle > should cleanup ProcessRunner when killed [31.44ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.2991424Z not awaited
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.3619242Z (pass) Resource Cleanup Internal Verification > ProcessRunner Lifecycle > should cleanup ProcessRunner when not awaited [63.30ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.3624634Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.3779308Z (pass) Resource Cleanup Internal Verification > Event Listener Management > should cleanup event listeners after command completion [16.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.3937307Z Command failed with exit code 1(pass) Resource Cleanup Internal Verification > Event Listener Management > should cleanup event listeners on error [15.72ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.3956634Z "line1"; echo "line2"; echo line3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.4413295Z (pass) Resource Cleanup Internal Verification > Event Listener Management > should cleanup stream iterator listeners [47.53ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.4855499Z real process
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.5037977Z (pass) Resource Cleanup Internal Verification > Child Process Management > should cleanup child process references [62.45ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.5511729Z (pass) Resource Cleanup Internal Verification > Child Process Management > should cleanup child process on kill [47.32ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6007935Z (pass) Resource Cleanup Internal Verification > Child Process Management > should cleanup child process on timeout [49.60ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6010615Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6146499Z (pass) Resource Cleanup Internal Verification > AbortController Management > should cleanup AbortController after completion [13.84ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6622743Z (pass) Resource Cleanup Internal Verification > AbortController Management > should abort controller when killed [47.57ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6781915Z Command failed with exit code 1(pass) Resource Cleanup Internal Verification > AbortController Management > should cleanup AbortController on error [15.72ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6801731Z virtual test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6950752Z (pass) Resource Cleanup Internal Verification > Virtual Command Management > should cleanup after virtual command completion [17.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6955133Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6955694Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6955960Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6956211Z 4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6956487Z 5
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6956742Z 6
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6956977Z 7
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6957217Z 8
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6957488Z 9
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6957694Z 10
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6957863Z 11
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6958056Z 12
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6958291Z 13
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6958523Z 14
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6958740Z 15
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6958945Z 16
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6959169Z 17
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6959388Z 18
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6959630Z 19
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6959860Z 20
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6960030Z 21
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6960203Z 22
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6960380Z 23
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6960564Z 24
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6960752Z 25
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6960932Z 26
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6961110Z 27
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6961296Z 28
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6961474Z 29
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6961653Z 30
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6961832Z 31
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6962009Z 32
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6962187Z 33
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6962366Z 34
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6962546Z 35
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6962725Z 36
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6962917Z 37
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6963099Z 38
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6963285Z 39
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6963464Z 40
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6963645Z 41
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6963831Z 42
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6964012Z 43
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6964190Z 44
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6964370Z 45
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6964548Z 46
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6964732Z 47
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6964910Z 48
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6965091Z 49
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6965270Z 50
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6965448Z 51
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6965629Z 52
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6965810Z 53
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6965988Z 54
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6966167Z 55
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6966345Z 56
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6966526Z 57
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6966721Z 58
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6966901Z 59
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6967081Z 60
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6967260Z 61
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6967442Z 62
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6967620Z 63
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6967805Z 64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6967985Z 65
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6968168Z 66
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6968347Z 67
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6968532Z 68
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6968711Z 69
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6969264Z 70
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6969445Z 71
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6969626Z 72
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6969804Z 73
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6969987Z 74
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6970165Z 75
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6970341Z 76
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6970517Z 77
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6970694Z 78
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6970887Z 79
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6971064Z 80
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6971244Z 81
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6971426Z 82
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6971588Z 83
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6971733Z 84
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6971878Z 85
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6972022Z 86
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6972165Z 87
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6972312Z 88
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6972457Z 89
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6972605Z 90
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6972760Z 91
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6972906Z 92
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6973058Z 93
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6973205Z 94
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6973352Z 95
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6973499Z 96
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6973657Z 97
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6973802Z 98
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6974098Z 99
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.6974254Z 100
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.7259451Z (pass) Resource Cleanup Internal Verification > Virtual Command Management > should cleanup virtual generator when killed [30.80ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.7890353Z (pass) Resource Cleanup Internal Verification > Stream Management > should cleanup stdin handlers on completion [63.07ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.7894215Z test input"stdout"; echo stderr >&2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.8049716Z (pass) Resource Cleanup Internal Verification > Stream Management > should cleanup stdout/stderr streams [15.92ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.8078225Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.8209895Z (pass) Resource Cleanup Internal Verification > Stream Management > should cleanup streams when piping [15.94ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.8235102Z hello
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.8367890Z (pass) Resource Cleanup Internal Verification > Pipeline Cleanup > should cleanup all processes in pipeline [15.79ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:12.9122250Z (pass) Resource Cleanup Internal Verification > Pipeline Cleanup > should cleanup pipeline on error [75.42ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5020726Z (pass) Resource Cleanup Internal Verification > Pipeline Cleanup > should cleanup pipeline when killed [589.77ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5047599Z 0
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5048413Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5048654Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5048884Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5049110Z 4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5049350Z 5
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5049625Z 6
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5049862Z 7
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5050126Z 8
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5050394Z 9
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5050719Z 10
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5051030Z 11
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5051557Z 12
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5051853Z 13
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5052140Z 14
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5052433Z 15
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5052711Z 16
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5052982Z 17
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5053257Z 18
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5053536Z 19
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5053704Z 20
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5053862Z 21
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5054016Z 22
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5054173Z 23
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5054351Z 24
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5054532Z 25
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5054685Z 26
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5054984Z 27
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5055214Z 28
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5055843Z 29
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5056195Z 30
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5056468Z 31
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5056731Z 32
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5056995Z 33
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5057254Z 34
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5057518Z 35
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5057780Z 36
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5058016Z 37
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5058229Z 38
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5058789Z 39
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5059026Z 40
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5059270Z 41
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5059521Z 42
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5059761Z 43
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5059997Z 44
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5060237Z 45
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5060485Z 46
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5060727Z 47
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5060971Z 48
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5061205Z 49
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5061446Z 50
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5061693Z 51
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5061955Z 52
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5062196Z 53
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5062434Z 54
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5062676Z 55
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5062938Z 56
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5063179Z 57
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5063926Z 58
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5064176Z 59
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5064419Z 60
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5064655Z 61
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5064907Z 62
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5065155Z 63
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5065400Z 64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5065642Z 65
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5065887Z 66
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5066124Z 67
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5066366Z 68
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5066618Z 69
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5066861Z 70
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5067102Z 71
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5067342Z 72
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5067588Z 73
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5067850Z 74
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5068096Z 75
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5068339Z 76
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5068585Z 77
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5068822Z 78
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5069059Z 79
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5069304Z 80
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5069542Z 81
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5069779Z 82
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5070020Z 83
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5070256Z 84
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5070501Z 85
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5070740Z 86
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5071246Z 87
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5071570Z 88
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5071824Z 89
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5072069Z 90
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5072309Z 91
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5072548Z 92
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5072796Z 93
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5073038Z 94
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5073281Z 95
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5073525Z 96
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5073768Z 97
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5074012Z 98
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5074249Z 99
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5179097Z (pass) Resource Cleanup Internal Verification > Memory Leak Prevention > should not leak memory with rapid command execution [15.83ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5236968Z 0
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5237248Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5237528Z 4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5237732Z 6
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5238368Z 8
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5238680Z 10
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5238934Z 12
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5239183Z 14
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5239429Z 16
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5239677Z 18
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5239920Z 20
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5240193Z 22
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5240441Z 24
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5240727Z 26
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5240983Z 28
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5241239Z 30
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5241481Z 32
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5241717Z 34
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5241940Z 36
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5242165Z 38
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5242418Z 40
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5242568Z 42
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5242709Z 44
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5242848Z 46
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5253182Z 48
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5499927Z Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1Command failed with exit code 1(pass) Resource Cleanup Internal Verification > Memory Leak Prevention > should cleanup when mixing success and failure [31.62ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5519630Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5655284Z (pass) Resource Cleanup Internal Verification > Memory Leak Prevention > should cleanup with nested event emitters [15.87ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5816772Z Test left behind 1 SIGINT handlers, forcing cleanup...
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5819472Z (pass) Resource Cleanup Internal Verification > Edge Cases > should cleanup when promise is created but not started [16.33ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5841356Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.5976702Z (pass) Resource Cleanup Internal Verification > Edge Cases > should cleanup when using finally without await [15.76ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.6554032Z start
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.6688595Z (pass) Resource Cleanup Internal Verification > Edge Cases > should cleanup when command throws during execution [71.15ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.6802077Z (pass) Resource Cleanup Internal Verification > Edge Cases > should cleanup when parent process streams close [11.26ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.8188239Z (pass) Resource Cleanup Internal Verification > Concurrent Execution Patterns > should cleanup with Promise.race [138.60ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.8194028Z inheritsuccess
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.8194934Z another success
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.8982160Z Command failed with exit code 1Command failed with exit code 2(pass) Resource Cleanup Internal Verification > Concurrent Execution Patterns > should cleanup with Promise.allSettled [79.32ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.9355939Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.9670313Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.9936617Z (pass) Resource Cleanup Internal Verification > Concurrent Execution Patterns > should cleanup with async iteration break [95.41ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.9938360Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.9939023Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.9939826Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.9940389Z ##[group]js\tests\setup-npm.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:13.9976233Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0005194Z (pass) compares semantic versions numerically [0.25ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0006727Z (pass) requires npm 11.5.1 or later for OIDC [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0007661Z (pass) requires Node.js 22.14.0 or later [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0013035Z (pass) selects the latest npm 11 tarball that satisfies trusted publishing [0.47ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0013647Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0014137Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0014331Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0014971Z ##[group]js\tests\shell-settings.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0054343Z continued
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0055531Z Command failed with exit code 1(pass) Shell Settings (set -e / set +e equivalent) > Error Handling (set -e / set +e) > should continue execution by default (like bash without set -e) [0.79ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0060982Z Command failed with exit code 42(pass) Shell Settings (set -e / set +e equivalent) > Error Handling (set -e / set +e) > should throw on error when errexit enabled (set -e) [0.50ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0063947Z Command failed with exit code 1(pass) Shell Settings (set -e / set +e equivalent) > Error Handling (set -e / set +e) > should stop throwing when errexit disabled (set +e) [0.30ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0071160Z Command failed with exit code 1Command failed with exit code 2Command failed with exit code 3(pass) Shell Settings (set -e / set +e equivalent) > Error Handling (set -e / set +e) > should allow mid-script changes (like bash) [0.68ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0073273Z silent
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0074615Z (pass) Shell Settings (set -e / set +e equivalent) > Verbose Mode (set -v) > should not print commands by default [0.33ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0078024Z verbose test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0079652Z (pass) Shell Settings (set -e / set +e equivalent) > Verbose Mode (set -v) > should print commands when verbose enabled [0.53ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0080191Z + set +e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0081857Z no trace
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0083107Z (pass) Shell Settings (set -e / set +e equivalent) > Trace Mode (set -x) > should not trace commands by default [0.30ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0086514Z trace test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0088151Z (pass) Shell Settings (set -e / set +e equivalent) > Trace Mode (set -x) > should trace commands when xtrace enabled [0.48ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0090161Z (pass) Shell Settings (set -e / set +e equivalent) > Settings API > should allow setting options with set() function [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0091759Z + set -v
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0093281Z (pass) Shell Settings (set -e / set +e equivalent) > Settings API > should allow unsetting options with unset() function [0.08ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0094742Z (pass) Shell Settings (set -e / set +e equivalent) > Settings API > should support long option names [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0095543Z + set -x
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0095817Z + set +e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0096084Z + set -v
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0096359Z + set +e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0096664Z + set -verbose
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0096951Z + set +errexit
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0097565Z + set +e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0098234Z (pass) Shell Settings (set -e / set +e equivalent) > Settings API > should return current settings [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0098993Z + set -v
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0099291Z + set +e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0331547Z 4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0632425Z 5
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0672077Z stdout
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0672860Z stderr
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0723486Z 501 |     return;
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0724082Z 502 |   }
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0724806Z 503 | 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0725263Z 504 |   trace('ProcessRunner', () => `Errexit mode: throwing error`);
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0725799Z 505 | 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0726677Z 506 |   const error = new Error(
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0727084Z                           ^
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0727502Z error: Command failed with exit code 143
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0727895Z    code: 143,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0728163Z  stdout: "",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0729265Z  stderr: "Process killed with SIGTERM",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0729641Z  result: {
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0729828Z   code: 143,
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0730122Z   stdout: "",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0730379Z   stderr: "Process killed with SIGTERM",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0730634Z   stdin: "",
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0730820Z   text: [Function: text],
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0731028Z },
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0731124Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0731459Z       at throwErrexitIfNeeded (D:\a\command-stream\command-stream\js\src\$.process-runner-execution.mjs:506:21)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0732179Z       at <anonymous> (D:\a\command-stream\command-stream\js\src\$.process-runner-execution.mjs:1191:7)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0732584Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0763274Z ##[error]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	      at throwErrexitIfNeeded (D:\a\command-stream\command-stream\js\src\$.process-runner-execution.mjs:506:21)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	      at <anonymous> (D:\a\command-stream\command-stream\js\src\$.process-runner-execution.mjs:1191:7)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0777940Z (fail) Shell Settings (set -e / set +e equivalent) > Shell Replacement Benefits > should provide better error objects than bash [63.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0779542Z (skip) Shell Settings (set -e / set +e equivalent) > Shell Replacement Benefits > should allow JavaScript control flow with shell semantics
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0780553Z setup complete
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0781694Z ls: /nonexistent: No such file or directory(pass) Shell Settings (set -e / set +e equivalent) > Real-world Shell Script Pattern > should support common shell script patterns [1.23ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0783094Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0784399Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0784612Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0785108Z ##[group]js\tests\sigint-cleanup-isolated.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0785691Z critical operation
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0790088Z (skip) SIGINT Cleanup Tests (Isolated) > should properly manage SIGINT handlers
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0790982Z (skip) SIGINT Cleanup Tests (Isolated) > should forward SIGINT to child processes
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0791905Z (skip) SIGINT Cleanup Tests (Isolated) > should cleanup all resources properly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0792797Z (skip) SIGINT Cleanup Tests (Isolated) > should not interfere with user SIGINT handlers
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0793364Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0793750Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0793916Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0794312Z ##[group]js\tests\sigint-cleanup.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0819722Z (skip) SIGINT Handler Cleanup Tests > should remove SIGINT handler when all ProcessRunners finish
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0821001Z (skip) SIGINT Handler Cleanup Tests > should not interfere with user SIGINT handlers after commands finish
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0822405Z (skip) SIGINT Handler Cleanup Tests > should maintain SIGINT handler while commands are active
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0824968Z (skip) SIGINT Handler Cleanup Tests > should handle multiple concurrent ProcessRunners correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0825620Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0826036Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0826211Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0826609Z ##[group]js\tests\start-run-edge-cases.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0859730Z (pass) Start/Run Edge Cases and Advanced Usage > should handle complex option combinations [0.88ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0861638Z (skip) Start/Run Edge Cases and Advanced Usage > should work with real shell commands that produce large output
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0863935Z (pass) Start/Run Edge Cases and Advanced Usage > should handle stderr with capture: false [0.41ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0867582Z ls: /nonexistent-path-98765: No such file or directory(pass) Start/Run Edge Cases and Advanced Usage > should handle stderr with capture: true [0.31ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0869530Z multiple calls
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0870299Z (pass) Start/Run Edge Cases and Advanced Usage > should handle multiple consecutive start() calls correctly [0.32ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.0872598Z async mode
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.1277280Z sync mode
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.1279081Z (pass) Start/Run Edge Cases and Advanced Usage > should handle mixed sync/async mode correctly [40.78ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.1281779Z with start
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.1282922Z with run
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.1283973Z direct await
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.1285167Z (pass) Start/Run Edge Cases and Advanced Usage > should preserve original behavior when no options passed [0.63ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.1287579Z hello world
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.1762293Z hello world
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.1787360Z (pass) Start/Run Edge Cases and Advanced Usage > should work with piped commands [50.14ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2376122Z (pass) Start/Run Edge Cases and Advanced Usage > should handle buffer stdin correctly with options [58.81ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2380030Z (pass) Start/Run Edge Cases and Advanced Usage > should maintain performance with capture: false [0.44ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2382504Z (pass) Start/Run Edge Cases and Advanced Usage > should handle empty string stdin [0.21ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2383094Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2383557Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2383669Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2383975Z ##[group]js\tests\start-run-options.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2415320Z (pass) Start/Run Options Passing > .start() method with options > should pass capture: false option correctly [0.28ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2417249Z (pass) Start/Run Options Passing > .start() method with options > should pass capture: true option correctly [0.25ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2417798Z test with capture true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2419530Z (pass) Start/Run Options Passing > .start() method with options > should pass mirror: false option correctly [0.18ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2421959Z (pass) Start/Run Options Passing > .start() method with options > should pass both capture and mirror options [0.21ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2954191Z (pass) Start/Run Options Passing > .start() method with options > should pass stdin option correctly [53.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2955460Z (skip) Start/Run Options Passing > .start() method with options > should work with real shell commands
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2957893Z custom input dataalready started test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2958848Z (pass) Start/Run Options Passing > .start() method with options > should ignore options if process already started [0.54ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2962027Z (pass) Start/Run Options Passing > .run() method (alias for .start()) > should work identically to .start() with capture: false [0.22ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2963076Z test with run alias
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2963968Z (pass) Start/Run Options Passing > .run() method (alias for .start()) > should work identically to .start() with capture: true [0.26ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.2967019Z (pass) Start/Run Options Passing > .run() method (alias for .start()) > should work with multiple options [0.19ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3462258Z (pass) Start/Run Options Passing > .run() method (alias for .start()) > should work with stdin option [49.47ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3485295Z run method inputdefault behavior
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3486261Z (pass) Start/Run Options Passing > Backward compatibility > direct await should still work with default options [2.43ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3488185Z no options test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3489760Z (pass) Start/Run Options Passing > Backward compatibility > .start() without options should work identically to direct await [0.36ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3490353Z no options test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3491946Z run no options
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3492960Z run no options
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3493751Z (pass) Start/Run Options Passing > Backward compatibility > .run() without options should work identically to direct await [0.37ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3496040Z (pass) Start/Run Options Passing > Virtual commands support > should work with virtual echo command [0.19ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3498259Z (pass) Start/Run Options Passing > Virtual commands support > should work with virtual commands using .run() [0.19ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3499688Z empty options
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3500263Z (pass) Start/Run Options Passing > Edge cases > should handle empty options object [0.21ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3503680Z (pass) Start/Run Options Passing > Edge cases > should handle mode option alongside other options [0.26ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3506039Z (pass) Start/Run Options Passing > Edge cases > should reinitialize chunks when capture option changes [0.22ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3506582Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3506909Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3507013Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3507291Z ##[group]js\tests\stderr-output-handling.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3534201Z (skip) Stderr output handling in $.mjs > commands that output to stderr should not hang when captured
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3535206Z (skip) Stderr output handling in $.mjs > gh commands with progress output to stderr should complete
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3535867Z (skip) Stderr output handling in $.mjs > capturing with 2>&1 should combine stderr into stdout
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3536477Z (skip) Stderr output handling in $.mjs > long-running commands with stderr output should not hang
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3537093Z (skip) Stderr output handling in $.mjs > gh gist create with stderr progress should work correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3537666Z (skip) Stderr output handling in $.mjs > streaming mode should handle stderr correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3538199Z (skip) Stderr output handling in $.mjs > timeout should work even with pending stderr
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3538521Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3538790Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3538895Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3539151Z ##[group]js\tests\stream-exit-chunks.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3558101Z (pass) stream() yields an exit chunk with the exit code (success) [0.55ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3558747Z (skip) stream() exit chunk reports a non-zero exit code
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3559147Z (skip) stream() does not hang when a grandchild keeps stdout open
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3559596Z (skip) await on a command does not hang when a grandchild keeps stdout open
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3560042Z (skip) stream() can be stopped from inside the loop with kill()
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3560487Z (skip) breaking out of the stream() loop stops the process
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3560897Z (skip) kill() honors the configured killSignal option (SIGINT => 130)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3561425Z (skip) an explicit kill(signal) overrides the configured killSignal
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3562153Z (skip) breaking out of the loop uses the configured killSignal
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3562798Z (skip) an external AbortSignal stops an awaited command and honors killSignal
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3563362Z (pass) exit chunk is yielded with zero added latency for normal commands [0.33ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3563686Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3563972Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3564088Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3564365Z ##[group]js\tests\streaming-interfaces.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3587068Z (skip) streaming interfaces - basic functionality
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3961486Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3986095Z (pass) streaming interfaces - auto-start behavior [39.82ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.3986545Z (skip) streaming interfaces - buffers interface
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4343831Z String test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4390953Z (pass) streaming interfaces - strings interface [40.47ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4391766Z (skip) streaming interfaces - mixed stdout/stderr
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4392101Z (skip) streaming interfaces - kill method works
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4392516Z (skip) streaming interfaces - stdin control with cross-platform command
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4394175Z immediate test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4396383Z (pass) streaming interfaces - immediate access after completion [0.54ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4398472Z backward compatible
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4398979Z (pass) streaming interfaces - backward compatibility [0.25ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4399518Z (skip) streaming interfaces - stdin pipe mode works
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4399870Z (skip) streaming interfaces - grep filtering via stdin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4400096Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4400408Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4400521Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4400753Z ##[group]js\tests\sync.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4823353Z hello sync
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.4825557Z (pass) Synchronous Execution (.sync()) > Basic Sync Functionality > should execute commands synchronously [39.91ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.5410232Z stderr
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.5410488Z stdout
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.5411507Z (pass) Synchronous Execution (.sync()) > Basic Sync Functionality > should handle stderr in sync mode [58.55ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.5799844Z (pass) Synchronous Execution (.sync()) > Basic Sync Functionality > should handle non-zero exit codes [38.69ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.6265850Z /usr/bin/bash: line 1: nonexistent-command-99999: command not found
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.6266830Z (pass) Synchronous Execution (.sync()) > Basic Sync Functionality > should handle command not found [46.80ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.6650133Z sync output
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.6652691Z (pass) Synchronous Execution (.sync()) > Events in Sync Mode > should emit batched events after completion [38.52ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.7230810Z error
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.7233116Z (pass) Synchronous Execution (.sync()) > Events in Sync Mode > should emit stderr events in sync mode [58.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.7613296Z mirrored
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.7994326Z (pass) Synchronous Execution (.sync()) > Options in Sync Mode > should respect mirror option [76.01ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.8377492Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.8378423Z (pass) Synchronous Execution (.sync()) > Options in Sync Mode > should respect capture option [38.46ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.9698579Z custom inputbuffer inputignored
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.9699786Z (pass) Synchronous Execution (.sync()) > Options in Sync Mode > should handle stdin options [132.10ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:14.9700828Z (skip) Synchronous Execution (.sync()) > Options in Sync Mode > should handle cwd option
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.0467868Z (pass) Synchronous Execution (.sync()) > Shell Settings in Sync Mode > should respect errexit setting [76.70ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.0854915Z verbose test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.0856212Z + set +e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.0856818Z (pass) Synchronous Execution (.sync()) > Shell Settings in Sync Mode > should respect verbose setting [38.96ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.1246877Z trace test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.1249166Z (pass) Synchronous Execution (.sync()) > Shell Settings in Sync Mode > should respect xtrace setting [39.18ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.1252282Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.1253553Z (pass) Synchronous Execution (.sync()) > Error Handling > should throw if command already started asynchronously [0.42ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.1840754Z error
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.1841002Z output
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.1842472Z (pass) Synchronous Execution (.sync()) > Error Handling > should include error details when errexit is enabled [58.85ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2228258Z line1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2228519Z line2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2229913Z (pass) Synchronous Execution (.sync()) > Complex Scenarios > should handle multiline output [38.72ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2701564Z line31
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2702050Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2702347Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2702668Z 4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2702962Z 5
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2703209Z 6
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2703872Z 7
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2704132Z 8
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2704715Z 9
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2704974Z 10
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2705200Z 11
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2705438Z 12
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2705684Z 13
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2705934Z 14
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2706167Z 15
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2706433Z 16
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2706694Z 17
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2706953Z 18
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2707579Z 19
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2707863Z 20
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2708099Z 21
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2708343Z 22
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2708578Z 23
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2708818Z 24
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2709054Z 25
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2709301Z 26
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2709542Z 27
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2709778Z 28
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2710014Z 29
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2710281Z 30
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2710522Z 31
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2710682Z 32
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2710830Z 33
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2710972Z 34
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2711112Z 35
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2712212Z 36
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2712401Z 37
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2712562Z 38
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2712715Z 39
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2712858Z 40
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2713003Z 41
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2713149Z 42
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2713289Z 43
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2713433Z 44
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2713581Z 45
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2713726Z 46
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2713867Z 47
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2714275Z 48
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2714422Z 49
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2714564Z 50
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2714702Z 51
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2714845Z 52
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2714984Z 53
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2715135Z 54
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2715279Z 55
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2715417Z 56
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2715555Z 57
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2715694Z 58
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2715832Z 59
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2715973Z 60
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2716116Z 61
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2716370Z 62
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2716597Z 63
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2716745Z 64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2716884Z 65
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2717025Z 66
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2717173Z 67
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2717316Z 68
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2717463Z 69
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2717604Z 70
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2717741Z 71
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2717883Z 72
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2718024Z 73
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2718165Z 74
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2718306Z 75
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2718447Z 76
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2718590Z 77
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2718732Z 78
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2718879Z 79
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2719051Z 80
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2719325Z 81
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2719475Z 82
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2719618Z 83
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2719759Z 84
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2719901Z 85
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2720047Z 86
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2720191Z 87
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2720333Z 88
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2720475Z 89
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2720615Z 90
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2720753Z 91
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2720893Z 92
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2721036Z 93
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2721174Z 94
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2721314Z 95
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2721451Z 96
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2721588Z 97
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2721732Z 98
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2721871Z 99
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2722016Z 100
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2722161Z 101
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2722302Z 102
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2722446Z 103
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2722594Z 104
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2722735Z 105
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2722879Z 106
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2723019Z 107
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2723160Z 108
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2723301Z 109
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2723442Z 110
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2723584Z 111
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2723725Z 112
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2723868Z 113
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2724007Z 114
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2724237Z 115
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2724484Z 116
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2724737Z 117
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2724992Z 118
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2725242Z 119
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2725491Z 120
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2725739Z 121
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2725995Z 122
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2726241Z 123
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2726494Z 124
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2726754Z 125
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2726995Z 126
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2727248Z 127
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2727509Z 128
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2727762Z 129
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2728285Z 130
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2728487Z 131
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2728725Z 132
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2728961Z 133
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2729204Z 134
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2729460Z 135
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2729708Z 136
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2729958Z 137
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2730203Z 138
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2730450Z 139
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2730692Z 140
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2730939Z 141
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2731191Z 142
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2731449Z 143
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2731704Z 144
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2731960Z 145
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2732215Z 146
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2732467Z 147
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2732709Z 148
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2732979Z 149
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2733240Z 150
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2733497Z 151
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2733735Z 152
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2733991Z 153
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2734688Z 154
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2734956Z 155
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2735205Z 156
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2735447Z 157
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2735922Z 158
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2736150Z 159
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2736370Z 160
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2736586Z 161
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2736817Z 162
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2737035Z 163
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2737259Z 164
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2737491Z 165
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2737729Z 166
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2737970Z 167
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2738214Z 168
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2738452Z 169
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2738693Z 170
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2738934Z 171
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2739177Z 172
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2739441Z 173
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2739675Z 174
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2739905Z 175
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2740142Z 176
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2740390Z 177
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2740635Z 178
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2740891Z 179
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2741141Z 180
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2741422Z 181
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2741631Z 182
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2741772Z 183
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2741913Z 184
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2742060Z 185
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2742201Z 186
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2742350Z 187
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2742499Z 188
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2742643Z 189
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2742789Z 190
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2742931Z 191
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2743075Z 192
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2743218Z 193
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2743362Z 194
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2743503Z 195
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2743644Z 196
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2743786Z 197
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2743928Z 198
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2744070Z 199
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2744212Z 200
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2744357Z 201
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2744499Z 202
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2744642Z 203
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2744784Z 204
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2744975Z 205
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2745233Z 206
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2745465Z 207
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2745675Z 208
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2745895Z 209
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2746138Z 210
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2746378Z 211
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2746624Z 212
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2746865Z 213
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2747106Z 214
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2747356Z 215
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2747602Z 216
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2747852Z 217
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2748099Z 218
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2748340Z 219
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2748591Z 220
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2748835Z 221
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2749081Z 222
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2749331Z 223
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2749567Z 224
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2749814Z 225
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2750066Z 226
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2750314Z 227
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2750552Z 228
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2750798Z 229
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2751047Z 230
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2751306Z 231
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2751558Z 232
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2751807Z 233
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2752043Z 234
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2752287Z 235
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2752534Z 236
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2752792Z 237
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2753059Z 238
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2753317Z 239
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2753566Z 240
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2753880Z 241
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2754131Z 242
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2754376Z 243
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2754640Z 244
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2754912Z 245
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2755173Z 246
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2755433Z 247
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2755724Z 248
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2755977Z 249
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2756240Z 250
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2756778Z 251
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2757039Z 252
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2757304Z 253
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2757560Z 254
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2757817Z 255
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2758077Z 256
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2758335Z 257
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2758611Z 258
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2758873Z 259
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2759139Z 260
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2759712Z 261
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2759982Z 262
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2760229Z 263
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2760482Z 264
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2760739Z 265
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2761003Z 266
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2761263Z 267
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2761520Z 268
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2761782Z 269
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2762043Z 270
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2762314Z 271
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2762593Z 272
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2762842Z 273
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2763099Z 274
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2763356Z 275
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2763617Z 276
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2763873Z 277
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2764362Z 278
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2764636Z 279
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2764902Z 280
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2765167Z 281
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2765418Z 282
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2765694Z 283
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2765961Z 284
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2766239Z 285
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2766502Z 286
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2766760Z 287
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2767024Z 288
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2767286Z 289
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2767554Z 290
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2767813Z 291
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2768068Z 292
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2768329Z 293
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2768591Z 294
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2768856Z 295
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2769118Z 296
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2769368Z 297
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2769625Z 298
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2769881Z 299
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2770140Z 300
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2770390Z 301
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2770652Z 302
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2770906Z 303
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2771153Z 304
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2771409Z 305
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2771663Z 306
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2771915Z 307
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2772185Z 308
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2772455Z 309
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2772714Z 310
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2772975Z 311
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2773232Z 312
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2773491Z 313
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2773737Z 314
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2773973Z 315
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2774210Z 316
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2774476Z 317
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2774632Z 318
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2774780Z 319
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2774923Z 320
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2775065Z 321
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2775204Z 322
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2775345Z 323
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2775484Z 324
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2775631Z 325
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2775778Z 326
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2775924Z 327
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2776070Z 328
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2776217Z 329
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2776364Z 330
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2776511Z 331
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2776657Z 332
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2776810Z 333
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2776958Z 334
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2777104Z 335
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2777250Z 336
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2777404Z 337
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2777556Z 338
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2777710Z 339
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2777862Z 340
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2778024Z 341
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2778176Z 342
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2778323Z 343
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2778471Z 344
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2778625Z 345
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2778777Z 346
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2778925Z 347
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2779077Z 348
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2779227Z 349
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2779376Z 350
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2779535Z 351
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2780258Z 352
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2780426Z 353
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2780633Z 354
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2780885Z 355
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2781144Z 356
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2781399Z 357
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2781639Z 358
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2781890Z 359
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2782049Z 360
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2782200Z 361
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2782349Z 362
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2782499Z 363
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2782650Z 364
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2782799Z 365
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2782949Z 366
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2783097Z 367
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2783248Z 368
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2783404Z 369
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2783551Z 370
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2783939Z 371
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2784087Z 372
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2784235Z 373
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2784383Z 374
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2784531Z 375
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2784677Z 376
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2784824Z 377
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2784970Z 378
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2785120Z 379
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2785265Z 380
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2785421Z 381
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2785569Z 382
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2785728Z 383
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2786259Z (pass) Synchronous Execution (.sync()) > Complex Scenarios > should handle large output [47.36ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2786708Z 384
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2786864Z 385
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2787017Z 386
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2787165Z 387
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2787314Z 388
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2787463Z 389
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2787613Z 390
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2787763Z 391
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2787925Z 392
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2788076Z 393
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2788230Z 394
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2788498Z 395
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2788658Z 396
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2788810Z 397
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2788958Z 398
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2789108Z 399
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2789258Z 400
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2789407Z 401
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2789555Z 402
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2789712Z 403
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2790205Z 404
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2790472Z 405
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2801081Z 406
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2801360Z 407
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2801521Z 408
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2801675Z 409
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2801828Z 410
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2801977Z 411
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2802127Z 412
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2802268Z 413
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2802415Z 414
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2802558Z 415
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2802700Z 416
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2802844Z 417
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2803047Z 418
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2803194Z 419
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2803371Z 420
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2803518Z 421
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2803661Z 422
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2803802Z 423
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2803956Z 424
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2804110Z 425
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2804253Z 426
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2804395Z 427
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2804546Z 428
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2804692Z 429
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2804835Z 430
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2804977Z 431
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2805121Z 432
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2805263Z 433
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2805404Z 434
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2805546Z 435
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2805689Z 436
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2805831Z 437
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2805975Z 438
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2806118Z 439
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2806266Z 440
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2806412Z 441
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2806557Z 442
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2806701Z 443
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2806842Z 444
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2806986Z 445
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2807131Z 446
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2807277Z 447
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2807427Z 448
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2807581Z 449
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2807728Z 450
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2807871Z 451
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2808014Z 452
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2808161Z 453
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2808307Z 454
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2808463Z 455
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2808616Z 456
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2808759Z 457
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2808909Z 458
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2809051Z 459
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2809192Z 460
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2809334Z 461
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2809474Z 462
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2809618Z 463
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2809763Z 464
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2809906Z 465
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2810394Z 466
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2810551Z 467
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2810692Z 468
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2810835Z 469
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2810983Z 470
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2811127Z 471
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2811269Z 472
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2811415Z 473
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2811565Z 474
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2811708Z 475
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2811854Z 476
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2811993Z 477
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2812134Z 478
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2812277Z 479
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2812420Z 480
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2812563Z 481
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2812704Z 482
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2812847Z 483
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2812987Z 484
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2813132Z 485
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2813277Z 486
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2813421Z 487
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2813789Z 488
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2813936Z 489
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2814080Z 490
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2814225Z 491
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2814373Z 492
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2814517Z 493
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2814661Z 494
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2814808Z 495
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2814951Z 496
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2815095Z 497
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2815241Z 498
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2815391Z 499
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2815534Z 500
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2815684Z 501
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2815827Z 502
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2815968Z 503
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2816114Z 504
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2816255Z 505
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2816400Z 506
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2816549Z 507
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2816691Z 508
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2816833Z 509
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2816975Z 510
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2817116Z 511
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2817260Z 512
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2817405Z 513
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2817546Z 514
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2817695Z 515
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2817952Z 516
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2818101Z 517
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2818248Z 518
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2818390Z 519
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2818532Z 520
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2818675Z 521
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2818818Z 522
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2818961Z 523
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2819111Z 524
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2819256Z 525
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2819397Z 526
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2819540Z 527
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2819684Z 528
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2819829Z 529
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2819971Z 530
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2820114Z 531
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2820260Z 532
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2820404Z 533
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2820554Z 534
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2820700Z 535
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2820847Z 536
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2820991Z 537
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2821136Z 538
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2821284Z 539
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2821427Z 540
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2821573Z 541
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2821720Z 542
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2821864Z 543
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2822009Z 544
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2822150Z 545
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2822300Z 546
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2822444Z 547
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2822596Z 548
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2822744Z 549
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2822890Z 550
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2823038Z 551
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2823187Z 552
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2823332Z 553
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2823481Z 554
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2823629Z 555
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2823847Z 556
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2824092Z 557
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2824281Z 558
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2824431Z 559
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2824581Z 560
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2824727Z 561
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2824877Z 562
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2825019Z 563
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2825164Z 564
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2825420Z 565
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2825618Z 566
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2825769Z 567
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2825911Z 568
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2826055Z 569
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2826199Z 570
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2826342Z 571
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2826486Z 572
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2826634Z 573
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2826775Z 574
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2826921Z 575
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2827074Z 576
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2827227Z 577
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2827381Z 578
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2827524Z 579
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2827667Z 580
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2827813Z 581
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2827960Z 582
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2828101Z 583
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2828245Z 584
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2828389Z 585
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2828532Z 586
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2828683Z 587
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2828823Z 588
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2828968Z 589
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2829117Z 590
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2829262Z 591
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2829408Z 592
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2829557Z 593
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2829704Z 594
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2829849Z 595
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2829997Z 596
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2830152Z 597
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2830632Z 598
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2830784Z 599
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2830935Z 600
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2831080Z 601
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2831226Z 602
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2831370Z 603
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2831513Z 604
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2831657Z 605
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2831806Z 606
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2831951Z 607
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2832258Z 608
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2832399Z 609
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2832543Z 610
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2832689Z 611
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2832843Z 612
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2832985Z 613
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2833129Z 614
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2833272Z 615
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2833414Z 616
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2833556Z 617
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2833699Z 618
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2833846Z 619
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2833989Z 620
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2834130Z 621
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2834272Z 622
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2834416Z 623
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2834562Z 624
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2834702Z 625
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2834845Z 626
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2834988Z 627
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2835132Z 628
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2835279Z 629
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2835421Z 630
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2835563Z 631
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2835709Z 632
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2835852Z 633
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2835994Z 634
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2836141Z 635
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2836380Z 636
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2836546Z 637
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2836699Z 638
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2836843Z 639
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2836988Z 640
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2837135Z 641
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2837279Z 642
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2837425Z 643
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2837568Z 644
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2837709Z 645
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2837851Z 646
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2837995Z 647
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2838140Z 648
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2838283Z 649
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2838429Z 650
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2838572Z 651
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2838713Z 652
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2838855Z 653
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2838996Z 654
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2839141Z 655
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2839282Z 656
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2839426Z 657
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2839572Z 658
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2839716Z 659
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2839862Z 660
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2840010Z 661
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2840160Z 662
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2840301Z 663
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2840439Z 664
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2840581Z 665
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2840728Z 666
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2840870Z 667
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2841014Z 668
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2841154Z 669
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2841296Z 670
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2841435Z 671
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2841569Z 672
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2841714Z 673
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2841855Z 674
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2841995Z 675
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2842139Z 676
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2842284Z 677
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2842429Z 678
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2842573Z 679
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2842718Z 680
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2842861Z 681
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2843004Z 682
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2843148Z 683
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2843294Z 684
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2843439Z 685
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2843587Z 686
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2843736Z 687
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2843877Z 688
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2844024Z 689
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2844170Z 690
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2844316Z 691
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2844461Z 692
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2844605Z 693
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2844748Z 694
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2844892Z 695
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2845040Z 696
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2845187Z 697
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2845329Z 698
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2845474Z 699
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2845618Z 700
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2845771Z 701
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2845913Z 702
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2846053Z 703
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2846196Z 704
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2846333Z 705
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2846474Z 706
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2846612Z 707
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2846751Z 708
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2846892Z 709
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2847033Z 710
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2847241Z 711
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2847502Z 712
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2847749Z 713
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2847997Z 714
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2848246Z 715
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2848489Z 716
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2848734Z 717
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2848994Z 718
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2849244Z 719
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2849494Z 720
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2849744Z 721
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2849985Z 722
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2850241Z 723
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2850865Z 724
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2851124Z 725
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2851384Z 726
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2851621Z 727
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2851834Z 728
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2852319Z 729
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2852563Z 730
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2852809Z 731
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2853055Z 732
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2853306Z 733
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2853549Z 734
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2853794Z 735
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2854045Z 736
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2854300Z 737
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2854546Z 738
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2854801Z 739
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2855055Z 740
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2855305Z 741
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2855555Z 742
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2855803Z 743
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2856063Z 744
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2856333Z 745
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2856597Z 746
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2856850Z 747
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2857109Z 748
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2857374Z 749
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2857627Z 750
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2857881Z 751
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2858243Z 752
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2858489Z 753
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2858729Z 754
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2858971Z 755
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2859193Z 756
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2859614Z 757
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2859854Z 758
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2860095Z 759
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2860334Z 760
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2860570Z 761
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2860812Z 762
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2861052Z 763
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2861293Z 764
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2861535Z 765
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2861781Z 766
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2862020Z 767
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2862255Z 768
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2862491Z 769
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2862736Z 770
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2862978Z 771
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2863214Z 772
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2863473Z 773
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2863742Z 774
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2864039Z 775
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2864199Z 776
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2864349Z 777
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2864494Z 778
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2864636Z 779
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2864776Z 780
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2864924Z 781
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2865073Z 782
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2865215Z 783
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2865363Z 784
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2865507Z 785
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2865652Z 786
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2865802Z 787
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2865945Z 788
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2866098Z 789
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2866238Z 790
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2866376Z 791
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2866515Z 792
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2866662Z 793
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2866803Z 794
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2866942Z 795
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2867083Z 796
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2867226Z 797
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2867381Z 798
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2867528Z 799
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2867674Z 800
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2867821Z 801
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2867969Z 802
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2868153Z 803
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2868429Z 804
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2868682Z 805
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2868925Z 806
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2869147Z 807
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2869403Z 808
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2869647Z 809
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2869896Z 810
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2870146Z 811
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2870393Z 812
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2871029Z 813
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2871317Z 814
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2871566Z 815
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2871812Z 816
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2872078Z 817
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2872321Z 818
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2872561Z 819
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2872811Z 820
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2873060Z 821
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2873327Z 822
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2873581Z 823
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2873832Z 824
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2874075Z 825
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2874327Z 826
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2874564Z 827
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2874809Z 828
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2875054Z 829
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2875306Z 830
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2875554Z 831
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2875814Z 832
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2876057Z 833
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2876313Z 834
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2876591Z 835
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2876858Z 836
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2877126Z 837
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2877383Z 838
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2877664Z 839
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2877953Z 840
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2878253Z 841
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2878545Z 842
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2878844Z 843
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2879144Z 844
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2879433Z 845
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2879713Z 846
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2879993Z 847
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2880272Z 848
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2880944Z 849
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2881235Z 850
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2881503Z 851
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2881765Z 852
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2882047Z 853
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2882314Z 854
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2882563Z 855
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2882809Z 856
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2883064Z 857
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2883331Z 858
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2883594Z 859
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2883859Z 860
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2884112Z 861
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2884366Z 862
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2884634Z 863
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2884891Z 864
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2885149Z 865
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2885403Z 866
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2885656Z 867
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2885915Z 868
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2886168Z 869
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2886428Z 870
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2886691Z 871
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2886944Z 872
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2887206Z 873
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2887468Z 874
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2887731Z 875
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2887985Z 876
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2888499Z 877
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2888777Z 878
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2889035Z 879
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2889264Z 880
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2889483Z 881
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2889713Z 882
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2889952Z 883
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2890186Z 884
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2890424Z 885
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2890665Z 886
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2891248Z 887
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2891500Z 888
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2891756Z 889
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2892002Z 890
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2892238Z 891
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2892521Z 892
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2892781Z 893
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2892975Z 894
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2893124Z 895
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2893266Z 896
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2893408Z 897
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2893558Z 898
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2893702Z 899
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2893842Z 900
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2893988Z 901
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2894124Z 902
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2894268Z 903
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2894410Z 904
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2894555Z 905
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2894701Z 906
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2894853Z 907
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2894997Z 908
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2895144Z 909
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2895288Z 910
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2895432Z 911
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2895578Z 912
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2895721Z 913
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2895861Z 914
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2896006Z 915
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2896147Z 916
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2896291Z 917
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2896432Z 918
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2896575Z 919
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2896720Z 920
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2896863Z 921
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2897009Z 922
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2897150Z 923
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2897293Z 924
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2897437Z 925
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2897583Z 926
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2897724Z 927
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2897867Z 928
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2898012Z 929
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2898156Z 930
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2898304Z 931
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2898453Z 932
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2898603Z 933
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2898751Z 934
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2898902Z 935
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2899052Z 936
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2899208Z 937
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2899353Z 938
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2899493Z 939
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2899640Z 940
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2899784Z 941
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2899931Z 942
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2900072Z 943
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2900214Z 944
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2900357Z 945
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2900500Z 946
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2900644Z 947
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2900786Z 948
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2900929Z 949
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2901071Z 950
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2901213Z 951
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2901356Z 952
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2901495Z 953
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2901633Z 954
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2901775Z 955
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2901914Z 956
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2902054Z 957
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2902197Z 958
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2902341Z 959
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2902486Z 960
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2902628Z 961
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2902780Z 962
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2902921Z 963
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2903061Z 964
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2903202Z 965
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2903345Z 966
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2903490Z 967
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2903633Z 968
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2903773Z 969
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2904103Z 970
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2904247Z 971
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2904387Z 972
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2904532Z 973
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2904676Z 974
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2904824Z 975
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2904973Z 976
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2905121Z 977
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2905272Z 978
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2905419Z 979
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2905561Z 980
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2905710Z 981
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2905855Z 982
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2905999Z 983
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2906144Z 984
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2906284Z 985
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2906425Z 986
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2906578Z 987
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2906720Z 988
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2906860Z 989
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2907002Z 990
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2907142Z 991
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2907289Z 992
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2907434Z 993
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2907578Z 994
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2907720Z 995
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2907864Z 996
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2908117Z 997
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2908265Z 998
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2908407Z 999
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.2908565Z 1000
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.3140487Z It's a 'test' with "quotes"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.3141788Z (pass) Synchronous Execution (.sync()) > Complex Scenarios > should handle commands with quotes and special characters [43.77ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.3846849Z error
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.3847038Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.4487858Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.4515190Z error
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.4542757Z (pass) Synchronous Execution (.sync()) > Comparison with Async > should produce same result as async version [140.06ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.4928259Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.4930860Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.4934897Z (pass) Synchronous Execution (.sync()) > Comparison with Async > should handle events differently than async [39.09ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.4935649Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.4936127Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.4936326Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.4936765Z ##[group]js\tests\system-pipe.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5327836Z (skip) System Command Piping (Issue #8) > Piping to jq > should pipe echo output to jq for JSON processing
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5329039Z (skip) System Command Piping (Issue #8) > Piping to jq > should extract specific field with jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5330051Z (skip) System Command Piping (Issue #8) > Piping to jq > should handle jq array operations
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5330980Z (skip) System Command Piping (Issue #8) > Piping to jq > should pipe cat output to jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5331968Z (skip) System Command Piping (Issue #8) > Piping to grep > should pipe to grep for pattern matching
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5332933Z (skip) System Command Piping (Issue #8) > Piping to grep > should handle grep with flags
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5334317Z (skip) System Command Piping (Issue #8) > Piping to sed > should pipe to sed for text substitution
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5335005Z (skip) System Command Piping (Issue #8) > Piping to sed > should handle sed with multiple operations
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5335672Z (skip) System Command Piping (Issue #8) > Piping to awk > should pipe to awk for field extraction
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5336287Z (skip) System Command Piping (Issue #8) > Piping to awk > should handle awk with calculations
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5336875Z (skip) System Command Piping (Issue #8) > Piping to wc > should pipe to wc for line counting
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5337480Z (skip) System Command Piping (Issue #8) > Piping to wc > should pipe to wc for word counting
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5338072Z (skip) System Command Piping (Issue #8) > Piping to cut > should pipe to cut for field extraction
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5338667Z (skip) System Command Piping (Issue #8) > Piping to cut > should handle cut with multiple fields
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5339250Z (skip) System Command Piping (Issue #8) > Piping to sort > should pipe to sort for sorting lines
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5340226Z (skip) System Command Piping (Issue #8) > Piping to sort > should handle sort with reverse flag
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5341951Z (skip) System Command Piping (Issue #8) > Piping to head/tail > should pipe to head for first lines
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5343552Z (skip) System Command Piping (Issue #8) > Piping to head/tail > should pipe to tail for last lines
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5344270Z (skip) System Command Piping (Issue #8) > Complex multi-pipe operations > should handle multiple system command pipes
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5345021Z (skip) System Command Piping (Issue #8) > Complex multi-pipe operations > should combine jq with other tools
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5345746Z (skip) System Command Piping (Issue #8) > Complex multi-pipe operations > should handle pipes with text processing chain
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5346203Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5346521Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5346881Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5347136Z ##[group]js\tests\text-method.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5747121Z sync test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.5748429Z (pass) .text() method for Bun.$ compatibility > sync execution should have .text() method [39.67ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.6089728Z async test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.6132507Z (pass) .text() method for Bun.$ compatibility > async execution should have .text() method [38.35ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.6526757Z hello world
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.6529269Z (pass) .text() method for Bun.$ compatibility > .text() should return stdout content (sync) [39.67ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.6871110Z hello async
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.6918448Z (pass) .text() method for Bun.$ compatibility > .text() should return stdout content (async) [38.82ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.7303922Z (pass) .text() method for Bun.$ compatibility > .text() should handle empty output [38.55ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.7723193Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.7723442Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.7723604Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.7772482Z (pass) .text() method for Bun.$ compatibility > .text() should handle multiline output [46.84ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.8191322Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.8191666Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.8191913Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.8238634Z (pass) .text() method for Bun.$ compatibility > .text() should work with built-in commands [46.59ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.9061022Z test content
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:15.9657783Z (pass) .text() method for Bun.$ compatibility > .text() should work with cat built-in command [141.83ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0096088Z $.features.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0096715Z $.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0097093Z array-interpolation.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0097575Z builtin-commands.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0098221Z bun-shell-path-fix.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0098837Z bun.features.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0099510Z cd-virtual-command.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0100140Z check-release-needed.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0100851Z cleanup-verification.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0111845Z ctrl-c-baseline.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0112162Z ctrl-c-basic.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0112452Z ctrl-c-library.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0112741Z ctrl-c-signal.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0113035Z cwd-cd-pattern-issue.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0113339Z examples.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0113635Z execa.features.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0114053Z getcwd-error-handling.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0114379Z gh-commands.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0114619Z gh-gist-operations.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0114858Z git-gh-cd.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0115067Z interactive-option.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0115301Z interactive-streaming.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0115538Z issue-135-final.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0115830Z jq-color-behavior.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0116194Z jq.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0116501Z options-examples.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0116874Z options-syntax.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0117236Z path-interpolation.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0117600Z pipe.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0117910Z publish-to-npm.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0118279Z quiet-method.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0118904Z raw-function.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0119263Z readme-examples.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0119648Z repository-layout.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0120051Z resource-cleanup-internals.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0120815Z setup-npm.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0121141Z shell-settings.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0121505Z sigint-cleanup-isolated.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0121906Z sigint-cleanup.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0122265Z start-run-edge-cases.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0122655Z start-run-options.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0123847Z stderr-output-handling.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0124993Z stream-exit-chunks.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0125638Z streaming-interfaces.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0126041Z sync.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0126636Z system-pipe.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0126866Z test-cleanup.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0127079Z test-helper-fixed.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0127302Z test-helper-v2.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0127502Z test-helper.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0127690Z test-sigint-child.js
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0127893Z text-method.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0128089Z virtual.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0128505Z wait-for-npm.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0128755Z yes-command-cleanup.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0128992Z zx.features.test.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0133205Z (pass) .text() method for Bun.$ compatibility > .text() should work with ls built-in command [47.59ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0486619Z /d/a/command-stream/command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.0507792Z (pass) .text() method for Bun.$ compatibility > .text() should work with pwd built-in command [37.39ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.1566030Z (pass) .text() method for Bun.$ compatibility > .text() should return empty string for commands with no stdout [105.72ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.1794170Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.1794407Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.1794571Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.1798064Z (pass) .text() method for Bun.$ compatibility > .text() should work with piped commands (when supported) [23.25ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.3298081Z ???
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.3786357Z (pass) .text() method for Bun.$ compatibility > .text() should work with complex pipeline (when supported) [198.72ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.4228298Z cat: nonexistent-file-text-test.txt: No such file or directory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.4253457Z (pass) .text() method for Bun.$ compatibility > .text() should handle commands with stderr but no stdout [46.72ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.4616332Z consistency test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.4644995Z (pass) .text() method for Bun.$ compatibility > .text() should be consistent with .stdout property [39.11ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.4980985Z multiple calls
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.5024049Z (pass) .text() method for Bun.$ compatibility > .text() can be called multiple times [37.88ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.5409394Z promise test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.5410194Z (pass) .text() method for Bun.$ compatibility > .text() returns a Promise [38.63ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.6877535Z content with special chars: üñíçødé 🚀
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.7391092Z (pass) .text() method for Bun.$ compatibility > .text() should work with binary-safe content [197.98ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.7730652Z pipe test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.8214532Z pipe test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.8265793Z (pass) .text() method for Bun.$ compatibility > .text() should work with .pipe() method results [87.45ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.8651073Z test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.8651976Z (pass) .text() method for Bun.$ compatibility > .text() method should be accessible [38.66ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9094317Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9094668Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9094920Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9095172Z 4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9095414Z 5
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9095657Z 6
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9095886Z 7
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9096140Z 8
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9096381Z 9
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9096626Z 10
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9096880Z 11
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9097131Z 12
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9097380Z 13
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9097635Z 14
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9097924Z 15
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9098135Z 16
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9098334Z 17
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9098593Z 18
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9099127Z 19
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9099382Z 20
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9099658Z 21
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9099891Z 22
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9100121Z 23
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9100718Z 24
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9100950Z 25
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9101184Z 26
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9101415Z 27
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9101650Z 28
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9101882Z 29
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9102116Z 30
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9102348Z 31
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9102581Z 32
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9102815Z 33
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9103054Z 34
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9103299Z 35
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9103530Z 36
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9103762Z 37
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9104002Z 38
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9104232Z 39
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9104459Z 40
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9104684Z 41
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9104927Z 42
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9105175Z 43
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9105411Z 44
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9105647Z 45
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9105885Z 46
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9106123Z 47
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9106361Z 48
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9106605Z 49
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9106879Z 50
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9107108Z 51
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9107584Z 52
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9107847Z 53
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9108094Z 54
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9108346Z 55
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9108748Z 56
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9108991Z 57
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9109229Z 58
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9109492Z 59
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9109744Z 60
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9110004Z 61
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9110261Z 62
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9110515Z 63
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9110784Z 64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9111052Z 65
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9111296Z 66
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9111552Z 67
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9111804Z 68
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9112067Z 69
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9112309Z 70
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9112575Z 71
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9113150Z 72
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9113402Z 73
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9113648Z 74
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9113900Z 75
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9114146Z 76
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9114387Z 77
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9114637Z 78
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9114873Z 79
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9115112Z 80
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9115360Z 81
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9115608Z 82
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9115867Z 83
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9116120Z 84
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9116367Z 85
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9116615Z 86
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9116854Z 87
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9117089Z 88
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9117340Z 89
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9117579Z 90
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9117828Z 91
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9118072Z 92
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9118310Z 93
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9118565Z 94
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9118804Z 95
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9119033Z 96
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9119271Z 97
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9119516Z 98
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9119751Z 99
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9119991Z 100
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9120240Z 101
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9120486Z 102
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9120716Z 103
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9120947Z 104
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9121187Z 105
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9121433Z 106
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9121688Z 107
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9121941Z 108
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9122187Z 109
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9122439Z 110
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9122705Z 111
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9122978Z 112
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9123231Z 113
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9123402Z 114
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9123556Z 115
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9123714Z 116
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9123864Z 117
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9124011Z 118
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9124162Z 119
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9124312Z 120
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9124456Z 121
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9124608Z 122
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9124751Z 123
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9124898Z 124
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9125046Z 125
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9125193Z 126
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9125341Z 127
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9125492Z 128
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9125638Z 129
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9125783Z 130
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9125929Z 131
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9126075Z 132
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9126223Z 133
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9126368Z 134
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9126516Z 135
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9126667Z 136
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9126814Z 137
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9127040Z 138
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9127317Z 139
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9127575Z 140
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9127827Z 141
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9128040Z 142
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9128300Z 143
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9128579Z 144
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9128739Z 145
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9129248Z 146
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9129403Z 147
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9129549Z 148
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9129697Z 149
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9129849Z 150
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9129997Z 151
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9130147Z 152
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9130727Z 153
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9130903Z 154
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9131054Z 155
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9131201Z 156
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9131358Z 157
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9131507Z 158
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9131661Z 159
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9131811Z 160
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9131960Z 161
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9132107Z 162
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9132254Z 163
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9132401Z 164
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9132549Z 165
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9132694Z 166
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9132840Z 167
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9132991Z 168
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9133145Z 169
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9133296Z 170
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9133440Z 171
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9133588Z 172
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9133733Z 173
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9134037Z 174
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9134194Z 175
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9134349Z 176
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9134503Z 177
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9134655Z 178
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9134800Z 179
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9134946Z 180
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9135093Z 181
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9135240Z 182
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9135392Z 183
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9135541Z 184
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9135689Z 185
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9135841Z 186
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9135986Z 187
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9136133Z 188
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9136281Z 189
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9136433Z 190
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9136588Z 191
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9136740Z 192
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9136892Z 193
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9137373Z 194
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9137699Z 195
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9137968Z 196
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9138219Z 197
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9138697Z 198
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9138877Z 199
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9139022Z 200
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9139164Z 201
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9139306Z 202
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9139447Z 203
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9139598Z 204
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9139739Z 205
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9139882Z 206
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9140030Z 207
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9140172Z 208
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9140312Z 209
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9140454Z 210
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9140596Z 211
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9140740Z 212
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9140887Z 213
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9141040Z 214
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9141180Z 215
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9141322Z 216
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9141464Z 217
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9141605Z 218
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9141743Z 219
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9141891Z 220
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9142030Z 221
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9142173Z 222
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9142311Z 223
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9142452Z 224
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9142598Z 225
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9142740Z 226
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9142878Z 227
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9143018Z 228
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9143157Z 229
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9143304Z 230
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9143449Z 231
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9143598Z 232
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9143741Z 233
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9143893Z 234
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9144069Z 235
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9144534Z 236
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9144776Z 237
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9145036Z 238
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9145289Z 239
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9145517Z 240
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9145743Z 241
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9145989Z 242
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9146203Z 243
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9146344Z 244
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9146481Z 245
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9146619Z 246
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9146766Z 247
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9146908Z 248
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9147051Z 249
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9147191Z 250
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9147329Z 251
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9147468Z 252
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9147608Z 253
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9147748Z 254
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9147884Z 255
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9148025Z 256
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9148173Z 257
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9148318Z 258
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9148458Z 259
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9148601Z 260
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9148742Z 261
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9148884Z 262
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9149024Z 263
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9149174Z 264
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9149316Z 265
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9149462Z 266
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9150663Z 267
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9150814Z 268
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9150961Z 269
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9151100Z 270
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9151244Z 271
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9151390Z 272
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9151537Z 273
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9151675Z 274
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9151819Z 275
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9151962Z 276
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9152101Z 277
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9152239Z 278
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9152381Z 279
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9152516Z 280
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9152657Z 281
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9152805Z 282
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9152945Z 283
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9153087Z 284
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9153230Z 285
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9153375Z 286
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9153522Z 287
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9153669Z 288
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9153823Z 289
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9153971Z 290
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9154113Z 291
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9154253Z 292
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9154395Z 293
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9154536Z 294
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9154819Z 295
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9154968Z 296
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9155114Z 297
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9155254Z 298
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9155394Z 299
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9155979Z 300
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9156136Z 301
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9156275Z 302
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9156414Z 303
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9156554Z 304
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9156757Z 305
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9156904Z 306
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9157052Z 307
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9157194Z 308
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9157332Z 309
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9157472Z 310
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9157617Z 311
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9157757Z 312
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9157897Z 313
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9158044Z 314
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9158189Z 315
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9158332Z 316
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9158475Z 317
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9158619Z 318
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9158765Z 319
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9158901Z 320
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9159041Z 321
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9159180Z 322
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9159317Z 323
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9159457Z 324
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9159605Z 325
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9159746Z 326
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9159887Z 327
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9160027Z 328
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9160165Z 329
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9160301Z 330
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9160440Z 331
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9160586Z 332
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9160723Z 333
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9160862Z 334
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9161004Z 335
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9161141Z 336
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9161280Z 337
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9161419Z 338
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9161560Z 339
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9161701Z 340
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9161847Z 341
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9161988Z 342
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9162126Z 343
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9162267Z 344
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9162407Z 345
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9162550Z 346
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9162690Z 347
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9162834Z 348
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9162971Z 349
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9163110Z 350
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9163252Z 351
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9163396Z 352
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9163540Z 353
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9163678Z 354
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9163826Z 355
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9163973Z 356
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9164125Z 357
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9164267Z 358
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9164407Z 359
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9164554Z 360
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9164696Z 361
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9164830Z 362
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9164980Z 363
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9165115Z 364
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9165254Z 365
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9165390Z 366
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9165526Z 367
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9165665Z 368
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9165805Z 369
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9165945Z 370
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9166084Z 371
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9166223Z 372
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9166361Z 373
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9166506Z 374
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9166647Z 375
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9166791Z 376
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9166932Z 377
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9167080Z 378
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9167221Z 379
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9167359Z 380
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9167503Z 381
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9167642Z 382
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9167781Z 383
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9167920Z 384
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9168070Z 385
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9168215Z 386
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9168530Z 387
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9168673Z 388
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9168821Z 389
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9168961Z 390
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9169103Z 391
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9169240Z 392
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9169383Z 393
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9169523Z 394
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9169663Z 395
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9169801Z 396
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9169939Z 397
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9170082Z 398
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9170225Z 399
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9170369Z 400
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9170512Z 401
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9170669Z 402
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9170813Z 403
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9170954Z 404
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9171097Z 405
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9171236Z 406
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9171378Z 407
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9171525Z 408
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9171667Z 409
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9171809Z 410
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9171951Z 411
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9172092Z 412
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9172229Z 413
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9172367Z 414
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9172617Z 415
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9172763Z 416
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9172905Z 417
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9173045Z 418
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9173185Z 419
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9173324Z 420
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9173460Z 421
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9173599Z 422
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9173738Z 423
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9173876Z 424
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9174012Z 425
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9174153Z 426
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9174300Z 427
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9174445Z 428
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9174584Z 429
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9174728Z 430
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9174869Z 431
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9175007Z 432
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9175145Z 433
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9175283Z 434
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9175423Z 435
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9175561Z 436
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9175989Z 437
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9176197Z 438
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9176344Z 439
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9176487Z 440
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9176628Z 441
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9176768Z 442
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9176908Z 443
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9177053Z 444
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9177202Z 445
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9177347Z 446
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9177493Z 447
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9177633Z 448
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9177777Z 449
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9177920Z 450
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9178060Z 451
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9178208Z 452
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9178353Z 453
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9178495Z 454
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9178634Z 455
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9178767Z 456
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9178904Z 457
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9179039Z 458
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9179174Z 459
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9179311Z 460
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9179447Z 461
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9179585Z 462
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9179720Z 463
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9179858Z 464
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9179997Z 465
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9180135Z 466
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9180273Z 467
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9180410Z 468
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9180552Z 469
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9180688Z 470
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9180827Z 471
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9180964Z 472
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9181107Z 473
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9181248Z 474
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9181389Z 475
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9181531Z 476
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9181679Z 477
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9181821Z 478
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9181961Z 479
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9182101Z 480
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9182239Z 481
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9182378Z 482
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9182516Z 483
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9182657Z 484
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9182795Z 485
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9182938Z 486
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9183080Z 487
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9183222Z 488
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9183364Z 489
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9183503Z 490
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9183643Z 491
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9183787Z 492
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9183930Z 493
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9184073Z 494
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9184212Z 495
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9184357Z 496
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9184495Z 497
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9184638Z 498
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9184776Z 499
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9184916Z 500
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9185055Z 501
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9185199Z 502
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9185336Z 503
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9185474Z 504
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9185615Z 505
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9185754Z 506
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9185893Z 507
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9186151Z 508
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9186294Z 509
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9186431Z 510
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9186569Z 511
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9186708Z 512
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9186848Z 513
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9186989Z 514
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9187127Z 515
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9187265Z 516
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9187404Z 517
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9187542Z 518
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9187681Z 519
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9187819Z 520
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9187960Z 521
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9188099Z 522
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9188238Z 523
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9188380Z 524
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9188519Z 525
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9188658Z 526
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9188803Z 527
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9188946Z 528
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9189095Z 529
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9189235Z 530
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9189376Z 531
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9189518Z 532
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9189659Z 533
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9189798Z 534
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9189938Z 535
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9190184Z 536
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9190331Z 537
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9190477Z 538
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9190618Z 539
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9190759Z 540
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9190896Z 541
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9191038Z 542
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9191175Z 543
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9191311Z 544
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9191449Z 545
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9191588Z 546
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9191729Z 547
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9191864Z 548
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9192003Z 549
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9192143Z 550
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9192280Z 551
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9192425Z 552
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9192565Z 553
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9192704Z 554
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9192840Z 555
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9192979Z 556
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9193118Z 557
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9193256Z 558
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9193395Z 559
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9193533Z 560
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9193674Z 561
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9193812Z 562
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9193952Z 563
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9194099Z 564
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9194242Z 565
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9194385Z 566
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9194528Z 567
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9194671Z 568
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9194811Z 569
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9194961Z 570
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9195105Z 571
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9195247Z 572
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9195388Z 573
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9195531Z 574
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9195671Z 575
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9195812Z 576
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9196275Z 577
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9196428Z 578
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9196571Z 579
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9196712Z 580
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9196850Z 581
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9196990Z 582
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9197125Z 583
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9197271Z 584
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9197407Z 585
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9197546Z 586
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9197685Z 587
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9197828Z 588
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9208577Z 589
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9208782Z 590
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9208937Z 591
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9209085Z 592
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9209240Z 593
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9209389Z 594
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9209532Z 595
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9209687Z 596
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9209831Z 597
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9209987Z 598
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9210130Z 599
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9210271Z 600
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9210410Z 601
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9210552Z 602
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9210699Z 603
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9210841Z 604
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9210984Z 605
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9211136Z 606
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9211278Z 607
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9211421Z 608
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9211563Z 609
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9211706Z 610
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9211846Z 611
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9211988Z 612
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9212130Z 613
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9212276Z 614
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9212417Z 615
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9212557Z 616
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9212698Z 617
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9212843Z 618
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9212990Z 619
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9213130Z 620
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9213273Z 621
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9213415Z 622
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9213560Z 623
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9213704Z 624
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9213846Z 625
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9213993Z 626
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9214136Z 627
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9214559Z 628
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9214702Z 629
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9214843Z 630
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9214989Z 631
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9215134Z 632
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9215282Z 633
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9215424Z 634
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9215567Z 635
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9215714Z 636
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9215856Z 637
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9215993Z 638
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9216514Z 639
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9216681Z 640
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9216837Z 641
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9216981Z 642
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9217127Z 643
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9217267Z 644
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9217409Z 645
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9217551Z 646
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9217691Z 647
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9217837Z 648
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9217980Z 649
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9218116Z 650
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9218255Z 651
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9218397Z 652
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9218544Z 653
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9218687Z 654
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9218828Z 655
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9219961Z 656
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9220146Z 657
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9220304Z 658
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9220449Z 659
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9220597Z 660
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9220740Z 661
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9220884Z 662
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9221028Z 663
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9221166Z 664
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9221308Z 665
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9221447Z 666
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9221581Z 667
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9221716Z 668
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9221852Z 669
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9221994Z 670
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9222130Z 671
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9222264Z 672
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9222410Z 673
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9222545Z 674
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9222688Z 675
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9222831Z 676
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9222973Z 677
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9223121Z 678
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9223264Z 679
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9223404Z 680
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9223551Z 681
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9223694Z 682
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9223836Z 683
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9223980Z 684
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9224122Z 685
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9224271Z 686
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9224409Z 687
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9224555Z 688
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9224700Z 689
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9224841Z 690
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9224982Z 691
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9225122Z 692
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9225262Z 693
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9225403Z 694
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9225543Z 695
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9225690Z 696
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9225832Z 697
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9225972Z 698
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9226113Z 699
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9226256Z 700
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9226397Z 701
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9226537Z 702
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9226677Z 703
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9226818Z 704
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9226963Z 705
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9227112Z 706
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9227255Z 707
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9227396Z 708
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9227540Z 709
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9227680Z 710
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9227823Z 711
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9227964Z 712
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9228104Z 713
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9228246Z 714
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9228386Z 715
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9228537Z 716
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9228685Z 717
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9228827Z 718
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9228973Z 719
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9229114Z 720
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9229255Z 721
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9229401Z 722
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9229543Z 723
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9229686Z 724
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9229832Z 725
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9229971Z 726
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9230110Z 727
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9230252Z 728
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9230393Z 729
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9230539Z 730
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9230687Z 731
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9230828Z 732
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9230966Z 733
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9231113Z 734
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9231255Z 735
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9231403Z 736
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9231544Z 737
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9231689Z 738
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9231834Z 739
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9231980Z 740
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9232128Z 741
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9232270Z 742
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9232415Z 743
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9232567Z 744
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9232709Z 745
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9232858Z 746
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9232998Z 747
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9233140Z 748
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9233412Z 749
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9233551Z 750
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9233692Z 751
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9233836Z 752
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9233979Z 753
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9234121Z 754
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9234262Z 755
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9234403Z 756
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9234544Z 757
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9234685Z 758
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9234828Z 759
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9234970Z 760
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9235112Z 761
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9235252Z 762
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9235393Z 763
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9235538Z 764
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9235679Z 765
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9235818Z 766
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9235957Z 767
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9236103Z 768
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9236251Z 769
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9236657Z 770
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9236799Z 771
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9236939Z 772
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9237083Z 773
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9237226Z 774
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9237364Z 775
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9237612Z 776
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9237764Z 777
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9237909Z 778
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9238061Z 779
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9238204Z 780
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9238347Z 781
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9238491Z 782
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9238637Z 783
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9238778Z 784
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9238923Z 785
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9239065Z 786
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9239204Z 787
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9239344Z 788
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9239487Z 789
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9239627Z 790
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9239768Z 791
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9239908Z 792
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9240050Z 793
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9240199Z 794
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9240341Z 795
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9240482Z 796
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9240627Z 797
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9240767Z 798
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9240914Z 799
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9241059Z 800
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9241207Z 801
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9241381Z 802
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9241646Z 803
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9241869Z 804
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9242018Z 805
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9242158Z 806
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9242312Z 807
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9242452Z 808
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9242602Z 809
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9242744Z 810
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9242884Z 811
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9243025Z 812
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9243164Z 813
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9243305Z 814
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9243445Z 815
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9243585Z 816
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9243732Z 817
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9243873Z 818
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9244031Z 819
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9244175Z 820
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9244318Z 821
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9244465Z 822
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9244607Z 823
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9244751Z 824
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9244899Z 825
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9245040Z 826
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9245183Z 827
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9245329Z 828
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9245471Z 829
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9245612Z 830
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9245754Z 831
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9245899Z 832
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9246041Z 833
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9246182Z 834
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9246322Z 835
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9246465Z 836
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9246615Z 837
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9246758Z 838
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9246903Z 839
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9247049Z 840
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9247193Z 841
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9247336Z 842
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9247479Z 843
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9247631Z 844
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9247773Z 845
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9247921Z 846
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9248061Z 847
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9248203Z 848
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9248349Z 849
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9248490Z 850
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9248634Z 851
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9248775Z 852
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9248915Z 853
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9249059Z 854
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9249200Z 855
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9249340Z 856
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9249484Z 857
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9249625Z 858
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9249768Z 859
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9249912Z 860
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9250061Z 861
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9250206Z 862
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9250349Z 863
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9250491Z 864
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9250635Z 865
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9250779Z 866
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9250924Z 867
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9251071Z 868
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9251364Z 869
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9251507Z 870
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9251653Z 871
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9251792Z 872
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9251929Z 873
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9252069Z 874
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9252209Z 875
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9252352Z 876
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9252492Z 877
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9252635Z 878
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9252774Z 879
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9252914Z 880
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9253055Z 881
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9253195Z 882
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9253336Z 883
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9253478Z 884
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9253629Z 885
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9253766Z 886
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9253907Z 887
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9254046Z 888
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9254188Z 889
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9254332Z 890
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9254474Z 891
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9254614Z 892
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9254759Z 893
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9254901Z 894
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9255047Z 895
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9255189Z 896
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9255426Z 897
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9255574Z 898
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9255719Z 899
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9255856Z 900
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9255996Z 901
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9256134Z 902
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9256275Z 903
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9256413Z 904
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9256557Z 905
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9256760Z 906
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9256898Z 907
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9257039Z 908
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9257177Z 909
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9257316Z 910
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9257453Z 911
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9257594Z 912
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9257730Z 913
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9257868Z 914
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9258005Z 915
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9258145Z 916
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9258284Z 917
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9258422Z 918
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9258559Z 919
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9258700Z 920
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9258836Z 921
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9258976Z 922
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9259116Z 923
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9259256Z 924
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9259399Z 925
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9259540Z 926
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9259686Z 927
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9259827Z 928
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9259969Z 929
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9260111Z 930
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9260262Z 931
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9260405Z 932
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9260548Z 933
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9260688Z 934
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9260834Z 935
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9260973Z 936
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9261115Z 937
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9261258Z 938
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9261398Z 939
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9261907Z 940
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9262071Z 941
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9262213Z 942
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9262351Z 943
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9262499Z 944
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9262643Z 945
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9262777Z 946
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9262916Z 947
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9263056Z 948
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9263195Z 949
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9263332Z 950
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9263469Z 951
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9263606Z 952
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9263746Z 953
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9263883Z 954
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9264024Z 955
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9264169Z 956
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9264314Z 957
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9264453Z 958
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9264602Z 959
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9264744Z 960
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9264880Z 961
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9265018Z 962
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9265158Z 963
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9265295Z 964
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9265431Z 965
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9265569Z 966
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9265708Z 967
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9265848Z 968
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9265986Z 969
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9266123Z 970
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9266261Z 971
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9266398Z 972
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9266539Z 973
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9266681Z 974
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9266821Z 975
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9266961Z 976
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9267106Z 977
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9267245Z 978
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9267385Z 979
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9267528Z 980
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9267675Z 981
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9267820Z 982
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9267965Z 983
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9268105Z 984
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9268242Z 985
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9268382Z 986
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9268523Z 987
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9268661Z 988
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9268796Z 989
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9269079Z 990
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9269217Z 991
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9269354Z 992
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9269490Z 993
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9269625Z 994
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9269764Z 995
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9269902Z 996
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9270040Z 997
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9270184Z 998
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9270320Z 999
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9270464Z 1000
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9270935Z (pass) .text() method for Bun.$ compatibility > .text() should handle very large output efficiently [47.50ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9271350Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9271673Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9271786Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9272023Z ##[group]js\tests\virtual.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9307845Z Hello, Alice!
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9329345Z (pass) Virtual Commands System > Registration API > should register and execute custom virtual command [16.86ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9910898Z /usr/bin/bash: line 1: temp: command not found
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9947020Z (pass) Virtual Commands System > Registration API > should unregister commands [61.74ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9984591Z (pass) Virtual Commands System > Registration API > should list registered commands [3.70ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:16.9985702Z (skip) Virtual Commands System > Built-in Commands > should execute virtual cd command
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.0112802Z D:\a\command-stream\command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.0243725Z (pass) Virtual Commands System > Built-in Commands > should execute virtual pwd command [25.87ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.0281377Z Hello World
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.0402048Z (pass) Virtual Commands System > Built-in Commands > should execute virtual echo command [15.79ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.0560477Z (pass) Virtual Commands System > Built-in Commands > should execute echo with -n flag [15.78ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.1826526Z (pass) Virtual Commands System > Built-in Commands > should execute virtual sleep command [126.53ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2142664Z (pass) Virtual Commands System > Built-in Commands > should execute virtual true command [31.66ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2460827Z (pass) Virtual Commands System > Built-in Commands > should execute virtual false command [31.67ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2503561Z Helloecho: shell builtin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2618142Z (pass) Virtual Commands System > Built-in Commands > should execute virtual which command [15.79ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2797136Z Command failed with exit code 42(pass) Virtual Commands System > Built-in Commands > should execute virtual exit command [17.85ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2944198Z NODE_ENV=test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2945001Z ACTIONS_ORCHESTRATION_ID=83071e28-8147-4891-b1ba-6e3465de357c.test.windows-latest_bun
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2945920Z ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE=C:\actionarchivecache\
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2946538Z ACTIONS_RUNNER_RETURN_JOB_RESULT_FOR_HOSTED=1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2947064Z AGENT_TOOLSDIRECTORY=C:\hostedtoolcache\windows
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2947465Z ALLUSERSPROFILE=C:\ProgramData
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2947771Z ANDROID_HOME=C:\Android\android-sdk
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2948153Z ANDROID_NDK=C:\Android\android-sdk\ndk\27.3.13750724
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2948554Z ANDROID_NDK_HOME=C:\Android\android-sdk\ndk\27.3.13750724
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2948945Z ANDROID_NDK_LATEST_HOME=C:\Android\android-sdk\ndk\29.0.14206865
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2949338Z ANDROID_NDK_ROOT=C:\Android\android-sdk\ndk\27.3.13750724
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2949655Z ANDROID_SDK_ROOT=C:\Android\android-sdk
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2950005Z ANT_HOME=C:\ProgramData\chocolatey\lib\ant\tools\apache-ant-1.10.17
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2950389Z APPDATA=C:\Users\runneradmin\AppData\Roaming
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2950673Z AZURE_CONFIG_DIR=C:\azureCli
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2950929Z AZURE_DEVOPS_CACHE_DIR=C:\azureDevOpsCli\cache
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2951347Z AZURE_EXTENSION_DIR=C:\Program Files\Common Files\AzureCliExtensionDirectory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2951763Z AZ_DEVOPS_GLOBAL_CONFIG_DIR=C:\azureDevOpsCli
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2952037Z CABAL_DIR=C:\cabal
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2952263Z ChocolateyInstall=C:\ProgramData\chocolatey
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2953000Z ChromeWebDriver=C:\SeleniumWebDrivers\ChromeDriver
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2953682Z COBERTURA_HOME=C:\cobertura-2.1.1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2953971Z CommonProgramFiles=C:\Program Files\Common Files
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2954334Z CommonProgramFiles(x86)=C:\Program Files (x86)\Common Files
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2954692Z CommonProgramW6432=C:\Program Files\Common Files
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2954989Z COMPUTERNAME=runnervmebrks
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2955216Z ComSpec=C:\Windows\system32\cmd.exe
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2955453Z CONDA=C:\Miniconda
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2955646Z DOTNET_MULTILEVEL_LOOKUP=0
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2955855Z DOTNET_NOLOGO=1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2956050Z DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2956328Z DriverData=C:\Windows\System32\Drivers\DriverData
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2956645Z EdgeWebDriver=C:\SeleniumWebDrivers\EdgeDriver
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2957089Z ENABLE_RUNNER_TRACING=true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2957313Z GCM_INTERACTIVE=Never
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2957555Z GeckoWebDriver=C:\SeleniumWebDrivers\GeckoDriver
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2957845Z GHCUP_INSTALL_BASE_PREFIX=C:\
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2958063Z GHCUP_MSYS2=C:\msys64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2958254Z GITHUB_ACTION=__run_5
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2958447Z GITHUB_ACTIONS=true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2958628Z GITHUB_ACTION_REF=
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2958824Z GITHUB_ACTION_REPOSITORY=
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2959026Z GITHUB_ACTOR=konard
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2959208Z GITHUB_ACTOR_ID=1431904
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2959438Z GITHUB_API_URL=https://api.github.com
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2959686Z GITHUB_BASE_REF=
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2960018Z GITHUB_ENV=D:\a\_temp\_runner_file_commands\set_env_02eb0990-9eff-4c0d-a838-d0952230b1c1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2960423Z GITHUB_EVENT_NAME=push
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2960678Z GITHUB_EVENT_PATH=D:\a\_temp\_github_workflow\event.json
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2961021Z GITHUB_GRAPHQL_URL=https://api.github.com/graphql
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2961302Z GITHUB_HEAD_REF=
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2961481Z GITHUB_JOB=test
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2961829Z GITHUB_OUTPUT=D:\a\_temp\_runner_file_commands\set_output_02eb0990-9eff-4c0d-a838-d0952230b1c1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2962387Z GITHUB_PATH=D:\a\_temp\_runner_file_commands\add_path_02eb0990-9eff-4c0d-a838-d0952230b1c1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2962786Z GITHUB_REF=refs/heads/main
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2962990Z GITHUB_REF_NAME=main
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2963182Z GITHUB_REF_PROTECTED=false
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2963387Z GITHUB_REF_TYPE=branch
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2963618Z GITHUB_REPOSITORY=link-foundation/command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2963901Z GITHUB_REPOSITORY_ID=1036989446
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2964140Z GITHUB_REPOSITORY_OWNER=link-foundation
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2964397Z GITHUB_REPOSITORY_OWNER_ID=176174013
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2964639Z GITHUB_RETENTION_DAYS=90
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2964840Z GITHUB_RUN_ATTEMPT=1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2965028Z GITHUB_RUN_ID=27310950658
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2965232Z GITHUB_RUN_NUMBER=48
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2965437Z GITHUB_SERVER_URL=https://github.com
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2965722Z GITHUB_SHA=fe8aae79cc1bdf829528257e76194fd9f03d5a4e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2966158Z GITHUB_STATE=D:\a\_temp\_runner_file_commands\save_state_02eb0990-9eff-4c0d-a838-d0952230b1c1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2966757Z GITHUB_STEP_SUMMARY=D:\a\_temp\_runner_file_commands\step_summary_02eb0990-9eff-4c0d-a838-d0952230b1c1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2967204Z GITHUB_TRIGGERING_ACTOR=konard
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2967452Z GITHUB_WORKFLOW=JavaScript checks and release
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2967893Z GITHUB_WORKFLOW_REF=link-foundation/command-stream/.github/workflows/js.yml@refs/heads/main
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2968391Z GITHUB_WORKFLOW_SHA=fe8aae79cc1bdf829528257e76194fd9f03d5a4e
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2968743Z GITHUB_WORKSPACE=D:\a\command-stream\command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2969086Z GOROOT_1_22_X64=C:\hostedtoolcache\windows\go\1.22.12\x64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2969425Z GOROOT_1_23_X64=C:\hostedtoolcache\windows\go\1.23.12\x64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2969758Z GOROOT_1_24_X64=C:\hostedtoolcache\windows\go\1.24.13\x64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2970196Z GOROOT_1_25_X64=C:\hostedtoolcache\windows\go\1.25.10\x64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2970571Z GRADLE_HOME=C:\ProgramData\chocolatey\lib\gradle\tools\gradle-9.5.1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2970900Z HOMEDRIVE=C:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2971083Z HOMEPATH=\Users\runneradmin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2971320Z IEWebDriver=C:\SeleniumWebDrivers\IEDriver
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2971580Z ImageOS=win25-vs2026
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2971780Z ImageVersion=20260525.121.1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2972107Z JAVA_HOME=C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\17.0.19-10\x64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2972602Z JAVA_HOME_11_X64=C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\11.0.31-11\x64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2973107Z JAVA_HOME_17_X64=C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\17.0.19-10\x64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2974097Z JAVA_HOME_21_X64=C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\21.0.11-10.0\x64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2974745Z JAVA_HOME_25_X64=C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\25.0.3-9.0\x64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2975267Z JAVA_HOME_8_X64=C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\8.0.492-9\x64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2975695Z LOCALAPPDATA=C:\Users\runneradmin\AppData\Local
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2975978Z LOGONSERVER=\\runnervmebrks
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2976274Z M2=C:\ProgramData\chocolatey\lib\maven\apache-maven-3.9.16\bin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2976599Z M2_REPO=C:\ProgramData\m2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2976839Z MAVEN_OPTS=-Xms256m
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2977036Z npm_config_prefix=C:\npm\prefix
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2977262Z NUMBER_OF_PROCESSORS=4
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2977460Z OS=Windows_NT
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2986206Z Path=C:\Program Files\PowerShell\7;C:\Users\runneradmin\.bun\bin;C:\Program Files\MongoDB\Server\7.0\bin;C:\vcpkg;C:\tools\zstd;C:\hostedtoolcache\windows\stack\3.9.3\x64;C:\cabal\bin;C:\\ghcup\bin;C:\mingw64\bin;C:\Program Files\dotnet;C:\Program Files\MySQL\MySQL Server 8.0\bin;C:\Program Files\R\R-4.6.0\bin\x64;C:\SeleniumWebDrivers\GeckoDriver;C:\SeleniumWebDrivers\EdgeDriver\;C:\SeleniumWebDrivers\ChromeDriver;C:\Program Files (x86)\sbt\bin;C:\Program Files (x86)\GitHub CLI;C:\Program Files\Git\bin;C:\Program Files (x86)\pipx_bin;C:\npm\prefix;C:\hostedtoolcache\windows\go\1.24.13\x64\bin;C:\hostedtoolcache\windows\Python\3.12.10\x64\Scripts;C:\hostedtoolcache\windows\Python\3.12.10\x64;C:\hostedtoolcache\windows\Ruby\3.3.11\x64\bin;C:\Program Files\OpenSSL\bin;C:\tools\kotlinc\bin;C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\17.0.19-10\x64\bin;C:\Program Files\ImageMagick-7.1.2-Q16-HDRI;C:\Program Files\Microsoft SDKs\Azure\CLI2\wbin;C:\ProgramData\kind;C:\ProgramData\Chocolatey\bin;C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\Windows\System32\OpenSSH\;C:\Program Files\PowerShell\7\;C:\Program Files\Microsoft\Web Platform Installer\;C:\Program Files\Microsoft SQL Server\170\Tools\Binn\;C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\170\Tools\Binn\;C:\Program Files\dotnet\;C:\Program Files (x86)\Windows Kits\10\Windows Performance Toolkit\;C:\Program Files (x86)\WiX Toolset v3.14\bin;C:\Program Files\Microsoft SQL Server\130\DTS\Binn\;C:\Program Files\Microsoft SQL Server\140\DTS\Binn\;C:\Program Files\Microsoft SQL Server\150\DTS\Binn\;C:\Program Files\Microsoft SQL Server\160\DTS\Binn\;C:\Program Files\Microsoft SQL Server\170\DTS\Binn\;C:\ProgramData\chocolatey\lib\pulumi\tools\Pulumi\bin;C:\Program Files\CMake\bin;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\ProgramData\chocolatey\lib\maven\apache-maven-3.9.16\bin;C:\Program Files\Microsoft Service Fabric\bin\Fabric\Fabric.Code;C:\Program Files\Microsoft SDKs\Service Fabric\Tools\ServiceFabricLocalClusterManager;C:\Program Files\nodejs\;C:\Program Files\Git\cmd;C:\Program Files\Git\mingw64\bin;C:\Program Files\Git\usr\bin;C:\Program Files\GitHub CLI\;c:\tools\php;C:\Program Files (x86)\sbt\bin;C:\Program Files\Amazon\AWSCLIV2\;C:\Program Files\Amazon\SessionManagerPlugin\bin\;C:\Program Files\Amazon\AWSSAMCLI\bin\;C:\Program Files\Microsoft SQL Server\130\Tools\Binn\;C:\Program Files\mongosh\;C:\Program Files\LLVM\bin;C:\Program Files (x86)\LLVM\bin;C:\Users\runneradmin\.dotnet\tools;C:\Users\runneradmin\.cargo\bin;C:\Users\runneradmin\AppData\Local\Microsoft\WindowsApps
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2995641Z PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2995998Z PGBIN=C:\Program Files\PostgreSQL\17\bin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2996282Z PGDATA=C:\PostgreSQL\17\data
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2996508Z PGPASSWORD=root
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2996715Z PGROOT=C:\Program Files\PostgreSQL\17
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2996965Z PGUSER=postgres
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2997157Z PHPROOT=c:\tools\php
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2997380Z PIPX_BIN_DIR=C:\Program Files (x86)\pipx_bin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2997667Z PIPX_HOME=C:\Program Files (x86)\pipx
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2997987Z POWERSHELL_DISTRIBUTION_CHANNEL=GitHub-Actions-win25-vs2026
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2998430Z POWERSHELL_UPDATECHECK=Off
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2998676Z PROCESSOR_ARCHITECTURE=AMD64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2999002Z PROCESSOR_IDENTIFIER=AMD64 Family 25 Model 1 Stepping 1, AuthenticAMD
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2999344Z PROCESSOR_LEVEL=25
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2999532Z PROCESSOR_REVISION=0101
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2999739Z ProgramData=C:\ProgramData
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.2999954Z ProgramFiles=C:\Program Files
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3000189Z ProgramFiles(x86)=C:\Program Files (x86)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3000443Z ProgramW6432=C:\Program Files
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3000801Z PSModuleAnalysisCachePath=C:\PSModuleAnalysisCachePath\ModuleAnalysisCache
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3002328Z PSModulePath=C:\Users\runneradmin\Documents\PowerShell\Modules;C:\Program Files\PowerShell\Modules;c:\program files\powershell\7\Modules;C:\\Modules\az_14.6.0;C:\Users\packer\Documents\WindowsPowerShell\Modules;C:\Program Files\WindowsPowerShell\Modules;C:\Windows\system32\WindowsPowerShell\v1.0\Modules;C:\Program Files\Microsoft SQL Server\130\Tools\PowerShell\Modules\
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3003693Z PUBLIC=C:\Users\Public
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3003902Z RTOOLS45_HOME=C:\rtools45
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3004100Z RUNNER_ARCH=X64
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3004292Z RUNNER_ENVIRONMENT=github-hosted
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3004531Z RUNNER_NAME=GitHub Actions 1000034376
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3004760Z RUNNER_OS=Windows
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3004944Z RUNNER_TEMP=D:\a\_temp
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3005165Z RUNNER_TOOL_CACHE=C:\hostedtoolcache\windows
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3005494Z RUNNER_TRACKING_ID=github_0ae37879-4601-4363-9773-6e4dbeec9eff
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3005817Z RUNNER_WORKSPACE=D:\a\command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3006066Z SBT_HOME=C:\Program Files (x86)\sbt\
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3006341Z SELENIUM_JAR_PATH=C:\selenium\selenium-server.jar
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3006624Z SystemDrive=C:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3006804Z SystemRoot=C:\Windows
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3007019Z TEMP=C:\Users\RUNNER~1\AppData\Local\Temp
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3007290Z TMP=C:\Users\RUNNER~1\AppData\Local\Temp
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3007544Z USERDOMAIN=runnervmebrks
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3007774Z USERDOMAIN_ROAMINGPROFILE=runnervmebrks
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3008022Z USERNAME=runneradmin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3008237Z USERPROFILE=C:\Users\runneradmin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3008474Z VCPKG_INSTALLATION_ROOT=C:\vcpkg
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3008694Z windir=C:\Windows
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3008905Z WIX=C:\Program Files (x86)\WiX Toolset v3.14\
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3009251Z OLDPWD=C:\Users\RUNNER~1\AppData\Local\Temp\cleanup-test5-4Y2z1J
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3010195Z ***
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3010362Z CI=true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3092676Z (pass) Virtual Commands System > Built-in Commands > should execute virtual env command [29.57ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3409714Z (pass) Virtual Commands System > Built-in Commands > should execute virtual test command [31.66ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.3575648Z virtual ls output
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4020980Z LICENSE
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4021450Z README.md
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4022032Z claude-profile-list.sh
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4022726Z claude-profile-restore.sh
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4023491Z claude-profile-save.sh
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4023853Z claude-profiles.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4024153Z docs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4024413Z experiments
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4024700Z gitpod-backup-auth.sh
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4025031Z gitpod-restore-auth.sh
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4025371Z js
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4025623Z rust
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4064533Z (pass) Virtual Commands System > Virtual vs System Commands > should prioritize virtual commands over system commands [65.45ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4697287Z Wed Jun 10 22:41:17 CUT 2026
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4740630Z (pass) Virtual Commands System > Virtual vs System Commands > should fall back to system commands when virtual not found [67.60ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.4766657Z 1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.5013438Z 2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.5174658Z 3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.5354595Z (pass) Virtual Commands System > Streaming Virtual Commands > should support async generator virtual commands [61.18ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.5479412Z chunk1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.5480773Z chunk2
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.5631763Z (pass) Virtual Commands System > Streaming Virtual Commands > should handle events with streaming virtual commands [27.71ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.5829433Z Virtual command failed(pass) Virtual Commands System > Error Handling > should handle virtual command errors [19.86ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6107749Z FailedFailedFailed(pass) Virtual Commands System > Error Handling > should respect errexit setting with virtual commands [27.77ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6268857Z Args: [one, two three, four]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6282711Z (pass) Virtual Commands System > Command Arguments and Stdin > should pass arguments correctly to virtual commands [17.54ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6432374Z Received: test input
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6432604Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6581715Z (pass) Virtual Commands System > Command Arguments and Stdin > should pass stdin to virtual commands [29.80ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6901010Z (pass) Virtual Commands System > Shell Settings Integration > should respect verbose setting for virtual commands [31.73ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6978640Z (pass) Virtual Commands System > Shell Settings Integration > should respect xtrace setting for virtual commands [7.81ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6979624Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6980198Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6980398Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.6980880Z ##[group]js\tests\wait-for-npm.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.7116244Z (pass) returns true as soon as the version is visible [1.84ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.7117051Z (pass) polls until the version appears, then succeeds [0.18ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.7119163Z (pass) returns false after exhausting all attempts [0.16ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.7120504Z (pass) awaits async availability checks [0.12ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.7120989Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.7121714Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.7121853Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.7122164Z ##[group]js\tests\yes-command-cleanup.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.8185592Z (pass) Yes Command Cleanup Tests > should stop yes command when breaking from async iteration [103.99ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.8717960Z (pass) Yes Command Cleanup Tests > should stop yes command when killed explicitly [53.19ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.9777243Z (pass) Yes Command Cleanup Tests > should stop yes command on timeout [105.90ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.9812136Z (pass) Yes Command Cleanup Tests > should stop yes when error occurs in handler [3.50ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:17.9821162Z (pass) Yes Command Cleanup Tests > should handle multiple yes commands without interference [0.91ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.2779586Z outputoutputCOUNT:3
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.2781295Z FINISHED:true
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.6199141Z (pass) Yes Command Cleanup Tests > should cleanup yes command in subprocess [637.69ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7364506Z (pass) Yes Command Cleanup Tests > critical: yes must stop within reasonable time when cancelled [116.48ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7365073Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7365607Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7365742Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7366044Z ##[group]js\tests\zx.features.test.mjs:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7389137Z (pass) zx Feature Validation (Conceptual) > Runtime Support > should work in Node.js runtime [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7390513Z (pass) zx Feature Validation (Conceptual) > Runtime Support > should NOT work natively in Bun without compatibility [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7391793Z (pass) zx Feature Validation (Conceptual) > Template Literals > should support $`cmd` syntax [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7392982Z (pass) zx Feature Validation (Conceptual) > Template Literals > should support variable interpolation [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7394225Z (pass) zx Feature Validation (Conceptual) > Real-time Streaming > should NOT provide real-time streaming (buffers only) [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7395584Z (pass) zx Feature Validation (Conceptual) > Real-time Streaming > should return complete buffered output [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7397262Z (pass) zx Feature Validation (Conceptual) > Async Iteration > should NOT support for await iteration [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7398466Z (pass) zx Feature Validation (Conceptual) > EventEmitter Pattern > should NOT support .on() events [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7399389Z (pass) zx Feature Validation (Conceptual) > Mixed Patterns > should NOT support events + await (only await) [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7400289Z (pass) zx Feature Validation (Conceptual) > Shell Injection Protection > should be safe by default [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7401225Z (pass) zx Feature Validation (Conceptual) > Cross-platform Support > should work cross-platform [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7402108Z (pass) zx Feature Validation (Conceptual) > Performance > should have slow performance [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7412832Z (pass) zx Feature Validation (Conceptual) > Memory Efficiency > should buffer in memory [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7414093Z (pass) zx Feature Validation (Conceptual) > Error Handling > should throw exception on error [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7415188Z (pass) zx Feature Validation (Conceptual) > Error Handling > should support nothrow mode [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7416275Z (pass) zx Feature Validation (Conceptual) > Stdin Support > should support basic stdin [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7417382Z (pass) zx Feature Validation (Conceptual) > Built-in Commands > should NOT have built-in commands [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7420176Z (pass) zx Feature Validation (Conceptual) > Bundle Size > should have ~50KB bundle size [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7421880Z (pass) zx Feature Validation (Conceptual) > TypeScript Support > should have full TypeScript support [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7423247Z (pass) zx Feature Validation (Conceptual) > Shell Scripting Features > should support convenient shell scripting helpers [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7424068Z (pass) zx Feature Validation (Conceptual) > Shell Scripting Features > should support colorful output [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7424827Z (pass) zx Feature Validation (Conceptual) > Shell Scripting Features > should support file system utilities [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7425605Z (pass) zx Feature Validation (Conceptual) > Developer Experience > should have excellent DX for shell scripts [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7426372Z (pass) zx Feature Validation (Conceptual) > Developer Experience > should support shebang for executable scripts [0.02ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7427124Z (pass) zx Feature Validation (Conceptual) > Execution Model > should use system shell for all commands [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7427822Z (pass) zx Feature Validation (Conceptual) > Execution Model > should support shell-specific features [0.03ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7428221Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7428533Z ##[endgroup]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7428702Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7428785Z 185 tests skipped:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7429037Z (skip) ProcessRunner Options > should handle cwd option
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7429588Z (skip) Built-in Commands (Bun.$ compatible) > Command Location (which) > which should find existing system commands
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7430244Z (skip) String interpolation fix for Bun > Template literal without interpolation should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7431900Z (skip) String interpolation fix for Bun > String interpolation with complete command should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7432545Z (skip) String interpolation fix for Bun > String interpolation with command and args should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7433150Z (skip) String interpolation fix for Bun > Mixed template literal with interpolation should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7433874Z (skip) String interpolation fix for Bun > Complex shell commands via interpolation should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7434460Z (skip) String interpolation fix for Bun > Shell operators in interpolated commands should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7435020Z (skip) String interpolation fix for Bun > Commands with special characters should work
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7435824Z (skip) String interpolation fix for Bun > Multiple argument interpolation should still quote properly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7436434Z (skip) String interpolation fix for Bun > Empty command string should not cause issues
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7437023Z (skip) String interpolation fix for Bun > Command with unsafe characters should be handled correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7437585Z (skip) Bun-specific shell path tests > Bun.spawn compatibility is maintained
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7438087Z (skip) Bun-specific shell path tests > Bun runtime detection works correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7438567Z (skip) cd Virtual Command - Core Behavior > should change to absolute path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7439030Z (skip) cd Virtual Command - Core Behavior > should change to relative path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7439535Z (skip) cd Virtual Command - Core Behavior > should handle cd with no arguments (go to home)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7440107Z (skip) cd Virtual Command - Core Behavior > should handle cd - (return to previous directory)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7440662Z (skip) cd Virtual Command - Core Behavior > should handle cd .. (parent directory)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7441166Z (skip) cd Virtual Command - Core Behavior > should handle cd . (current directory)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7441672Z (skip) cd Virtual Command - Core Behavior > should fail with non-existent directory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7442159Z (skip) cd Virtual Command - Core Behavior > should handle paths with spaces
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7443006Z (skip) cd Virtual Command - Core Behavior > should handle special characters in paths
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7443584Z (skip) cd Virtual Command - Command Chains > should persist directory change within command chain
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7444163Z (skip) cd Virtual Command - Command Chains > should handle multiple cd commands in chain
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7444697Z (skip) cd Virtual Command - Command Chains > should work with git commands in chain
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7445328Z (skip) cd Virtual Command - Command Chains > should maintain separate directory context per command when not chained
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7446011Z (skip) cd Virtual Command - Subshell Behavior > should not affect parent shell when in subshell
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7446597Z (skip) cd Virtual Command - Subshell Behavior > should work in subshell with other commands
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7447075Z (skip) cd Virtual Command - Edge Cases > should handle symlinks
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7447480Z (skip) cd Virtual Command - Edge Cases > should handle very long paths
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7447946Z (skip) cd Virtual Command - Edge Cases > should handle permission errors gracefully
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7448436Z (skip) cd Virtual Command - Edge Cases > should handle cd with trailing slash
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7448910Z (skip) cd Virtual Command - Edge Cases > should handle cd with multiple slashes
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7449477Z (skip) cd Virtual Command - Platform Compatibility > should handle platform-specific path separators
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7450076Z (skip) cd Virtual Command - Platform Compatibility > should normalize paths correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7450580Z (skip) Cleanup Verification > should not affect cwd when cd is in subshell
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7451249Z (skip) CTRL+C Baseline Tests (Native Spawn) > should handle SIGINT with simple shell command
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7451838Z (skip) CTRL+C Baseline Tests (Native Spawn) > should handle Node.js inline script with SIGINT
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7452380Z (skip) CTRL+C Baseline Tests (Native Spawn) > should handle Node.js script file
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7452866Z (skip) CTRL+C Basic Handling > should be able to kill a long-running process
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7453347Z (skip) CTRL+C Basic Handling > should spawn processes with detached flag on Unix
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7453824Z (skip) CTRL+C Basic Handling > should handle CTRL+C character in raw mode
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7454306Z (skip) CTRL+C Virtual Commands > should cancel virtual command with AbortController
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7454774Z (skip) CTRL+C Virtual Commands > should cancel virtual async generator
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7455335Z (skip) CTRL+C Different stdin Modes > should handle CTRL+C with string stdin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7455803Z (skip) CTRL+C Different stdin Modes > should handle CTRL+C with Buffer stdin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7456268Z (skip) CTRL+C Different stdin Modes > should handle CTRL+C with ignore stdin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7456722Z (skip) CTRL+C Pipeline Interruption > should interrupt simple pipeline
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7457185Z (skip) CTRL+C Process Groups > should handle process group termination on Unix
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7457719Z (skip) CTRL+C Library Tests (command-stream) > should handle command cancellation with kill()
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7458387Z (skip) CTRL+C Library Tests (command-stream) > should test our library via external script - SKIP: uses test-sleep.mjs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7459042Z (skip) CTRL+C Library Tests (command-stream) > should handle virtual command cancellation
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7459586Z (skip) CTRL+C Signal Handling > BASELINE: should handle SIGINT with plain shell command
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7460163Z (skip) CTRL+C Signal Handling > should forward SIGINT to child process when external CTRL+C is sent
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7460801Z (skip) CTRL+C Signal Handling > should not interfere with user SIGINT handling when no children active
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7461384Z (skip) CTRL+C Signal Handling > should handle SIGINT in long-running commands via API
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7461935Z (skip) CTRL+C Signal Handling > should handle multiple concurrent processes receiving signals
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7462514Z (skip) CTRL+C Signal Handling > should properly handle signals in external process with sleep
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7463412Z (skip) CTRL+C Signal Handling > should not interfere with child process signal handlers
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7463943Z (skip) CTRL+C with Different stdin Modes > should handle kill regardless of stdin mode
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7464527Z (skip) CTRL+C with Different stdin Modes > should properly clean up stdin forwarding on external SIGINT
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7465194Z (skip) CTRL+C with Different stdin Modes > should handle parent stream closure triggering process cleanup
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7465905Z (skip) CTRL+C with Different stdin Modes > should bypass virtual commands with custom stdin for proper signal handling
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7466566Z (skip) CTRL+C with Different stdin Modes > should handle Bun vs Node.js signal differences
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7467272Z (skip) CTRL+C with Different stdin Modes > should properly cancel virtual commands and respect user SIGINT handlers (regression test)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7468012Z (skip) Issue #50: CWD with CD pattern failure > should handle separate cd and pwd commands correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7468576Z (skip) Issue #50: CWD with CD pattern failure > should handle cd && pwd pattern correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7469132Z (skip) Issue #50: CWD with CD pattern failure > should handle git scenario from issue description
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7469780Z (skip) Issue #50: CWD with CD pattern failure > should maintain directory changes across multiple shell operations
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7470443Z (skip) Issue #50: CWD with CD pattern failure > should handle complex build scenario with cd pattern
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7471144Z (skip) Issue #50: CWD with CD pattern failure > should work with relative paths after cd
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7471701Z (skip) Issue #50: CWD with CD pattern failure > should handle cwd option vs cd command consistency
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7472247Z (skip) Issue #50: CWD with CD pattern failure > should handle error cases correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7472845Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd with no argument goes to $HOME (like sh)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7473557Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd ~ expands tilde to $HOME (like sh)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7474286Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd ~/subpath expands tilde prefix (like sh)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7475183Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd - switches to previous directory and prints it (like sh)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7475998Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd updates PWD and OLDPWD environment variables (like sh)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7476844Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > cd to a non-existent directory reports a sh-style error and keeps cwd
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7477639Z (skip) Issue #50: cd sh-compatibility (drop-in translation from sh) > relative cd resolves against the cwd option
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7478342Z (skip) Examples Execution Tests > readme-example.mjs should execute and demonstrate new API signature
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7478954Z (skip) Examples Execution Tests > simple-jq-streaming.mjs should complete successfully
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7479569Z (skip) Examples Execution Tests > should not interfere with user SIGINT handling when no children active
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7480197Z (skip) getcwd() error handling > subshell runs even when the real working directory was deleted
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7480787Z (skip) GitHub CLI (gh) commands > gh auth status returns correct exit code and output structure
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7481369Z (skip) GitHub CLI (gh) commands > gh command with invalid subcommand returns non-zero exit code
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7481881Z (skip) GitHub CLI (gh) commands > gh api can be called with parameters
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7482309Z (skip) GitHub CLI (gh) commands > gh gist list works with parameters
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7482734Z (skip) GitHub CLI (gh) commands > complex gh command with pipes and jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7483632Z (skip) GitHub Gist Operations with $.mjs > gh gist edit should add files to existing gist
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7484383Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should initialize git repo after cd to temp directory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7485310Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should handle git commands in temp directory with cd chain
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7486220Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should create and commit files in temp git repo
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7487068Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should handle git branch operations with cd
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7487907Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should handle multiple temp directories with cd
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7488742Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should handle git diff operations after cd
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7489535Z (skip) Git and GH commands with cd virtual command > Git operations in temp directories > should work with git in subshells
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7490260Z (skip) Git and GH commands with cd virtual command > GH CLI operations with cd > should check gh auth status
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7490999Z (skip) Git and GH commands with cd virtual command > GH CLI operations with cd > should handle gh api calls with cd to temp directory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7491900Z (skip) Git and GH commands with cd virtual command > GH CLI operations with cd > should simulate gh repo clone pattern
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7492663Z (skip) Git and GH commands with cd virtual command > GH CLI operations with cd > should handle gh commands with directory context
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7493448Z (skip) Git and GH commands with cd virtual command > Combined git and gh workflows > should simulate solve.mjs workflow pattern
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7494241Z (skip) Git and GH commands with cd virtual command > Combined git and gh workflows > should handle error scenarios with cd and git
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7495029Z (skip) Git and GH commands with cd virtual command > Combined git and gh workflows > should preserve cwd after command chains
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7495929Z (skip) Git and GH commands with cd virtual command > Combined git and gh workflows > should work with complex git workflows using operators
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7496816Z (skip) Git and GH commands with cd virtual command > Path resolution and quoting with cd > should handle paths with spaces in git operations
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7497668Z (skip) Git and GH commands with cd virtual command > Path resolution and quoting with cd > should handle special characters in paths
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7498283Z (skip) jq streaming tests > stream of JSON objects through jq -c
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7498715Z (skip) jq streaming tests > stream JSON objects with filtering through jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7499153Z (skip) jq streaming tests > generate JSON stream using echo in loop
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7501380Z (skip) jq streaming tests > transform JSON stream with jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7502094Z (skip) jq streaming tests > generate and process array elements as stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7502872Z (skip) jq streaming tests > combine multiple JSON sources into stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7503743Z (skip) jq streaming with pipe | syntax > stream of JSON objects through jq -c using pipe syntax
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7504766Z (skip) jq streaming with pipe | syntax > stream JSON with filtering using pipe syntax
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7505664Z (skip) jq streaming with pipe | syntax > transform JSON stream with jq using pipe syntax
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7506598Z (skip) jq streaming with pipe | syntax > process array elements as stream using pipe syntax
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7507427Z (skip) jq streaming with pipe | syntax > multi-pipe JSON processing
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7508184Z (skip) jq streaming with pipe | syntax > complex JSON stream manipulation with pipes
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7509098Z (skip) realtime JSON streaming with delays > stream JSON with random delays between outputs
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7510102Z (skip) realtime JSON streaming with delays > stream JSON with fixed delays using printf and sleep
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7511099Z (skip) realtime JSON streaming with delays > simulate server logs with delayed JSON output
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7512088Z (skip) realtime JSON streaming with delays > process streaming metrics with delays and aggregation
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7513028Z (skip) realtime JSON streaming with delays > handle burst then delay pattern
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7513835Z (skip) realtime JSON streaming with delays > stream with varying delay intervals
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7514687Z (skip) realtime JSON streaming with delays > verify immediate streaming output from jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7515589Z (skip) Options Examples (Feature Demo) > example: real shell command vs virtual command
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7516816Z (skip) Shell Settings (set -e / set +e equivalent) > Shell Replacement Benefits > should allow JavaScript control flow with shell semantics
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7518022Z (skip) SIGINT Cleanup Tests (Isolated) > should properly manage SIGINT handlers
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7518866Z (skip) SIGINT Cleanup Tests (Isolated) > should forward SIGINT to child processes
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7520053Z (skip) SIGINT Cleanup Tests (Isolated) > should cleanup all resources properly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7520924Z (skip) SIGINT Cleanup Tests (Isolated) > should not interfere with user SIGINT handlers
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7523847Z (skip) SIGINT Handler Cleanup Tests > should remove SIGINT handler when all ProcessRunners finish
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7524998Z (skip) SIGINT Handler Cleanup Tests > should not interfere with user SIGINT handlers after commands finish
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7526149Z (skip) SIGINT Handler Cleanup Tests > should maintain SIGINT handler while commands are active
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7527183Z (skip) SIGINT Handler Cleanup Tests > should handle multiple concurrent ProcessRunners correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7528327Z (skip) Start/Run Edge Cases and Advanced Usage > should work with real shell commands that produce large output
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7529476Z (skip) Start/Run Options Passing > .start() method with options > should work with real shell commands
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7530736Z (skip) Stderr output handling in $.mjs > commands that output to stderr should not hang when captured
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7531816Z (skip) Stderr output handling in $.mjs > gh commands with progress output to stderr should complete
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7532852Z (skip) Stderr output handling in $.mjs > capturing with 2>&1 should combine stderr into stdout
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7533832Z (skip) Stderr output handling in $.mjs > long-running commands with stderr output should not hang
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7534891Z (skip) Stderr output handling in $.mjs > gh gist create with stderr progress should work correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7535845Z (skip) Stderr output handling in $.mjs > streaming mode should handle stderr correctly
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7536766Z (skip) Stderr output handling in $.mjs > timeout should work even with pending stderr
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7537507Z (skip) stream() exit chunk reports a non-zero exit code
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7538120Z (skip) stream() does not hang when a grandchild keeps stdout open
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7538869Z (skip) await on a command does not hang when a grandchild keeps stdout open
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7539856Z (skip) stream() can be stopped from inside the loop with kill()
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7540509Z (skip) breaking out of the stream() loop stops the process
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7541179Z (skip) kill() honors the configured killSignal option (SIGINT => 130)
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7541905Z (skip) an explicit kill(signal) overrides the configured killSignal
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7542607Z (skip) breaking out of the loop uses the configured killSignal
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7543332Z (skip) an external AbortSignal stops an awaited command and honors killSignal
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7544015Z (skip) streaming interfaces - basic functionality
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7544579Z (skip) streaming interfaces - buffers interface
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7545122Z (skip) streaming interfaces - mixed stdout/stderr
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7545649Z (skip) streaming interfaces - kill method works
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7546313Z (skip) streaming interfaces - stdin control with cross-platform command
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7546952Z (skip) streaming interfaces - stdin pipe mode works
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7547529Z (skip) streaming interfaces - grep filtering via stdin
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7548303Z (skip) Synchronous Execution (.sync()) > Options in Sync Mode > should handle cwd option
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7549343Z (skip) System Command Piping (Issue #8) > Piping to jq > should pipe echo output to jq for JSON processing
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7550391Z (skip) System Command Piping (Issue #8) > Piping to jq > should extract specific field with jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7551359Z (skip) System Command Piping (Issue #8) > Piping to jq > should handle jq array operations
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7552299Z (skip) System Command Piping (Issue #8) > Piping to jq > should pipe cat output to jq
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7553233Z (skip) System Command Piping (Issue #8) > Piping to grep > should pipe to grep for pattern matching
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7554253Z (skip) System Command Piping (Issue #8) > Piping to grep > should handle grep with flags
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7555228Z (skip) System Command Piping (Issue #8) > Piping to sed > should pipe to sed for text substitution
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7556667Z (skip) System Command Piping (Issue #8) > Piping to sed > should handle sed with multiple operations
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7557715Z (skip) System Command Piping (Issue #8) > Piping to awk > should pipe to awk for field extraction
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7558679Z (skip) System Command Piping (Issue #8) > Piping to awk > should handle awk with calculations
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7559939Z (skip) System Command Piping (Issue #8) > Piping to wc > should pipe to wc for line counting
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7560911Z (skip) System Command Piping (Issue #8) > Piping to wc > should pipe to wc for word counting
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7561908Z (skip) System Command Piping (Issue #8) > Piping to cut > should pipe to cut for field extraction
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7563082Z (skip) System Command Piping (Issue #8) > Piping to cut > should handle cut with multiple fields
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7564086Z (skip) System Command Piping (Issue #8) > Piping to sort > should pipe to sort for sorting lines
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7565083Z (skip) System Command Piping (Issue #8) > Piping to sort > should handle sort with reverse flag
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7566116Z (skip) System Command Piping (Issue #8) > Piping to head/tail > should pipe to head for first lines
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7567147Z (skip) System Command Piping (Issue #8) > Piping to head/tail > should pipe to tail for last lines
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7568307Z (skip) System Command Piping (Issue #8) > Complex multi-pipe operations > should handle multiple system command pipes
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7569558Z (skip) System Command Piping (Issue #8) > Complex multi-pipe operations > should combine jq with other tools
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7570808Z (skip) System Command Piping (Issue #8) > Complex multi-pipe operations > should handle pipes with text processing chain
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7571983Z (skip) Virtual Commands System > Built-in Commands > should execute virtual cd command
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7572498Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7572504Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7572617Z 1 tests failed:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7573488Z (fail) Shell Settings (set -e / set +e equivalent) > Shell Replacement Benefits > should provide better error objects than bash [63.04ms]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7574350Z 
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7574467Z  571 pass
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7574736Z  185 skip
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7575001Z  1 fail
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7575273Z  1191 expect() calls
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.7575588Z Ran 757 tests across 51 files. [19.45s]
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.8594031Z ##[error]Process completed with exit code 1.
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:18.8852455Z Post job cleanup.
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:19.0810843Z [command]"C:\Program Files\Git\bin\git.exe" version
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:19.1120983Z git version 2.54.0.windows.1
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:19.1206888Z Temporarily overriding HOME='D:\a\_temp\a97b5240-a435-456a-ba8a-916ff01d844d' before making global git config changes
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:19.1208240Z Adding repository directory to the temporary git global config as a safe directory
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:19.1219130Z [command]"C:\Program Files\Git\bin\git.exe" config --global --add safe.directory D:\a\command-stream\command-stream
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:19.1575080Z Removing SSH command configuration
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:19.1587016Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp core\.sshCommand
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:19.1965455Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :\""
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:19.7887564Z Removing HTTP extra header
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:19.7897818Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:19.8246805Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "sh -c \"git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :\""
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.4220325Z Removing includeIf entries pointing to credentials config files
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.4233863Z [command]"C:\Program Files\Git\bin\git.exe" config --local --name-only --get-regexp ^includeIf\.gitdir:
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.4531312Z includeif.gitdir:D:/a/command-stream/command-stream/.git.path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.4532001Z includeif.gitdir:D:/a/command-stream/command-stream/.git/worktrees/*.path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.4532570Z includeif.gitdir:/github/workspace/.git.path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.4533062Z includeif.gitdir:/github/workspace/.git/worktrees/*.path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.4581214Z [command]"C:\Program Files\Git\bin\git.exe" config --local --get-all includeif.gitdir:D:/a/command-stream/command-stream/.git.path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.4868365Z D:\a\_temp\git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.4921585Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset includeif.gitdir:D:/a/command-stream/command-stream/.git.path D:\a\_temp\git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.5264720Z [command]"C:\Program Files\Git\bin\git.exe" config --local --get-all includeif.gitdir:D:/a/command-stream/command-stream/.git/worktrees/*.path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.5561346Z D:\a\_temp\git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.5613711Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset includeif.gitdir:D:/a/command-stream/command-stream/.git/worktrees/*.path D:\a\_temp\git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.5959817Z [command]"C:\Program Files\Git\bin\git.exe" config --local --get-all includeif.gitdir:/github/workspace/.git.path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.6249044Z /github/runner_temp/git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.6296673Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset includeif.gitdir:/github/workspace/.git.path /github/runner_temp/git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.6658319Z [command]"C:\Program Files\Git\bin\git.exe" config --local --get-all includeif.gitdir:/github/workspace/.git/worktrees/*.path
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.6953120Z /github/runner_temp/git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.7005184Z [command]"C:\Program Files\Git\bin\git.exe" config --local --unset includeif.gitdir:/github/workspace/.git/worktrees/*.path /github/runner_temp/git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:20.7347540Z [command]"C:\Program Files\Git\bin\git.exe" submodule foreach --recursive "git config --local --show-origin --name-only --get-regexp remote.origin.url"
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:21.3572536Z Removing credentials config 'D:\a\_temp\git-credentials-c73bc05f-3aa6-4587-8a7b-759514ec5640.config'
+Test JavaScript (bun on windows-latest)	UNKNOWN STEP	2026-06-10T22:41:21.3795489Z Cleaning up orphan processes

--- a/docs/case-studies/issue-170/template-workflows/js/example-app.yml
+++ b/docs/case-studies/issue-170/template-workflows/js/example-app.yml
@@ -1,0 +1,296 @@
+name: Example app
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'examples/universal-app/**'
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/update-preview-images.mjs'
+      - '.github/workflows/example-app.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'examples/universal-app/**'
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/update-preview-images.mjs'
+      - '.github/workflows/example-app.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  web-build:
+    name: Build web app
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: npm
+          cache-dependency-path: examples/universal-app/package-lock.json
+
+      - name: Configure GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v6
+
+      - name: Install app dependencies
+        run: npm ci --prefix examples/universal-app
+
+      - name: Build app
+        run: npm run example:web:build
+        env:
+          GITHUB_PAGES: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          VITE_REPOSITORY_URL: https://github.com/${{ github.repository }}
+
+      - name: Upload web build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: universal-example-web
+          path: examples/universal-app/dist
+          if-no-files-found: error
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: examples/universal-app/dist
+
+  # Requires Settings → Pages → Source = GitHub Actions to be set once
+  # in the repository before this job can succeed. See README → "Deploying
+  # the example app". The Pages source cannot be configured from a workflow.
+  pages-deploy:
+    name: Deploy GitHub Pages
+    needs: [web-build]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@v5
+
+  desktop-package:
+    name: Package desktop app (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          # Electron Forge packaging currently exits before writing out/ under
+          # Node 24 in CI. Use the package's supported Node 20 floor here until
+          # the desktop packaging toolchain is compatible with Node 24.
+          node-version: '20.x'
+          cache: npm
+          cache-dependency-path: examples/universal-app/package-lock.json
+
+      - name: Install app dependencies
+        run: npm ci --prefix examples/universal-app
+
+      - name: Package Electron app
+        shell: bash
+        run: |
+          npm run example:desktop:package
+          for attempt in {1..30}; do
+            if [[ -d examples/universal-app/out ]] &&
+              [[ -n "$(find examples/universal-app/out -mindepth 1 -print -quit)" ]]; then
+              find examples/universal-app/out -maxdepth 2 -mindepth 1 -print
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Desktop package output was not created at examples/universal-app/out"
+          exit 1
+        env:
+          VITE_REPOSITORY_URL: https://github.com/${{ github.repository }}
+
+      - name: Upload desktop package
+        uses: actions/upload-artifact@v7
+        with:
+          name: universal-example-desktop-${{ matrix.os }}
+          path: examples/universal-app/out
+          if-no-files-found: error
+
+  android-build:
+    name: Build Android app
+    if: github.event_name == 'workflow_dispatch' && vars.EXAMPLE_APP_ENABLE_ANDROID_BUILD == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: npm
+          cache-dependency-path: examples/universal-app/package-lock.json
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install app dependencies
+        run: npm ci --prefix examples/universal-app
+
+      - name: Add Android project
+        run: npm --prefix examples/universal-app run mobile:android:add
+
+      - name: Build Android project
+        run: npm --prefix examples/universal-app run mobile:android:build
+
+      - name: Upload Android output
+        uses: actions/upload-artifact@v7
+        with:
+          name: universal-example-android
+          path: |
+            examples/universal-app/android/app/build/outputs/**/*.apk
+            examples/universal-app/android/app/build/outputs/**/*.aab
+          if-no-files-found: warn
+
+  ios-build:
+    name: Build iOS app
+    if: github.event_name == 'workflow_dispatch' && vars.EXAMPLE_APP_ENABLE_IOS_BUILD == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          cache: npm
+          cache-dependency-path: examples/universal-app/package-lock.json
+
+      - name: Install app dependencies
+        run: npm ci --prefix examples/universal-app
+
+      - name: Add iOS project
+        run: npm --prefix examples/universal-app run mobile:ios:add
+
+      - name: Build iOS project
+        run: npm --prefix examples/universal-app run mobile:ios:build
+
+  # Regenerate example-app preview screenshots (docs/screenshots/example-app/*)
+  # using browser-commander + Playwright so README/site images always reflect
+  # the current UI. Issue: #62. Implementation: scripts/update-preview-images.mjs.
+  preview-regen:
+    name: Regenerate Preview Images
+    runs-on: ubuntu-latest
+    container:
+      # Keep this tag in sync with the playwright package version below.
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
+    timeout-minutes: 20
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: write
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Regenerate against main HEAD so the bot commit lands on a
+          # fast-forward parent regardless of which trigger started the job.
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Install example app dependencies
+        run: npm ci --prefix examples/universal-app
+
+      - name: Install browser automation dependencies
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+        run: npm install --no-save --package-lock=false --no-audit --no-fund browser-commander@0.8.1 playwright@1.59.1
+
+      - name: Regenerate preview images
+        run: node scripts/update-preview-images.mjs
+
+      - name: Detect drift
+        id: drift
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            echo "Preview images drifted:"
+            git status --porcelain
+          else
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "Preview images already current."
+          fi
+
+      - name: Commit drift back to main
+        if: steps.drift.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # Stage only generated artifacts so unrelated changes can't leak in.
+          git add docs/screenshots/example-app/*.png || true
+          if git diff --cached --quiet; then
+            echo "::notice::No tracked preview-image changes to commit (drift was outside expected paths)."
+            git status --porcelain
+            exit 0
+          fi
+          # [skip ci] prevents an infinite re-run loop; the next push to main
+          # will pick up these fresh images for the regular pages-build.
+          git commit -m "chore(preview): regenerate example-app preview images [skip ci]"
+          git push origin HEAD:main
+
+      - name: Upload screenshot failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: preview-regen-failure-${{ github.run_id }}
+          path: |
+            docs/screenshots/
+            web/test-results/
+            web/playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Summarize regeneration result
+        if: always()
+        run: |
+          if [[ "${{ steps.drift.outputs.drift }}" == "true" ]]; then
+            echo "::notice::Preview images regenerated and (if applicable) committed to main."
+          else
+            echo "::notice::Preview images are already up to date."
+          fi

--- a/docs/case-studies/issue-170/template-workflows/js/links.yml
+++ b/docs/case-studies/issue-170/template-workflows/js/links.yml
@@ -1,0 +1,93 @@
+name: Broken Link Checker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**.md'
+      - '**.html'
+      - '.github/workflows/links.yml'
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**.md'
+      - '**.html'
+      - '.github/workflows/links.yml'
+  workflow_dispatch:
+
+# Concurrency: Only one workflow run per branch at a time
+# - For main branch: let runs finish so a newer push does not cancel an
+#   in-flight link check.
+# - For PR branches: cancel older runs so new pushes supersede stale checks.
+# See: docs/case-studies/issue-25/DETAILED-COMPARISON.md for context
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  link-checker:
+    name: Check Links
+    runs-on: ubuntu-latest
+    # Typical run: <1min with lychee cache. 10min prevents slow
+    # external hosts or Wayback Machine probes from hanging the workflow.
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check links with lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          # Check all Markdown and HTML files
+          # Exclude case-studies directory - these are research documents from
+          # external repos with references to files and issues that don't exist
+          # in this repository (similar exclusion pattern as eslint.config.js)
+          args: >-
+            --verbose
+            --no-progress
+            --cache
+            --max-cache-age 1d
+            --max-retries 3
+            --timeout 30
+            --exclude-path docs/case-studies
+            './**/*.md'
+            './**/*.html'
+          # Don't fail the workflow immediately - we want to check web archive first
+          fail: false
+          # Output file for broken links report (used by check-web-archive.mjs)
+          output: lychee/out.md
+          # Write a job summary
+          jobSummary: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check broken links against Web Archive
+        if: steps.lychee.outputs.exit_code != 0
+        id: webarchive
+        run: node scripts/check-web-archive.mjs
+        env:
+          LYCHEE_OUTPUT: lychee/out.md
+
+      - name: Fail if broken links found and no web archive fallback
+        if: steps.lychee.outputs.exit_code != 0 && steps.webarchive.outputs.all_archived != 'true'
+        run: |
+          echo "::error::Broken links were detected with no Web Archive fallback available."
+          echo ""
+          echo "What happened:"
+          echo "  lychee found one or more broken links in the *.md and *.html files of this repository."
+          echo "  The Web Archive (Wayback Machine) check found no archived versions for some of them."
+          echo ""
+          echo "How to fix:"
+          echo "  1. Review the 'Check links with lychee' step above for a full list of broken links."
+          echo "  2. For links marked with a '::notice::' annotation above, a Web Archive version exists."
+          echo "     Replace those broken links with the suggested archive.org URL."
+          echo "  3. For links with no archive version, either:"
+          echo "     a. Find an updated URL that points to the same or equivalent content."
+          echo "     b. Remove the link if the content is no longer relevant."
+          echo "     c. Add the URL to .lycheeignore if it is a known false positive."
+          echo ""
+          echo "Report location: lychee/out.md (available as a workflow artifact if configured)."
+          exit 1

--- a/docs/case-studies/issue-170/template-workflows/js/release.yml
+++ b/docs/case-studies/issue-170/template-workflows/js/release.yml
@@ -1,0 +1,600 @@
+name: Checks and release
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+  # Manual release support - consolidated here to work with npm trusted publishing
+  # npm only allows ONE workflow file as trusted publisher, so all publishing
+  # must go through this workflow (release.yml)
+  workflow_dispatch:
+    inputs:
+      release_mode:
+        description: 'Manual release mode'
+        required: true
+        type: choice
+        default: 'instant'
+        options:
+          - instant
+          - changeset-pr
+      bump_type:
+        description: 'Manual release type'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      description:
+        description: 'Manual release description (optional)'
+        required: false
+        type: string
+
+# Concurrency: Only one workflow run per branch at a time
+# - For main branch (releases): let runs finish so a newer push does not cancel
+#   an in-flight publish or release update.
+# - For PR branches: cancel older runs so new pushes supersede stale checks.
+# See: docs/case-studies/issue-25/DETAILED-COMPARISON.md for context
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  # === DETECT CHANGES - determines which jobs should run ===
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    # Typical run: ~6s. Cap at 5min so a hung detection step
+    # surfaces quickly instead of stalling the whole pipeline.
+    timeout-minutes: 5
+    if: github.event_name != 'workflow_dispatch'
+    outputs:
+      mjs-changed: ${{ steps.changes.outputs.mjs-changed }}
+      js-changed: ${{ steps.changes.outputs.js-changed }}
+      package-changed: ${{ steps.changes.outputs.package-changed }}
+      docs-changed: ${{ steps.changes.outputs.docs-changed }}
+      workflow-changed: ${{ steps.changes.outputs.workflow-changed }}
+      any-code-changed: ${{ steps.changes.outputs.any-code-changed }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: changes
+        run: node scripts/detect-code-changes.mjs
+
+  # === FAST CHECKS - run before slow tests for fastest feedback ===
+  # See: hive-mind CI/CD best practices principle #5 (fast-fail job ordering)
+
+  # Syntax check all .mjs files with node --check (~7s)
+  test-compilation:
+    name: Test Compilation
+    runs-on: ubuntu-latest
+    # Typical run: <10s. Tight cap fails fast on syntax-check hangs.
+    timeout-minutes: 5
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.mjs-changed == 'true' ||
+      needs.detect-changes.outputs.js-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check .mjs syntax
+        run: bash scripts/check-mjs-syntax.sh
+
+  # Enforce 1500-line limit on .mjs files and release.yml
+  check-file-line-limits:
+    name: Check File Line Limits
+    runs-on: ubuntu-latest
+    # Typical run: <10s. This job only walks tracked files and counts lines.
+    timeout-minutes: 5
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.mjs-changed == 'true' ||
+      needs.detect-changes.outputs.js-changed == 'true' ||
+      needs.detect-changes.outputs.docs-changed == 'true' ||
+      needs.detect-changes.outputs.workflow-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Simulate fresh merge with base branch (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: bash scripts/simulate-fresh-merge.sh
+
+      # Enforces the 1500-line limit on JavaScript (.js/.mjs/.cjs) and
+      # Markdown (.md) files plus release.yml. This is the single source
+      # of truth for the line limit; validate-docs no longer re-checks it.
+      - name: Check file line limits
+        run: bash scripts/check-file-line-limits.sh
+
+  # === VERSION CHANGE CHECK ===
+  # Prohibit manual version changes in package.json - versions should only be changed by CI/CD
+  version-check:
+    name: Check for Manual Version Changes
+    runs-on: ubuntu-latest
+    # Typical run: ~6s. Read-only package.json diff inspection.
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for version changes in package.json
+        env:
+          GITHUB_HEAD_REF: ${{ github.head_ref }}
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+        run: node scripts/check-version.mjs
+
+  # === CHANGESET CHECK - only runs on PRs with code changes ===
+  # Docs-only PRs (./docs folder, markdown files) don't require changesets
+  changeset-check:
+    name: Check for Changesets
+    runs-on: ubuntu-latest
+    # Typical run: <30s including npm install. 10min covers cold runners.
+    timeout-minutes: 10
+    needs: [detect-changes]
+    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.any-code-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Check for changesets
+        env:
+          # Pass PR context to the validation script
+          GITHUB_BASE_REF: ${{ github.base_ref }}
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Skip changeset check for automated version PRs
+          if [[ "${{ github.head_ref }}" == "changeset-release/"* ]]; then
+            echo "Skipping changeset check for automated release PR"
+            exit 0
+          fi
+
+          # Run changeset validation script
+          # This validates that exactly ONE changeset was ADDED by this PR
+          # Pre-existing changesets from other merged PRs are ignored
+          node scripts/validate-changeset.mjs
+
+  # === LINT AND FORMAT CHECK ===
+  # Lint runs independently of changeset-check - it's a fast check that should always run
+  # See: https://github.com/link-assistant/hive-mind/pull/1024 for why this dependency was removed
+  # IMPORTANT: ESLint includes max-lines rule (1500 lines) to ensure files stay maintainable
+  # See docs/case-studies/issue-23 for why fresh merge simulation is critical
+  lint:
+    name: Lint and Format Check
+    runs-on: ubuntu-latest
+    # Typical run: <1min including install, ESLint, Prettier, jscpd,
+    # and secretlint. 10min protects against a hung lint plugin.
+    timeout-minutes: 10
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.mjs-changed == 'true' ||
+      needs.detect-changes.outputs.js-changed == 'true' ||
+      needs.detect-changes.outputs.docs-changed == 'true' ||
+      needs.detect-changes.outputs.package-changed == 'true' ||
+      needs.detect-changes.outputs.workflow-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # For PRs, fetch enough history to merge with base branch
+          fetch-depth: 0
+
+      - name: Simulate fresh merge with base branch (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: bash scripts/simulate-fresh-merge.sh
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Check code duplication
+        run: npm run check:duplication
+
+      - name: Check for secrets
+        run: npx --yes -p secretlint -p @secretlint/secretlint-rule-preset-recommend secretlint "**/*"
+
+  # Test matrix: 3 runtimes (Node.js, Bun, Deno) x 3 OS (Ubuntu, macOS, Windows)
+  # IMPORTANT: Tests must validate the ACTUAL merge result, not a stale merge preview.
+  # See docs/case-studies/issue-23 for why this is critical.
+  # Fast-fail: slow test matrix only runs after fast checks pass (hive-mind principle #5)
+  test:
+    name: Test (${{ matrix.runtime }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    # Typical run: <1min per runtime/OS on warm runners, with Windows
+    # sometimes slower on cold starts. 10min fails hung tests well
+    # before GitHub Actions' 6h default.
+    timeout-minutes: 10
+    needs:
+      [
+        detect-changes,
+        changeset-check,
+        test-compilation,
+        lint,
+        check-file-line-limits,
+      ]
+    # Use !cancelled() instead of always() so cancellation propagates correctly (hive-mind issue #1278)
+    # Run if: push event, OR changeset-check succeeded, OR changeset-check was skipped (docs-only PR)
+    # AND all fast checks passed (or were skipped for irrelevant changes)
+    if: |
+      !cancelled() &&
+      (github.event_name == 'push' || needs.changeset-check.result == 'success' || needs.changeset-check.result == 'skipped') &&
+      (needs.test-compilation.result == 'success' || needs.test-compilation.result == 'skipped') &&
+      (needs.lint.result == 'success' || needs.lint.result == 'skipped') &&
+      (needs.check-file-line-limits.result == 'success' || needs.check-file-line-limits.result == 'skipped')
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        runtime: [node, bun, deno]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # For PRs, fetch enough history to merge with base branch
+          fetch-depth: 0
+
+      - name: Simulate fresh merge with base branch (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        shell: bash
+        run: bash scripts/simulate-fresh-merge.sh
+
+      - name: Setup Node.js
+        if: matrix.runtime == 'node'
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies (Node.js)
+        if: matrix.runtime == 'node'
+        run: npm install
+
+      - name: Run tests (Node.js)
+        if: matrix.runtime == 'node'
+        run: npm test
+
+      - name: Setup Bun
+        if: matrix.runtime == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies (Bun)
+        if: matrix.runtime == 'bun'
+        run: bun install
+
+      - name: Run tests (Bun)
+        if: matrix.runtime == 'bun'
+        # --timeout caps an individual test at 30s, matching Node's
+        # --test-timeout budget while leaving headroom for cold runners.
+        run: bun test --timeout 30000
+
+      - name: Setup Deno
+        if: matrix.runtime == 'deno'
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run tests (Deno)
+        if: matrix.runtime == 'deno'
+        run: deno test --allow-read
+
+  # === DOCUMENTATION VALIDATION ===
+  # Validate documentation files when docs change (hive-mind principle #12)
+  validate-docs:
+    name: Validate Documentation
+    runs-on: ubuntu-latest
+    # Typical run: <10s. Pure shell checks over documentation files.
+    timeout-minutes: 5
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.docs-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      # Documentation line limits (1500 lines, matching the architecture
+      # limit) are enforced by the check-file-line-limits job, which scans
+      # every .md file. This job only validates required-file presence.
+      - name: Check required documentation files exist
+        run: |
+          REQUIRED_FILES=(
+            "docs/BEST-PRACTICES.md"
+            "docs/CONTRIBUTING.md"
+            "README.md"
+            "CHANGELOG.md"
+          )
+
+          MISSING=()
+          for file in "${REQUIRED_FILES[@]}"; do
+            if [ ! -f "$file" ]; then
+              echo "ERROR: Required documentation file missing: $file"
+              MISSING+=("$file")
+            else
+              echo "Found: $file"
+            fi
+          done
+
+          if [ "${#MISSING[@]}" -gt 0 ]; then
+            echo ""
+            echo "Missing required documentation files:"
+            printf '  %s\n' "${MISSING[@]}"
+            exit 1
+          else
+            echo "All required documentation files present."
+          fi
+
+  # Release - only runs on main after tests pass (for push events)
+  release:
+    name: Release
+    needs: [lint, test]
+    # Typical run is well under 10min. 30min gives npm and GitHub
+    # release APIs room for retries without allowing a 6h hang.
+    timeout-minutes: 30
+    # Use !cancelled() instead of always() so cancellation propagates correctly (hive-mind issue #1278)
+    # This is needed because lint/test jobs have a transitive dependency on changeset-check
+    if: |
+      !cancelled() &&
+      github.ref == 'refs/heads/main' &&
+      github.event_name == 'push' &&
+      needs.lint.result == 'success' &&
+      needs.test.result == 'success'
+    runs-on: ubuntu-latest
+    # Permissions required for npm OIDC trusted publishing
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    outputs:
+      published: ${{ steps.publish.outputs.published }}
+      published_version: ${{ steps.publish.outputs.published_version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Update npm for OIDC trusted publishing
+        run: node scripts/setup-npm.mjs
+
+      - name: Check for changesets
+        id: check_changesets
+        run: node scripts/check-changesets.mjs
+
+      - name: Check if release is needed
+        id: check_release
+        env:
+          HAS_CHANGESETS: ${{ steps.check_changesets.outputs.has_changesets }}
+        run: node scripts/check-release-needed.mjs
+
+      - name: Merge multiple changesets
+        if: steps.check_changesets.outputs.has_changesets == 'true' && steps.check_changesets.outputs.changeset_count > 1
+        run: |
+          echo "Multiple changesets detected, merging..."
+          node scripts/merge-changesets.mjs
+
+      - name: Version packages and commit to main
+        if: steps.check_changesets.outputs.has_changesets == 'true'
+        id: version
+        run: node scripts/version-and-commit.mjs --mode changeset
+
+      - name: Publish to npm
+        # Run if version was committed, if a previous attempt already committed (for re-runs),
+        # or if check-release-needed detected an unpublished version (self-healing, issue #36)
+        if: >-
+          steps.version.outputs.version_committed == 'true' ||
+          steps.version.outputs.already_released == 'true' ||
+          (steps.check_release.outputs.should_release == 'true' && steps.check_release.outputs.skip_bump == 'true')
+        id: publish
+        run: node scripts/publish-to-npm.mjs --should-pull
+
+      - name: Create GitHub Release
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/create-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}"
+
+      - name: Format GitHub release notes
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/format-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}"
+
+  # Manual Instant Release - triggered via workflow_dispatch with instant mode
+  # This job is in release.yml because npm trusted publishing
+  # only allows one workflow file to be registered as a trusted publisher
+  instant-release:
+    name: Instant Release
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'instant'
+    runs-on: ubuntu-latest
+    # Same publish envelope as the automated release path.
+    timeout-minutes: 30
+    # Permissions required for npm OIDC trusted publishing
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    outputs:
+      published: ${{ steps.publish.outputs.published }}
+      published_version: ${{ steps.publish.outputs.published_version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Update npm for OIDC trusted publishing
+        run: node scripts/setup-npm.mjs
+
+      - name: Version packages and commit to main
+        id: version
+        run: node scripts/version-and-commit.mjs --mode instant --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+
+      - name: Publish to npm
+        # Run if version was committed OR if a previous attempt already committed (for re-runs)
+        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        id: publish
+        run: node scripts/publish-to-npm.mjs
+
+      - name: Create GitHub Release
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/create-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}"
+
+      - name: Format GitHub release notes
+        if: steps.publish.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/format-github-release.mjs --release-version "${{ steps.publish.outputs.published_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}"
+
+  # Optional Docker Hub publishing for packages that also ship Docker images.
+  # Set vars.DOCKERHUB_IMAGE to enable this path, then configure
+  # vars.DOCKERHUB_USERNAME and secrets.DOCKERHUB_TOKEN.
+  docker-publish:
+    name: Optional Docker Hub Publish
+    needs: [release, instant-release]
+    timeout-minutes: 30
+    if: |
+      !cancelled() &&
+      (
+        (needs.release.result == 'success' && needs.release.outputs.published == 'true') ||
+        (needs.instant-release.result == 'success' && needs.instant-release.outputs.published == 'true')
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      DOCKER_CONTEXT: ${{ vars.DOCKER_CONTEXT }}
+      DOCKERFILE: ${{ vars.DOCKERFILE }}
+      DOCKERHUB_IMAGE: ${{ vars.DOCKERHUB_IMAGE }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+      RELEASE_VERSION: ${{ needs.release.outputs.published_version || needs.instant-release.outputs.published_version }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check Docker publish configuration
+        id: docker_config
+        run: node scripts/check-docker-publish.mjs
+
+      - name: Wait for npm package availability before Docker publish
+        if: steps.docker_config.outputs.enabled == 'true'
+        run: node scripts/wait-for-npm.mjs --release-version "${{ env.RELEASE_VERSION }}"
+
+      - name: Publish Docker image to Docker Hub
+        if: steps.docker_config.outputs.enabled == 'true'
+        uses: ./.github/actions/publish-dockerhub
+        with:
+          context: ${{ steps.docker_config.outputs.context }}
+          file: ${{ steps.docker_config.outputs.dockerfile }}
+          image: ${{ steps.docker_config.outputs.image }}
+          token: ${{ env.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          version: ${{ env.RELEASE_VERSION }}
+
+  # Manual Changeset PR - creates a pull request with the changeset for review
+  changeset-pr:
+    name: Create Changeset PR
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.release_mode == 'changeset-pr'
+    runs-on: ubuntu-latest
+    # PR creation only: install, create a changeset, format, and open a PR.
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24.x'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Create changeset file
+        run: node scripts/create-manual-changeset.mjs --bump-type "${{ github.event.inputs.bump_type }}" --description "${{ github.event.inputs.description }}"
+
+      - name: Format changeset with Prettier
+        run: |
+          # Run Prettier on the changeset file to ensure it matches project style
+          npx prettier --write ".changeset/*.md" || true
+
+          echo "Formatted changeset files"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'chore: add changeset for manual ${{ github.event.inputs.bump_type }} release'
+          branch: changeset-manual-release-${{ github.run_id }}
+          delete-branch: true
+          title: 'chore: manual ${{ github.event.inputs.bump_type }} release'
+          body: |
+            ## Manual Release Request
+
+            This PR was created by a manual workflow trigger to prepare a **${{ github.event.inputs.bump_type }}** release.
+
+            ### Release Details
+            - **Type:** ${{ github.event.inputs.bump_type }}
+            - **Description:** ${{ github.event.inputs.description || 'Manual release' }}
+            - **Triggered by:** @${{ github.actor }}
+
+            ### Next Steps
+            1. Review the changeset in this PR
+            2. Merge this PR to main
+            3. The automated release workflow will create a version PR
+            4. Merge the version PR to publish to npm and create a GitHub release

--- a/experiments/repro-issue-170-awaited.mjs
+++ b/experiments/repro-issue-170-awaited.mjs
@@ -1,0 +1,41 @@
+// Reproduces issue #170: resetGlobalState() firing while a command is still
+// in-flight and being awaited must NOT replace the real exit code with a
+// synthetic SIGTERM (143) result.
+//
+// The CI failure on Windows/Bun was: `await $`sh -c "...; exit 5"`` reported
+// code 143 / stderr "Process killed with SIGTERM" instead of code 5, because
+// the global test-isolation reaper (cleanupActiveRunners) killed the live
+// command mid-flight.
+import { $, resetGlobalState } from '../js/src/$.mjs';
+
+async function run() {
+  // Schedule a global reset to fire while the command below is still running,
+  // emulating the Windows/Bun timing where a test hook's resetGlobalState()
+  // races a command that is still being awaited.
+  setTimeout(() => {
+    console.error('>>> firing resetGlobalState() mid-command');
+    resetGlobalState();
+  }, 100);
+
+  let code, stderr, threw;
+  try {
+    const result = await $`sh -c "echo stdout-marker; echo stderr-marker >&2; sleep 0.3; exit 5"`;
+    code = result.code;
+    stderr = result.stderr;
+  } catch (error) {
+    threw = true;
+    code = error.code;
+    stderr = error.stderr;
+  }
+
+  console.error(`RESULT threw=${threw} code=${code} stderr=${JSON.stringify(stderr)}`);
+  if (code === 5) {
+    console.error('PASS: real exit code 5 preserved');
+    process.exit(0);
+  } else {
+    console.error(`FAIL: expected code 5, got ${code}`);
+    process.exit(1);
+  }
+}
+
+run();

--- a/experiments/repro-issue-170-parentclose.mjs
+++ b/experiments/repro-issue-170-parentclose.mjs
@@ -1,0 +1,44 @@
+// Reproduce issue #170 via the REAL trigger: a spurious 'close' event on the
+// parent stdout stream while an errexit command is in flight and being awaited.
+//
+// On Windows/Bun the parent WriteStream can emit 'close' spuriously (this is also
+// why the run logged "11 close listeners added to [WriteStream]"). That fires
+// monitorParentStreams' listener -> _handleParentStreamClosure() on every active
+// runner, which aborts/kills the live command. If that replaces the real exit
+// code (5) with a synthetic SIGTERM (143), the errexit error is wrong.
+import { $, shell } from "../js/src/$.mjs";
+
+shell.errexit(true);
+
+// Fire a spurious 'close' on process.stdout shortly after the command starts.
+setTimeout(() => {
+  console.error(">>> emitting spurious close on process.stdout");
+  process.stdout.emit("close");
+}, 60);
+
+let code, stderr, stdout, threw;
+try {
+  const result =
+    await $`sh -c "echo stdout-marker; echo stderr-marker >&2; sleep 0.25; exit 5"`;
+  code = result.code;
+  stdout = result.stdout;
+  stderr = result.stderr;
+} catch (error) {
+  threw = true;
+  code = error.code;
+  stdout = error.stdout;
+  stderr = error.stderr;
+}
+
+console.error(
+  `RESULT threw=${threw} code=${code} stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`,
+);
+if (code === 5) {
+  console.error("PASS: real exit code 5 preserved");
+  process.exit(0);
+} else {
+  console.error(
+    `FAIL: expected code 5, got ${code} (synthetic SIGTERM means the bug reproduced)`,
+  );
+  process.exit(1);
+}

--- a/js/.changeset/issue-170-cleanup-race.md
+++ b/js/.changeset/issue-170-cleanup-race.md
@@ -2,9 +2,10 @@
 'command-stream': patch
 ---
 
-Fix CI false positives caused by the test-isolation reset racing in-flight commands (issue #170).
+Fix CI false positives where a global teardown preempted an in-flight, awaited command (issue #170).
 
-Two related defects made tests intermittently report a synthetic `SIGTERM` result (exit code 143, stderr `Process killed with SIGTERM`) and emit a `MaxListenersExceeded` warning, most visibly on Windows/Bun:
+Three related defects made tests intermittently report a `SIGTERM` result (exit code 143) and emit a `MaxListenersExceeded` warning, most visibly on Windows/Bun. All are now keyed on a new `_awaited` flag, set synchronously when user code starts consuming a runner (`await`/`then`/`catch`/`finally`/`stream`):
 
-- `cleanupActiveRunners()` (invoked by `resetGlobalState()` between tests) could force-kill a command that user code was still awaiting, replacing its real exit code with a synthetic SIGTERM result. The reaper now skips runners that are being awaited and have not finished, so the genuine exit code is preserved. A new `_awaited` flag is set synchronously when user code starts consuming a runner (`await`/`then`/`catch`/`finally`/`stream`).
+- `_handleParentStreamClosure()` killed any active runner when a parent `stdout`/`stderr` `close` event fired. On Windows/Bun the parent `WriteStream` can emit a spurious `close` (the same instability behind the `MaxListenersExceeded` warning), which preempted the awaited command and replaced its real exit code with `143`. It now skips runners that are being awaited, since the `await` is the authoritative consumer. This was the actual CI trigger.
+- `cleanupActiveRunners()` (invoked by `resetGlobalState()` between tests) could force-kill a command that user code was still awaiting, replacing its real exit code with a synthetic SIGTERM result. The reaper now skips awaited, unfinished runners.
 - `monitorParentStreams()` attached a `close` listener to `process.stdout`/`process.stderr` on every `ProcessRunner` construction but never removed them on reset, so they accumulated until Node/Bun emitted a `MaxListenersExceeded` warning. The listeners are now tracked and removed in `resetGlobalState()`/`resetParentStreamMonitoring()`.

--- a/js/.changeset/issue-170-cleanup-race.md
+++ b/js/.changeset/issue-170-cleanup-race.md
@@ -1,0 +1,10 @@
+---
+'command-stream': patch
+---
+
+Fix CI false positives caused by the test-isolation reset racing in-flight commands (issue #170).
+
+Two related defects made tests intermittently report a synthetic `SIGTERM` result (exit code 143, stderr `Process killed with SIGTERM`) and emit a `MaxListenersExceeded` warning, most visibly on Windows/Bun:
+
+- `cleanupActiveRunners()` (invoked by `resetGlobalState()` between tests) could force-kill a command that user code was still awaiting, replacing its real exit code with a synthetic SIGTERM result. The reaper now skips runners that are being awaited and have not finished, so the genuine exit code is preserved. A new `_awaited` flag is set synchronously when user code starts consuming a runner (`await`/`then`/`catch`/`finally`/`stream`).
+- `monitorParentStreams()` attached a `close` listener to `process.stdout`/`process.stderr` on every `ProcessRunner` construction but never removed them on reset, so they accumulated until Node/Bun emitted a `MaxListenersExceeded` warning. The listeners are now tracked and removed in `resetGlobalState()`/`resetParentStreamMonitoring()`.

--- a/js/src/$.process-runner-base.mjs
+++ b/js/src/$.process-runner-base.mjs
@@ -243,6 +243,13 @@ class ProcessRunner extends StreamEmitter {
     this._virtualGenerator = null;
     this._abortController = new AbortController();
 
+    // Set to true once user code starts consuming this runner (await / then /
+    // catch / finally / async iteration). Used by the global test-isolation
+    // reaper (cleanupActiveRunners) to avoid force-terminating a command that
+    // is still being awaited, which would mask its real exit code with a
+    // synthetic SIGTERM result (see issue #170).
+    this._awaited = false;
+
     activeProcessRunners.add(this);
     monitorParentStreams();
 

--- a/js/src/$.process-runner-base.mjs
+++ b/js/src/$.process-runner-base.mjs
@@ -487,6 +487,27 @@ class ProcessRunner extends StreamEmitter {
       return;
     }
 
+    // Never tear down a command that user code is actively awaiting (issue #170).
+    // Graceful shutdown on parent-stream closure exists for fire-and-forget /
+    // streamed commands whose output consumer went away; when the result is being
+    // awaited, the await is the authoritative consumer. A spurious parent
+    // stdout/stderr 'close' — observed on Windows/Bun, which also logged
+    // "11 close listeners added to [WriteStream]" in run 27310950658 — must not
+    // preempt the awaited result and replace the real exit code with a synthetic
+    // SIGTERM (143).
+    if (this._awaited) {
+      trace(
+        'ProcessRunner',
+        () =>
+          `Parent stream closure ignored for awaited command | ${JSON.stringify(
+            {
+              command: this.spec?.command?.slice(0, 50) || this.spec?.file,
+            }
+          )}`
+      );
+      return;
+    }
+
     trace(
       'ProcessRunner',
       () =>

--- a/js/src/$.process-runner-execution.mjs
+++ b/js/src/$.process-runner-execution.mjs
@@ -1450,6 +1450,7 @@ export function attachExecutionMethods(ProcessRunner, deps) {
 
   // Promise interface
   ProcessRunner.prototype.then = function (onFulfilled, onRejected) {
+    this._awaited = true;
     if (!this.promise) {
       this.promise = this._startAsync();
     }
@@ -1457,6 +1458,7 @@ export function attachExecutionMethods(ProcessRunner, deps) {
   };
 
   ProcessRunner.prototype.catch = function (onRejected) {
+    this._awaited = true;
     if (!this.promise) {
       this.promise = this._startAsync();
     }
@@ -1464,6 +1466,7 @@ export function attachExecutionMethods(ProcessRunner, deps) {
   };
 
   ProcessRunner.prototype.finally = function (onFinally) {
+    this._awaited = true;
     if (!this.promise) {
       this.promise = this._startAsync();
     }

--- a/js/src/$.process-runner-stream-kill.mjs
+++ b/js/src/$.process-runner-stream-kill.mjs
@@ -257,6 +257,7 @@ export function attachStreamKillMethods(ProcessRunner) {
   ProcessRunner.prototype.stream = async function* () {
     trace('ProcessRunner', () => `stream ENTER | started=${this.started}`);
     this._isStreaming = true;
+    this._awaited = true;
     if (!this.started) {
       this._startAsync();
     }

--- a/js/src/$.state.mjs
+++ b/js/src/$.state.mjs
@@ -13,6 +13,13 @@ const initialWorkingDirectory = process.cwd();
 
 // Track parent stream state for graceful shutdown
 let parentStreamsMonitored = false;
+// References to the 'close' listeners installed on the parent streams so they
+// can be removed on reset. Without this, resetGlobalState() would clear the
+// `parentStreamsMonitored` flag while leaving the old listeners attached, so
+// every subsequent ProcessRunner re-registered a new 'close' listener and they
+// accumulated until Node/Bun emitted a MaxListenersExceeded warning (issue
+// #170). Each entry is { stream, listener }.
+let parentStreamListeners = [];
 
 // Set of active ProcessRunner instances
 export const activeProcessRunners = new Set();
@@ -289,7 +296,7 @@ export function monitorParentStreams() {
 
   const checkParentStream = (stream, name) => {
     if (stream && typeof stream.on === 'function') {
-      stream.on('close', () => {
+      const listener = () => {
         trace(
           'ProcessRunner',
           () =>
@@ -300,7 +307,12 @@ export function monitorParentStreams() {
             runner._handleParentStreamClosure();
           }
         }
-      });
+      };
+      stream.on('close', listener);
+      // Keep a reference so the listener can be removed on reset; without this
+      // the listeners accumulate across resetGlobalState() calls and trigger a
+      // MaxListenersExceeded warning (issue #170).
+      parentStreamListeners.push({ stream, listener });
     }
   };
 
@@ -309,9 +321,26 @@ export function monitorParentStreams() {
 }
 
 /**
+ * Remove any parent-stream 'close' listeners installed by monitorParentStreams.
+ */
+function removeParentStreamListeners() {
+  for (const { stream, listener } of parentStreamListeners) {
+    try {
+      if (stream && typeof stream.removeListener === 'function') {
+        stream.removeListener('close', listener);
+      }
+    } catch (_e) {
+      // Ignore - stream may already be torn down
+    }
+  }
+  parentStreamListeners = [];
+}
+
+/**
  * Reset parent stream monitoring flag (for testing)
  */
 export function resetParentStreamMonitoring() {
+  removeParentStreamListeners();
   parentStreamsMonitored = false;
 }
 
@@ -369,6 +398,15 @@ function cleanupActiveRunners() {
       continue;
     }
     try {
+      // Never force-terminate a command that user code is still awaiting. The
+      // reaper exists to clean up *leaked* fire-and-forget runners between
+      // tests; killing a live, awaited command would replace its real exit
+      // code with a synthetic SIGTERM (143) result and mask the true outcome
+      // (issue #170). Awaited runners settle on their own and remove
+      // themselves from activeProcessRunners when they finish.
+      if (runner._awaited && !runner.finished) {
+        continue;
+      }
       if (!runner.started && runner._cleanup) {
         runner._cleanup();
       } else if (runner.kill) {
@@ -388,6 +426,9 @@ export function resetGlobalState() {
   cleanupActiveRunners();
   forceCleanupAll();
   clearShellCache();
+  // Remove the parent-stream 'close' listeners as well as clearing the flag, so
+  // they do not accumulate across resets (issue #170 listener leak).
+  removeParentStreamListeners();
   parentStreamsMonitored = false;
   resetShellSettings();
   virtualCommandsEnabled = true;

--- a/js/tests/issue-170-cleanup-race.test.mjs
+++ b/js/tests/issue-170-cleanup-race.test.mjs
@@ -1,0 +1,88 @@
+// Regression tests for issue #170:
+// "Check CI/CD for all false positives and errors and fix it all"
+//
+// The CI failure (run 27310950658, Windows/Bun) was the test
+// "should provide better error objects than bash" reporting exit code 143
+// with stderr "Process killed with SIGTERM" instead of the real exit code 5.
+//
+// Root causes:
+//  1. monitorParentStreams() leaked a 'close' listener on process.stdout /
+//     process.stderr on every ProcessRunner construction, because
+//     resetGlobalState() cleared the `parentStreamsMonitored` flag without
+//     removing the previously attached listeners. They accumulated until
+//     Node/Bun emitted a MaxListenersExceeded warning.
+//  2. cleanupActiveRunners() (run by resetGlobalState() between tests)
+//     force-killed a command that was still running and being awaited,
+//     replacing its real exit code with a synthetic SIGTERM (143) result.
+//
+// These tests reproduce both problems and verify the fixes.
+import { test, expect, describe } from 'bun:test';
+import './test-helper.mjs'; // installs beforeEach/afterEach resetGlobalState
+import { $, resetGlobalState } from '../src/$.mjs';
+
+describe('issue #170 - CI false positives', () => {
+  test('resetGlobalState() during an awaited command preserves the real exit code', async () => {
+    // Fire a global reset while the command below is still running. This mirrors
+    // the Windows/Bun timing where a test-isolation reset raced an in-flight,
+    // still-awaited command. The reaper must skip awaited runners so the real
+    // exit code wins instead of a synthetic SIGTERM (143).
+    const timer = setTimeout(() => resetGlobalState(), 50);
+
+    let observedCode;
+    try {
+      const result =
+        await $`sh -c "echo stdout-marker; echo stderr-marker >&2; sleep 0.3; exit 5"`;
+      observedCode = result.code;
+    } catch (error) {
+      observedCode = error.code;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    expect(observedCode).toBe(5);
+  });
+
+  test('errexit error object keeps the real code when reset races the command', async () => {
+    const timer = setTimeout(() => resetGlobalState(), 50);
+
+    let error;
+    try {
+      await $({
+        mirror: false,
+      })`sh -c "echo out; echo err >&2; sleep 0.3; exit 7"`.then((r) => {
+        // shouldn't normally reach here when the command exits non-zero with
+        // errexit; but if it does, surface the code for the assertion below.
+        error = { code: r.code };
+      });
+    } catch (e) {
+      error = e;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    // The result must reflect the real exit code (7), never a synthetic 143.
+    expect(error?.code).toBe(7);
+  });
+
+  test('parent stream monitoring does not leak listeners across resets', async () => {
+    const before =
+      process.stdout.listenerCount('close') +
+      process.stderr.listenerCount('close');
+
+    // Each $ construction calls monitorParentStreams(); each resetGlobalState()
+    // (run by the afterEach helper and explicitly here) must remove the
+    // previously installed listeners rather than letting them accumulate.
+    for (let i = 0; i < 25; i++) {
+      await $`true`;
+      resetGlobalState();
+    }
+
+    const after =
+      process.stdout.listenerCount('close') +
+      process.stderr.listenerCount('close');
+
+    // Without the fix this grew by one per iteration (eventually triggering a
+    // MaxListenersExceeded warning). With the fix it stays bounded.
+    expect(after - before).toBeLessThanOrEqual(2);
+  });
+});

--- a/js/tests/issue-170-cleanup-race.test.mjs
+++ b/js/tests/issue-170-cleanup-race.test.mjs
@@ -14,11 +14,15 @@
 //  2. cleanupActiveRunners() (run by resetGlobalState() between tests)
 //     force-killed a command that was still running and being awaited,
 //     replacing its real exit code with a synthetic SIGTERM (143) result.
+//  3. _handleParentStreamClosure() (fired by a parent stdout/stderr 'close'
+//     event — which can be spurious on Windows/Bun, the same place the
+//     MaxListeners warning came from) terminated a command that was still
+//     being awaited, again replacing the real exit code with 143.
 //
-// These tests reproduce both problems and verify the fixes.
+// These tests reproduce all three problems and verify the fixes.
 import { test, expect, describe } from 'bun:test';
 import './test-helper.mjs'; // installs beforeEach/afterEach resetGlobalState
-import { $, resetGlobalState } from '../src/$.mjs';
+import { $, shell, resetGlobalState } from '../src/$.mjs';
 
 describe('issue #170 - CI false positives', () => {
   test('resetGlobalState() during an awaited command preserves the real exit code', async () => {
@@ -62,6 +66,36 @@ describe('issue #170 - CI false positives', () => {
 
     // The result must reflect the real exit code (7), never a synthetic 143.
     expect(error?.code).toBe(7);
+  });
+
+  test('a spurious parent stdout close does not preempt an awaited command', async () => {
+    // This is the actual CI trigger (run 27310950658, Windows/Bun): the parent
+    // WriteStream emitted a 'close' event while an errexit command was in flight
+    // and being awaited. monitorParentStreams' listener -> _handleParentStreamClosure()
+    // then killed the live command, replacing the real exit code (5) with a
+    // synthetic SIGTERM (143). The _awaited guard must keep the real code.
+    shell.errexit(true);
+    try {
+      const timer = setTimeout(() => {
+        // Emit a spurious 'close' on the parent stdout, exactly as the flaky
+        // Windows/Bun WriteStream did.
+        process.stdout.emit('close');
+      }, 60);
+
+      let observedCode;
+      try {
+        await $`sh -c "echo stdout-marker; echo stderr-marker >&2; sleep 0.25; exit 5"`;
+        observedCode = 0;
+      } catch (error) {
+        observedCode = error.code;
+      } finally {
+        clearTimeout(timer);
+      }
+
+      expect(observedCode).toBe(5);
+    } finally {
+      shell.errexit(false);
+    }
   });
 
   test('parent stream monitoring does not leak listeners across resets', async () => {


### PR DESCRIPTION
## Summary

Fixes #170 — a CI/CD false positive on `Test JavaScript (bun on windows-latest)`
(run [27310950658](https://github.com/link-foundation/command-stream/actions/runs/27310950658)).

The test `Shell Settings > Shell Replacement Benefits > should provide better
error objects than bash` intermittently reported **exit code 143** with stderr
`"Process killed with SIGTERM"` instead of the command's real exit code **5**.
The same run also emitted `MaxListenersExceededWarning: … 11 close listeners`.

These are flaky/quality defects in the library's own source — not in any workflow
file. Full analysis (timeline, requirements, root causes, verification, workflow
comparison) lives in [`docs/case-studies/issue-170/`](docs/case-studies/issue-170/README.md).

## Root causes

The unifying cause is a **global teardown preempting a command that user code is
actively awaiting**, replacing its real exit code with a SIGTERM (143). Two
distinct teardown paths reach an in-flight, awaited runner during a
`resetGlobalState()`:

1. **Parent-stream-closure handler (the path that actually broke CI).**
   `monitorParentStreams()`'s `'close'` listener calls
   `_handleParentStreamClosure()` on every active runner, which aborts and kills
   its child. On Windows/Bun the parent `WriteStream` emits a **spurious**
   `'close'` (the same instability behind the MaxListeners warning), preempting
   the awaited command. A reaper-only fix (commit `9fd7ad2`) left this path open
   and CI **still failed** — see the case study §3.3.
2. **Reaper race.** `cleanupActiveRunners()` (run in `beforeEach`/`afterEach`)
   force-killed a still-awaited command; the synthetic SIGTERM from `killRunner()`
   won (`finish()` is first-wins) and masked the real code.
3. **Listener leak.** `monitorParentStreams()` added a `'close'` listener on every
   `ProcessRunner` construction, but `resetGlobalState()` cleared the
   `parentStreamsMonitored` flag **without** removing the listeners — so they
   accumulated until the MaxListeners warning. This warning is the smoking gun for
   the spurious-close instability behind root cause #1.

## The fix (applied across the whole codebase)

A new `_awaited` flag is set **synchronously** the moment user code consumes a
runner (`then`/`catch`/`finally`/`stream`). Both teardown paths honor it:

- `_handleParentStreamClosure()` ignores parent-stream closure for awaited
  runners — the `await` is the authoritative consumer. Fire-and-forget/streamed
  runners (`runner.start()` without awaiting the runner) are unaffected, so the
  legitimate graceful-shutdown path is preserved.
- `cleanupActiveRunners()` skips live, awaited runners while still reaping
  genuinely leaked fire-and-forget ones.
- Parent-stream `'close'` listeners are now tracked and removed in
  `resetGlobalState()` / `resetParentStreamMonitoring()`, bounding the count.

## How to reproduce

```
node experiments/repro-issue-170-parentclose.mjs  # Path B (the CI trigger): clean → code=143, fixed → code=5
node experiments/repro-issue-170-awaited.mjs       # Path A (reaper race):    clean → code=143, fixed → code=5
```

## Tests

- New regression test `js/tests/issue-170-cleanup-race.test.mjs` encodes all
  three defects. The parent-closure case was verified to go **143 without the
  guard → 5 with it**.
- `Test JavaScript (bun on windows-latest)` — the originally failing leg — now
  **passes** on this branch (CI run on commit `1c53eef`).
- Lint + Prettier clean on all changed files.

## JS/Rust parity

This change is JS-only. The Rust implementation's `reset()` (`rust/src/state.rs`)
merely clears the active-runner set; it has no parent-stream-closure monitoring,
no reaper kill, and no synthetic-SIGTERM result — so none of the three defects has
a Rust counterpart. The PR carries the `parity-exempt` label per the parity gate's
documented escape hatch.

## Workflow comparison (issue requirement R2)

Compared `.github/workflows/*.yml` against the js/rust/python/csharp pipeline
templates. The failing defect lives in command-stream's library source, which has
**no counterpart in the templates**, so there is no matching issue to file
upstream. Best-practice deltas (Deno matrix leg, fresh-merge simulation) are
documented as follow-up recommendations in the case study.

A changeset (`js/.changeset/issue-170-cleanup-race.md`, `patch`) is included to
trigger the next release.
