### PR TITLE
feat(js): support shell file/args specs (#191)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-08-07T19:41:37.524Z for PR creation at branch issue-187-3d458fd12c95 for issue https://github.com/link-foundation/command-stream/issues/187
+# Updated: 2026-08-11T10:09:05.550Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-08-07T19:41:37.524Z for PR creation at branch issue-187-3d458fd12c95 for issue https://github.com/link-foundation/command-stream/issues/187
-# Updated: 2026-08-11T10:09:05.550Z

--- a/js/.changeset/issue-191-shell-argv.md
+++ b/js/.changeset/issue-191-shell-argv.md
@@ -1,0 +1,5 @@
+---
+'command-stream': patch
+---
+
+Support `{ mode: 'shell', file, args }` ProcessRunner specifications for commands that require the platform shell, including Windows `.cmd` shims. Async and sync execution now delegate this form to Node's shell-enabled spawn APIs while preserving the existing streaming, capture, stdin, cwd, environment, and result behavior.

--- a/js/README.md
+++ b/js/README.md
@@ -1225,6 +1225,38 @@ $`download-large-file`
 
 The enhanced `$` function returns a `ProcessRunner` instance that extends `EventEmitter`.
 
+#### Command specifications
+
+`ProcessRunner` accepts three command specification shapes:
+
+```javascript
+// Exact argv execution without a shell (preferred for native executables)
+new ProcessRunner({ mode: 'exec', file, args });
+
+// A completed command string interpreted by the platform shell
+new ProcessRunner({ mode: 'shell', command });
+
+// An executable and arguments routed through the platform shell
+new ProcessRunner({ mode: 'shell', file, args });
+```
+
+The shell `file`/`args` form delegates to Node's shell-enabled process spawning. It is useful on Windows for command shims such as `code.cmd`, which cannot be executed directly:
+
+```javascript
+const install = new ProcessRunner(
+  {
+    mode: 'shell',
+    file: 'code.cmd',
+    args: ['--install-extension', 'publisher.extension'],
+  },
+  { mirror: false }
+);
+
+const result = await install;
+```
+
+As with any shell-enabled process, pass only trusted `file` and `args` values; shell metacharacters are interpreted by the platform shell. Use `mode: 'exec'` whenever the target is a native executable and exact argument boundaries are required.
+
 #### Events
 
 - `data`: Emitted for each chunk with `{type: 'stdout'|'stderr', data: Buffer}`

--- a/js/src/$.process-runner-execution.mjs
+++ b/js/src/$.process-runner-execution.mjs
@@ -3,7 +3,12 @@
 
 import cp from 'child_process';
 import { trace } from './$.trace.mjs';
-import { findAvailableShell, resolveSpawnCwd } from './$.shell.mjs';
+import {
+  buildCommandArgv,
+  isShellArgvSpec,
+  isShellCommandSpec,
+  resolveSpawnCwd,
+} from './$.shell.mjs';
 import { StreamUtils, safeWrite, asBuffer } from './$.stream-utils.mjs';
 import { pumpReadable } from './$.quote.mjs';
 import { createResult } from './$.result.mjs';
@@ -115,7 +120,7 @@ function spawnWithBun(argv, config) {
  * @returns {object} Child process
  */
 function spawnWithNode(argv, config) {
-  const { cwd, env, isInteractive } = config;
+  const { cwd, env, isInteractive, shell } = config;
 
   trace(
     'ProcessRunner',
@@ -124,6 +129,7 @@ function spawnWithNode(argv, config) {
         command: argv[0],
         args: argv.slice(1),
         isInteractive,
+        shell,
         cwd,
         platform: process.platform,
       })}`
@@ -133,6 +139,7 @@ function spawnWithNode(argv, config) {
     return cp.spawn(argv[0], argv.slice(1), {
       cwd,
       env,
+      shell,
       stdio: 'inherit',
     });
   }
@@ -140,6 +147,7 @@ function spawnWithNode(argv, config) {
   const child = cp.spawn(argv[0], argv.slice(1), {
     cwd,
     env,
+    shell,
     stdio: ['pipe', 'pipe', 'pipe'],
     detached: process.platform !== 'win32',
   });
@@ -166,12 +174,13 @@ function spawnWithNode(argv, config) {
  * @returns {object} Child process
  */
 function spawnChild(argv, config) {
-  const { stdin } = config;
+  const { stdin, shell } = config;
   // Make sure we never try to spawn from a deleted/inaccessible working
   // directory, which would make the OS-level spawn fail (issue #44).
   config = { ...config, cwd: resolveSpawnCwd(config.cwd) };
   const needsExplicitPipe = stdin !== 'inherit' && stdin !== 'ignore';
   const preferNodeForInput = isBun && needsExplicitPipe;
+  const preferNodeForShellArgv = isBun && shell;
 
   trace(
     'ProcessRunner',
@@ -179,13 +188,14 @@ function spawnChild(argv, config) {
       `About to spawn process | ${JSON.stringify({
         needsExplicitPipe,
         preferNodeForInput,
+        preferNodeForShellArgv,
         runtime: isBun ? 'Bun' : 'Node',
         command: argv[0],
         args: argv.slice(1),
       })}`
   );
 
-  if (preferNodeForInput) {
+  if (preferNodeForInput || preferNodeForShellArgv) {
     return spawnWithNode(argv, config);
   }
   return isBun ? spawnWithBun(argv, config) : spawnWithNode(argv, config);
@@ -558,10 +568,11 @@ function executeSyncBun(argv, options) {
  * @returns {object} Result object
  */
 function executeSyncNode(argv, options) {
-  const { cwd, env, stdin } = options;
+  const { cwd, env, stdin, shell } = options;
   const proc = cp.spawnSync(argv[0], argv.slice(1), {
     cwd,
     env,
+    shell,
     input: getSyncStdinInput(stdin),
     encoding: 'utf8',
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -586,7 +597,9 @@ function executeSyncNode(argv, options) {
 function executeSyncProcess(argv, options) {
   // Guard against a deleted/inaccessible working directory (issue #44).
   options = { ...options, cwd: resolveSpawnCwd(options.cwd) };
-  return isBun ? executeSyncBun(argv, options) : executeSyncNode(argv, options);
+  return isBun && !options.shell
+    ? executeSyncBun(argv, options)
+    : executeSyncNode(argv, options);
 }
 
 /**
@@ -1106,7 +1119,8 @@ export function attachExecutionMethods(ProcessRunner, deps) {
       }
 
       // Handle shell mode special cases
-      if (this.spec.mode === 'shell') {
+      const shellArgv = isShellArgvSpec(this.spec);
+      if (isShellCommandSpec(this.spec)) {
         const shellResult = await handleShellMode(this, deps);
         if (shellResult) {
           return this.finish(shellResult);
@@ -1114,11 +1128,7 @@ export function attachExecutionMethods(ProcessRunner, deps) {
       }
 
       // Build command arguments
-      const shell = findAvailableShell();
-      const argv =
-        this.spec.mode === 'shell'
-          ? [shell.cmd, ...shell.args, this.spec.command]
-          : [this.spec.file, ...this.spec.args];
+      const argv = buildCommandArgv(this.spec);
 
       trace(
         'ProcessRunner',
@@ -1126,13 +1136,16 @@ export function attachExecutionMethods(ProcessRunner, deps) {
           `Constructed argv | ${JSON.stringify({
             mode: this.spec.mode,
             argv,
+            shellArgv,
             originalCommand: this.spec.command,
           })}`
       );
 
       // Log command if tracing enabled
       const traceCmd =
-        this.spec.mode === 'shell' ? this.spec.command : argv.join(' ');
+        this.spec.mode === 'shell' && !shellArgv
+          ? this.spec.command
+          : argv.join(' ');
       logShellTrace(globalShellSettings, traceCmd);
 
       // Detect interactive mode
@@ -1157,6 +1170,7 @@ export function attachExecutionMethods(ProcessRunner, deps) {
         env,
         stdin,
         isInteractive,
+        shell: shellArgv,
       });
 
       this.finish(result);
@@ -1416,17 +1430,21 @@ export function attachExecutionMethods(ProcessRunner, deps) {
     this._mode = 'sync';
 
     const { cwd, env, stdin } = this.options;
-    const shell = findAvailableShell();
-    const argv =
-      this.spec.mode === 'shell'
-        ? [shell.cmd, ...shell.args, this.spec.command]
-        : [this.spec.file, ...this.spec.args];
+    const shellArgv = isShellArgvSpec(this.spec);
+    const argv = buildCommandArgv(this.spec);
 
     const traceCmd =
-      this.spec.mode === 'shell' ? this.spec.command : argv.join(' ');
+      this.spec.mode === 'shell' && !shellArgv
+        ? this.spec.command
+        : argv.join(' ');
     logShellTrace(globalShellSettings, traceCmd);
 
-    const result = executeSyncProcess(argv, { cwd, env, stdin });
+    const result = executeSyncProcess(argv, {
+      cwd,
+      env,
+      stdin,
+      shell: shellArgv,
+    });
     return processSyncResult(this, result, globalShellSettings);
   };
 

--- a/js/src/$.shell.mjs
+++ b/js/src/$.shell.mjs
@@ -10,6 +10,42 @@ import { trace } from './$.trace.mjs';
 let cachedShell = null;
 
 /**
+ * Check whether a shell spec supplies an executable and argument vector.
+ * @param {object} spec - ProcessRunner command specification
+ * @returns {boolean}
+ */
+export function isShellArgvSpec(spec) {
+  return spec.mode === 'shell' && typeof spec.file === 'string';
+}
+
+/**
+ * Check whether a shell spec supplies a completed command string.
+ * @param {object} spec - ProcessRunner command specification
+ * @returns {boolean}
+ */
+export function isShellCommandSpec(spec) {
+  return spec.mode === 'shell' && !isShellArgvSpec(spec);
+}
+
+/**
+ * Build the command vector for a ProcessRunner command specification.
+ * @param {object} spec - ProcessRunner command specification
+ * @returns {string[]}
+ */
+export function buildCommandArgv(spec) {
+  if (isShellArgvSpec(spec)) {
+    return [spec.file, ...(spec.args ?? [])];
+  }
+
+  if (isShellCommandSpec(spec)) {
+    const shell = findAvailableShell();
+    return [shell.cmd, ...shell.args, spec.command];
+  }
+
+  return [spec.file, ...spec.args];
+}
+
+/**
  * Pick a directory that is known to exist for spawning a child process.
  * @returns {string} An existing fallback directory
  */

--- a/js/tests/fixtures/argprint.cmd
+++ b/js/tests/fixtures/argprint.cmd
@@ -1,0 +1,2 @@
+@echo off
+node "%~dp0argprint.mjs" %*

--- a/js/tests/process-runner-shell-argv.test.mjs
+++ b/js/tests/process-runner-shell-argv.test.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+import { describe, expect, test } from 'bun:test';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ProcessRunner } from '../src/$.mjs';
+import { isWindows } from './test-helper.mjs';
+
+const fixturesDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures'
+);
+const argprint = path.join(fixturesDir, 'argprint.mjs');
+
+function shellArgvSpec() {
+  if (isWindows) {
+    return {
+      mode: 'shell',
+      file: path.join(fixturesDir, 'argprint.cmd'),
+      args: ['--install-extension', 'publisher.extension'],
+    };
+  }
+
+  return {
+    mode: 'shell',
+    file: process.execPath,
+    args: [argprint, '--install-extension', 'publisher.extension'],
+  };
+}
+
+describe('ProcessRunner shell file/args mode', () => {
+  test('runs argv through the platform shell asynchronously', async () => {
+    const runner = new ProcessRunner(shellArgvSpec(), {
+      mirror: false,
+      stdin: 'ignore',
+    });
+
+    const result = await runner;
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe(
+      'ARG[--install-extension]\nARG[publisher.extension]\n'
+    );
+  });
+
+  test('runs argv through the platform shell synchronously', () => {
+    const runner = new ProcessRunner(shellArgvSpec(), {
+      mirror: false,
+      stdin: 'ignore',
+    });
+
+    const result = runner.sync();
+
+    expect(result.code).toBe(0);
+    expect(result.stdout).toBe(
+      'ARG[--install-extension]\nARG[publisher.extension]\n'
+    );
+  });
+});

--- a/js/tests/process-runner-shell-argv.test.mjs
+++ b/js/tests/process-runner-shell-argv.test.mjs
@@ -6,6 +6,23 @@ import { fileURLToPath } from 'node:url';
 import { ProcessRunner } from '../src/$.mjs';
 import { isWindows } from './test-helper.mjs';
 
+// TEMPORARY CI DIAGNOSTIC: capture the caller if the unrelated issue-170
+// regression target is force-killed after these Windows shell-argv tests.
+const originalKill = ProcessRunner.prototype.kill;
+ProcessRunner.prototype.kill = function (...args) {
+  if (this.spec?.command?.includes("echo 'stdout'")) {
+    console.error(
+      `[issue-191 diagnostic] ${JSON.stringify({
+        spec: this.spec,
+        awaited: this._awaited,
+        started: this.started,
+        finished: this.finished,
+      })}\n${new Error('ProcessRunner.kill caller').stack}`
+    );
+  }
+  return originalKill.apply(this, args);
+};
+
 const fixturesDir = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   'fixtures'

--- a/js/tests/process-runner-shell-argv.test.mjs
+++ b/js/tests/process-runner-shell-argv.test.mjs
@@ -6,23 +6,6 @@ import { fileURLToPath } from 'node:url';
 import { ProcessRunner } from '../src/$.mjs';
 import { isWindows } from './test-helper.mjs';
 
-// TEMPORARY CI DIAGNOSTIC: capture the caller if the unrelated issue-170
-// regression target is force-killed after these Windows shell-argv tests.
-const originalKill = ProcessRunner.prototype.kill;
-ProcessRunner.prototype.kill = function (...args) {
-  if (this.spec?.command?.includes("echo 'stdout'")) {
-    console.error(
-      `[issue-191 diagnostic] ${JSON.stringify({
-        spec: this.spec,
-        awaited: this._awaited,
-        started: this.started,
-        finished: this.finished,
-      })}\n${new Error('ProcessRunner.kill caller').stack}`
-    );
-  }
-  return originalKill.apply(this, args);
-};
-
 const fixturesDir = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   'fixtures'


### PR DESCRIPTION
## Summary

- accept `{ mode: 'shell', file, args }` ProcessRunner specifications in async and sync modes
- delegate that form to Node's shell-enabled spawn APIs, including when command-stream is running under Bun
- preserve the existing command-string shell path and its virtual-command/operator handling
- document the shell trust boundary and add a patch changeset

## Root cause and reproduction

ProcessRunner treated every `mode: 'shell'` specification as a completed `command` string. A shell spec containing `file` and `args` therefore reached command-string parsing with `command === undefined`; async execution threw from `command.includes(...)`, while sync execution attempted an invalid shell command and returned exit code 127.

`js/tests/process-runner-shell-argv.test.mjs` reproduces the requested `code.cmd --install-extension ...` shape. On Windows it invokes a real `.cmd` fixture; on other platforms it exercises the same Node shell-enabled spawn boundary. The test covers both awaited and synchronous runners and failed before the implementation.

## Implementation

Shell specifications are now classified as either command-string or executable-plus-args forms. The latter bypasses command-string parsing, retains the separate command vector, and opts into `child_process.spawn()` or `spawnSync()` with `shell: true`. Existing streaming, capture, stdin, cwd, environment, cancellation, event, and result processing remains shared with native execution.

Because Node's shell-enabled spawning still invokes the platform shell, the README advises callers to pass only trusted values and to prefer `mode: 'exec'` for native executables requiring exact argument boundaries.

## Verification

- `bun test js/tests/ --timeout 10000` — 799 passed, 5 skipped, 0 failed across 58 files
- focused shell argv, start/run options, and sync suites — 41 passed, 0 failed
- direct Node 20 async and sync compatibility check — passed
- `bun run lint` — passed (one pre-existing warning in `$.cd.mjs`)
- `bun run format:check` — passed
- `bun run check:duplication` — passed
- `bun scripts/validate-changeset.mjs` against the PR base/head — passed

## Language parity

This is intentionally JavaScript-only: it exposes Node's platform shell command construction for `.cmd` shims and has no corresponding Rust runtime API. The PR is labeled `parity-exempt`.

Fixes #191
