### PR TITLE
feat(js): expose lightweight ProcessRunner entry

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-08-07T19:41:37.524Z for PR creation at branch issue-187-3d458fd12c95 for issue https://github.com/link-foundation/command-stream/issues/187
+# Updated: 2026-08-11T10:02:29.523Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-08-07T19:41:37.524Z for PR creation at branch issue-187-3d458fd12c95 for issue https://github.com/link-foundation/command-stream/issues/187
-# Updated: 2026-08-11T10:02:29.523Z

--- a/js/.changeset/lightweight-process-runner.md
+++ b/js/.changeset/lightweight-process-runner.md
@@ -1,0 +1,5 @@
+---
+'command-stream': patch
+---
+
+Add a lightweight `command-stream/process-runner` export that excludes optional PTY and terminal rendering dependencies from its module graph.

--- a/js/README.md
+++ b/js/README.md
@@ -156,6 +156,24 @@ npm install command-stream
 bun add command-stream
 ```
 
+### Lightweight ProcessRunner entry point
+
+Consumers that only need direct process execution can import `ProcessRunner`
+without loading the optional PTY, terminal rendering, SVG, or GIF modules:
+
+```javascript
+import { ProcessRunner } from 'command-stream/process-runner';
+
+const runner = new ProcessRunner(
+  { mode: 'exec', file: 'git', args: ['status', '--short'] },
+  { mirror: false, capture: true, stdin: 'ignore' }
+);
+const result = await runner;
+```
+
+The main `command-stream` entry point remains the supported import for `$` and
+terminal capture features.
+
 ## Smart Quoting & Security
 
 Command-stream provides intelligent auto-quoting to protect against shell injection while avoiding unnecessary quotes for safe strings:

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "src/$.mjs",
   "exports": {
-    ".": "./src/$.mjs"
+    ".": "./src/$.mjs",
+    "./process-runner": "./src/process-runner.mjs"
   },
   "repository": {
     "type": "git",

--- a/js/src/$.mjs
+++ b/js/src/$.mjs
@@ -5,7 +5,6 @@ import { trace } from './$.trace.mjs';
 import {
   globalShellSettings,
   virtualCommands,
-  isVirtualCommandsEnabled,
   enableVirtualCommands as enableVirtualCommandsState,
   disableVirtualCommands as disableVirtualCommandsState,
   forceCleanupAll,
@@ -25,32 +24,7 @@ import {
   unrollTerminalFrames,
 } from './terminal-capture.mjs';
 
-// Import ProcessRunner base and method modules
-import { ProcessRunner } from './$.process-runner-base.mjs';
-import { attachExecutionMethods } from './$.process-runner-execution.mjs';
-import { attachPipelineMethods } from './$.process-runner-pipeline.mjs';
-import { attachOrchestrationMethods } from './$.process-runner-orchestration.mjs';
-import { attachVirtualCommandMethods } from './$.process-runner-virtual.mjs';
-import { attachStreamKillMethods } from './$.process-runner-stream-kill.mjs';
-
-// Create dependencies object for method attachment
-const deps = {
-  virtualCommands,
-  globalShellSettings,
-  isVirtualCommandsEnabled,
-};
-
-// Attach all methods to ProcessRunner prototype using mixin pattern
-attachExecutionMethods(ProcessRunner, deps);
-attachPipelineMethods(ProcessRunner, deps);
-attachOrchestrationMethods(ProcessRunner, deps);
-attachVirtualCommandMethods(ProcessRunner, deps);
-attachStreamKillMethods(ProcessRunner, deps);
-
-trace(
-  'Initialization',
-  () => 'ProcessRunner methods attached via mixin pattern'
-);
+import { ProcessRunner } from './process-runner.mjs';
 
 // Public APIs
 async function sh(commandString, options = {}) {

--- a/js/src/process-runner.mjs
+++ b/js/src/process-runner.mjs
@@ -1,0 +1,33 @@
+// Lightweight ProcessRunner entry point without terminal capture dependencies
+
+import { ProcessRunner } from './$.process-runner-base.mjs';
+import { attachExecutionMethods } from './$.process-runner-execution.mjs';
+import { attachOrchestrationMethods } from './$.process-runner-orchestration.mjs';
+import { attachPipelineMethods } from './$.process-runner-pipeline.mjs';
+import { attachStreamKillMethods } from './$.process-runner-stream-kill.mjs';
+import { attachVirtualCommandMethods } from './$.process-runner-virtual.mjs';
+import {
+  globalShellSettings,
+  isVirtualCommandsEnabled,
+  virtualCommands,
+} from './$.state.mjs';
+import { trace } from './$.trace.mjs';
+
+const dependencies = {
+  virtualCommands,
+  globalShellSettings,
+  isVirtualCommandsEnabled,
+};
+
+attachExecutionMethods(ProcessRunner, dependencies);
+attachPipelineMethods(ProcessRunner, dependencies);
+attachOrchestrationMethods(ProcessRunner, dependencies);
+attachVirtualCommandMethods(ProcessRunner, dependencies);
+attachStreamKillMethods(ProcessRunner, dependencies);
+
+trace(
+  'Initialization',
+  () => 'ProcessRunner methods attached via mixin pattern'
+);
+
+export { ProcessRunner };

--- a/js/tests/process-runner-entry.test.mjs
+++ b/js/tests/process-runner-entry.test.mjs
@@ -48,7 +48,16 @@ test('exports a fully initialized ProcessRunner subpath', async () => {
   expect(processRunnerExport).toBe('./src/process-runner.mjs');
 
   const { ProcessRunner } = await import('command-stream/process-runner');
-  expect(typeof ProcessRunner.prototype.start).toBe('function');
+  for (const method of [
+    'start',
+    '_runPipeline',
+    'pipe',
+    '_runVirtual',
+    'stream',
+    'kill',
+  ]) {
+    expect(typeof ProcessRunner.prototype[method]).toBe('function');
+  }
 
   const runner = new ProcessRunner(
     {

--- a/js/tests/process-runner-entry.test.mjs
+++ b/js/tests/process-runner-entry.test.mjs
@@ -1,0 +1,83 @@
+import { expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const testDirectory = dirname(fileURLToPath(import.meta.url));
+const packageDirectory = resolve(testDirectory, '..');
+const packageJson = JSON.parse(
+  readFileSync(resolve(packageDirectory, 'package.json'), 'utf8')
+);
+const processRunnerExport = packageJson.exports['./process-runner'];
+const terminalDependencies = new Set([
+  '@resvg/resvg-js',
+  '@xterm/headless',
+  'gifenc',
+  'node-pty',
+]);
+
+function collectModuleGraph(entrypoint) {
+  const pending = [entrypoint];
+  const modules = new Set();
+  const packages = new Set();
+  const importPattern =
+    /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s*)['"]([^'"]+)['"]/g;
+
+  while (pending.length > 0) {
+    const modulePath = pending.pop();
+    if (modules.has(modulePath)) {
+      continue;
+    }
+    modules.add(modulePath);
+
+    const source = readFileSync(modulePath, 'utf8');
+    for (const match of source.matchAll(importPattern)) {
+      const specifier = match[1];
+      if (specifier.startsWith('.')) {
+        pending.push(resolve(dirname(modulePath), specifier));
+      } else if (!specifier.startsWith('node:')) {
+        packages.add(specifier);
+      }
+    }
+  }
+
+  return { modules, packages };
+}
+
+test('exports a fully initialized ProcessRunner subpath', async () => {
+  expect(processRunnerExport).toBe('./src/process-runner.mjs');
+
+  const { ProcessRunner } = await import('command-stream/process-runner');
+  expect(typeof ProcessRunner.prototype.start).toBe('function');
+
+  const runner = new ProcessRunner(
+    {
+      mode: 'exec',
+      file: process.execPath,
+      args: ['-e', "process.stdout.write('lightweight runner')"],
+    },
+    { capture: true, mirror: false, stdin: 'ignore' }
+  );
+  const result = await runner;
+
+  expect(result.code).toBe(0);
+  expect(result.stdout).toBe('lightweight runner');
+});
+
+test('keeps terminal features out of the ProcessRunner module graph', () => {
+  if (!processRunnerExport) {
+    throw new Error('command-stream/process-runner is not exported');
+  }
+
+  const entrypoint = resolve(packageDirectory, processRunnerExport);
+  const graph = collectModuleGraph(entrypoint);
+  const terminalModules = [...graph.modules]
+    .map((modulePath) => relative(packageDirectory, modulePath))
+    .filter((modulePath) => modulePath.includes('terminal-'));
+  const importedTerminalDependencies = [...graph.packages].filter((specifier) =>
+    terminalDependencies.has(specifier)
+  );
+
+  expect(terminalModules).toEqual([]);
+  expect(importedTerminalDependencies).toEqual([]);
+});


### PR DESCRIPTION
Fixes #192

## Reproduction

Bundling the package root pulls the terminal renderer into the graph and fails on its native binaries:

```sh
bunx esbuild 'src/$.mjs' --bundle --platform=node --format=esm
```

```text
No loader is configured for ".node" files:
@resvg/resvg-js-linux-x64-gnu/resvgjs.linux-x64-gnu.node
```

The new public entry bundles successfully:

```javascript
import { ProcessRunner } from 'command-stream/process-runner';
```

## Root cause

The only package export targeted `src/$.mjs`, which unconditionally imports `terminal-capture.mjs`. Bundlers therefore traversed the optional PTY, xterm, SVG, and GIF feature graph even when a consumer only imported `ProcessRunner`.

## Changes

- Add `command-stream/process-runner` as a supported package export.
- Move ProcessRunner mixin initialization into that terminal-free entry and reuse it from the package root.
- Document direct lightweight ProcessRunner construction.
- Add a patch changeset.
- Add a regression test that executes the exported runner and recursively verifies its module graph excludes terminal modules, `@resvg/resvg-js`, `@xterm/headless`, `gifenc`, and `node-pty`.

## Verification

- Red test before the implementation: 0 passed, 2 failed because the subpath was not exported.
- `bun test js/tests/process-runner-entry.test.mjs --timeout 10000`: 2 passed.
- Full `bun run test`: 797 passed, 5 skipped, 0 failed (802 total).
- `bun run lint`: passed with one pre-existing `prefer-template` warning.
- `bun run format:check`: passed.
- `bun run check:duplication`: passed.
- `bun scripts/validate-changeset.mjs`: passed.
- Node 20 package-root/subpath imports and terminal artifact test: passed.
- `npm pack --dry-run --json`: confirmed `src/process-runner.mjs` is included.
- esbuild root reproduction: fails on two resvg `.node` files as reported.
- esbuild ProcessRunner entry: succeeds (129.3 KB); its metafile contains no terminal/native dependency inputs.

## Language parity

This changes only the JavaScript npm package export graph; the Rust crate has no corresponding npm subpath or eager JavaScript terminal dependency. The PR is marked `parity-exempt`.