### PR TITLE
fix(js): preserve visible SVG text geometry on padded rows

### DIFF
--- a/js/.changeset/calm-terminals-align.md
+++ b/js/.changeset/calm-terminals-align.md
@@ -1,0 +1,6 @@
+---
+'command-stream': patch
+---
+
+Render terminal SVG text at its visible cell-grid position and width without
+stretching glyphs across leading or trailing row padding.

--- a/js/src/terminal-artifacts.mjs
+++ b/js/src/terminal-artifacts.mjs
@@ -153,6 +153,8 @@ const cellStyle = (cell, options) => {
 const sameStyle = (left, right) =>
   Object.keys(left).every((key) => left[key] === right[key]);
 
+const isBlankCell = (cell) => (cell.chars || ' ').trim() === '';
+
 const coalesceRow = (cells, options) => {
   const runs = [];
   for (let column = 0; column < cells.length; ) {
@@ -161,13 +163,19 @@ const coalesceRow = (cells, options) => {
       column += 1;
       continue;
     }
+    if (isBlankCell(cell)) {
+      column += Math.max(cell.width, 1);
+      continue;
+    }
     const style = cellStyle(cell, options);
     const run = {
       column,
       width: Math.max(cell.width, 1),
-      text: cell.chars || ' ',
+      text: cell.chars,
       style,
     };
+    let visibleTextLength = run.text.length;
+    let visibleWidth = run.width;
     column += Math.max(cell.width, 1);
     while (column < cells.length) {
       const next = cells[column];
@@ -182,7 +190,13 @@ const coalesceRow = (cells, options) => {
       run.text += next.chars || ' ';
       run.width += Math.max(next.width, 1);
       column += Math.max(next.width, 1);
+      if (!isBlankCell(next)) {
+        visibleTextLength = run.text.length;
+        visibleWidth = run.width;
+      }
     }
+    run.text = run.text.slice(0, visibleTextLength);
+    run.width = visibleWidth;
     runs.push(run);
   }
   return runs;

--- a/js/tests/terminal-capture.test.mjs
+++ b/js/tests/terminal-capture.test.mjs
@@ -173,6 +173,36 @@ describe('PTY terminal capture', () => {
     expect(duration).toBeLessThan(0.5);
   });
 
+  test('measures visible glyphs without stretching terminal row padding', async () => {
+    const artifactDirectory = await mkdtemp(
+      join(tmpdir(), 'command-stream-tui-padding-')
+    );
+    temporaryDirectories.push(artifactDirectory);
+
+    await captureTerminal({
+      file: process.execPath,
+      args: ['-e', "process.stdout.write('\\u001b[3Gok 表')"],
+      cols: 12,
+      rows: 2,
+      artifactDirectory,
+      artifactOptions: {
+        cellWidth: 10,
+        cellHeight: 20,
+        padding: 0,
+      },
+    });
+
+    const snapshot = await readFile(
+      join(artifactDirectory, 'snapshot.svg'),
+      'utf8'
+    );
+    expect(snapshot).toMatch(
+      /<text x="20" [^>]*textLength="50"[^>]*>ok 表<\/text>/
+    );
+    expect(snapshot).not.toMatch(/<text [^>]*>[ \t]/);
+    expect(snapshot).not.toMatch(/[ \t]<\/text>/);
+  });
+
   test('unrolls scrolled-off lines in order and exactly once', async () => {
     const capture = await captureTerminal({
       file: process.execPath,


### PR DESCRIPTION
## Summary

- exclude leading and trailing blank terminal cells from visible SVG text runs
- retain the original cell-grid offset, internal spaces, wide-glyph width, styling, background rendering, and vector rendering
- add a PTY regression that proves a five-cell `ok 表` run begins at column two and is not measured as a padded twelve-cell row
- add a patch changeset for the JavaScript package

## Root cause and reproduction

Terminal buffers pad every row to their full width. The renderer coalesced that padding with adjacent default-style text and emitted the full padded width as SVG `textLength`. Chromium disregards edge spaces when measuring the text, then stretches the visible glyphs to the full target width.

Before the fix, the new regression produces:

```xml
<text x="0" ... textLength="120">  ok 表     </text>
```

After the fix, the same terminal frame produces:

```xml
<text x="20" ... textLength="50">ok 表</text>
```

A real 96×36 OpenCode frame from link-assistant/formal-ai#841 was also re-rendered and inspected in Chromium. Its `(no output)` row is now an unstretched eleven-cell run (`textLength="99"`) rather than a full-row run.

## Automated verification

- `bun test js/tests/terminal-capture.test.mjs --timeout 10000` (10 passed)
- `bun run lint`
- `bun run format:check`
- `bun run check:duplication`
- `bun scripts/validate-changeset.mjs`
- full `bun test js/tests/ --timeout 10000`: 751 passed, 10 skipped; 28 unrelated jq tests could not run because this local environment has no `jq` executable
- Playwright/Chromium render of the real OpenCode snapshot visually verified

Fixes #185
