### PR TITLE
chore(js): recover 0.15.0 release after concurrent publish

### DIFF
--- a/js/.changeset/fuzzy-pianos-record.md
+++ b/js/.changeset/fuzzy-pianos-record.md
@@ -1,7 +1,0 @@
----
-'command-stream': minor
----
-
-Add PTY-backed terminal capture with resize and input control, settled frame
-deduplication, unrolled text transcripts, asciicast v2 interchange, and animated
-SVG recording artifacts.

--- a/js/.changeset/tender-terminals-repaint.md
+++ b/js/.changeset/tender-terminals-repaint.md
@@ -1,6 +1,0 @@
----
-'command-stream': patch
----
-
-Preserve the current terminal frame before a later full-screen repaint,
-including when its control sequence is split across PTY output chunks.

--- a/js/CHANGELOG.md
+++ b/js/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.15.0
+
+### Minor Changes
+
+- 4b8a864: Add PTY-backed terminal capture with resize and input control, settled frame
+  deduplication, unrolled text transcripts, asciicast v2 interchange, and animated
+  SVG recording artifacts.
+
+### Patch Changes
+
+- d917186: Preserve the current terminal frame before a later full-screen repaint,
+  including when its control sequence is split across PTY output chunks.
+
 ## 0.14.1
 
 ### Patch Changes

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "command-stream",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "command-stream",
-      "version": "0.14.1",
+      "version": "0.15.0",
       "license": "Unlicense",
       "dependencies": {
         "@xterm/headless": "^6.0.0",
-        "node-pty": "^1.1.0"
+        "node-pty": "^1.2.0-beta.14"
       },
       "devDependencies": {
         "@changesets/cli": "^2.29.7",
@@ -2431,9 +2431,9 @@
       "license": "MIT"
     },
     "node_modules/node-pty": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
-      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "version": "1.2.0-beta.14",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.14.tgz",
+      "integrity": "sha512-XORU9BQgpxVgqr7WivjJ17mLenOHUgKKWzuZZNaw3NDYgHc/wPJQMSaoLDrpEgqV6aU1nNwil1o/OqYj6lWmUA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "command-stream",
-  "version": "0.14.1",
+  "version": "0.15.0",
   "description": "Modern $ shell utility library with streaming, async iteration, and EventEmitter support, optimized for Bun runtime",
   "type": "module",
   "main": "src/$.mjs",


### PR DESCRIPTION
## Summary

- apply the generated JavaScript 0.15.0 version, changelog, and lockfile metadata on top of the Rust 0.13.1 release commit
- consume the two TUI capture changesets already merged in #176 and #177
- allow the existing release workflow to self-heal the unpublished npm package without another source change

## Why this follow-up is needed

The JavaScript and Rust release workflows started from the same `main` commit after #177. Rust published 0.13.1 and advanced `main` first. JavaScript generated its valid 0.15.0 release commit afterward, but its push was rejected as non-fast-forward. The retry logic could not rebase because dependency installation had left unstaged changes in the runner.

This PR recreates only that generated release metadata on the current `main` tip. Its `changeset-release/` branch name follows the workflow's generated-release convention and bypasses the normal requirement to add a new changeset while consuming existing ones.

## Verification

- `bun run format:check`
- `npm pack --dry-run` (package version 0.15.0; PTY capture files included)
- full cross-platform JavaScript and Rust checks passed on #177 before the release workflows started

Closes the JavaScript release portion of #175.
