### PR TITLE
fix(js): render GIF terminal artifacts on Node.js

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -185,6 +185,7 @@ jobs:
               process.exit(1);
             });
           "
+          node --test js/tests/node-terminal-artifacts.mjs
 
   release:
     name: Release JavaScript package

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -174,6 +174,11 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Install dependencies (Node)
+        if: matrix.runtime == 'node'
+        working-directory: js
+        run: npm ci
+
       - name: Test Node.js compatibility
         if: matrix.runtime == 'node'
         run: |

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-26T08:40:27.171Z for PR creation at branch issue-183-49600e8cc302 for issue https://github.com/link-foundation/command-stream/issues/183

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-26T08:40:27.171Z for PR creation at branch issue-183-49600e8cc302 for issue https://github.com/link-foundation/command-stream/issues/183

--- a/js/.changeset/fuzzy-gifs-wave.md
+++ b/js/.changeset/fuzzy-gifs-wave.md
@@ -1,0 +1,6 @@
+---
+'command-stream': patch
+---
+
+Fix GIF terminal artifact rendering on Node.js by supporting the CommonJS
+default export exposed by `gifenc`.

--- a/js/src/terminal-artifacts.mjs
+++ b/js/src/terminal-artifacts.mjs
@@ -407,9 +407,12 @@ const renderRecordingSvg = ({ frames, options, font }) => {
 };
 
 const renderGif = async ({ frames, options, font }) => {
-  const [{ Resvg }, { GIFEncoder, applyPalette, quantize }] = await Promise.all(
-    [import('@resvg/resvg-js'), import('gifenc')]
-  );
+  const [{ Resvg }, gifencModule] = await Promise.all([
+    import('@resvg/resvg-js'),
+    import('gifenc'),
+  ]);
+  const gifenc = gifencModule.GIFEncoder ? gifencModule : gifencModule.default;
+  const { GIFEncoder, applyPalette, quantize } = gifenc;
   const { width, height } = dimensions(frames, options);
   const { times } = frameTimes(frames, options.idleTimeLimit);
   const sheet = svgShell({

--- a/js/tests/node-terminal-artifacts.mjs
+++ b/js/tests/node-terminal-artifacts.mjs
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import { writeTerminalArtifacts } from '../src/terminal-artifacts.mjs';
+
+test('writes GIF terminal artifacts in Node.js', async (context) => {
+  const directory = await mkdtemp(join(tmpdir(), 'command-stream-node-gif-'));
+  context.after(() => rm(directory, { force: true, recursive: true }));
+
+  await writeTerminalArtifacts({
+    directory,
+    frames: [
+      {
+        time: 0,
+        cols: 1,
+        rows: 1,
+        lines: [''],
+        cells: [[]],
+      },
+    ],
+    transcript: '',
+    asciicast: {
+      header: { version: 2, width: 1, height: 1, timestamp: 0, env: {} },
+      events: [],
+    },
+  });
+
+  const gif = await readFile(join(directory, 'recording.gif'));
+  assert.equal(gif.subarray(0, 6).toString(), 'GIF89a');
+});


### PR DESCRIPTION
## Summary

- normalize the `gifenc` dynamic import for both Node.js CommonJS interop and Bun named exports
- add a Node-native artifact regression test that verifies a valid GIF is written
- run the regression test on the existing Node 20, 22, and 24 CI matrix
- add a patch changeset for the JavaScript package

## Reproduction

On Node 20.20.2, calling `writeTerminalArtifacts` (or `captureTerminal` with `artifactDirectory`) failed before this change with:

```text
TypeError: GIFEncoder is not a function
    at renderGif (.../src/terminal-artifacts.mjs:429:15)
```

The new Node-native test reproduced that exact failure before the implementation change.

## Automated verification

- `node --test js/tests/node-terminal-artifacts.mjs`
- `bun test js/tests/terminal-capture.test.mjs --timeout 10000`
- `bun test js/tests/ --timeout 10000` (783 passed, 5 skipped, 0 failed)
- `bun run lint`
- `bun run format:check`
- `bun run check:duplication`
- `bun scripts/validate-changeset.mjs`

Fixes #183
